### PR TITLE
core: fix nested try-catch blocks processing

### DIFF
--- a/jadx-core/src/test/java/jadx/tests/internal/trycatch/TestNestedTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/internal/trycatch/TestNestedTryCatch.java
@@ -1,0 +1,41 @@
+package jadx.tests.internal.trycatch;
+
+import jadx.api.InternalJadxTest;
+import jadx.core.dex.nodes.ClassNode;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+public class TestNestedTryCatch extends InternalJadxTest {
+
+	public static class TestCls {
+		private void f() {
+			try {
+				Thread.sleep(1);
+				try {
+					Thread.sleep(2);
+				} catch (InterruptedException e) {
+				}
+			} catch (Exception e) {
+			}
+			
+			return;
+		}
+	}
+
+	@Test
+	public void test() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("try {"));
+		assertThat(code, containsString("Thread.sleep(1);"));
+		assertThat(code, containsString("Thread.sleep(2);"));
+		assertThat(code, containsString("} catch (InterruptedException e) {"));
+		assertThat(code, containsString("} catch (Exception e2) {"));
+		assertThat(code, not(containsString("return")));
+	}
+}


### PR DESCRIPTION
Add code for processing nested try-catch blocks. Add a related test file.
