### PR TITLE
removed unused private method getCodePanel(int)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/TabbedPane.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/TabbedPane.java
@@ -95,14 +95,6 @@ class TabbedPane extends JTabbedPane {
 		return panel;
 	}
 
-	private CodePanel getCodePanel(int index) {
-		Component component = getComponent(index);
-		if (component instanceof CodePanel) {
-			return (CodePanel) component;
-		}
-		return null;
-	}
-
 	CodePanel getSelectedCodePanel() {
 		return (CodePanel) getSelectedComponent();
 	}


### PR DESCRIPTION
Only the other overload with a `JClass` parameter was used. It compiled cleanly on my box.
