### PR TITLE
core: fix processing of debug info (markup of local variables)

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
@@ -52,6 +52,7 @@ public class MethodNode extends LineAttrNode implements ILoadable {
 	private final Method methodData;
 	private int regsCount;
 	private InsnNode[] instructions;
+	private int codeSize;
 	private int debugInfoOffset;
 	private boolean noCode;
 
@@ -82,6 +83,7 @@ public class MethodNode extends LineAttrNode implements ILoadable {
 		try {
 			if (noCode) {
 				regsCount = 0;
+				codeSize = 0;
 				initMethodTypes();
 				return;
 			}
@@ -94,6 +96,7 @@ public class MethodNode extends LineAttrNode implements ILoadable {
 			InsnDecoder decoder = new InsnDecoder(this);
 			decoder.decodeInsns(mthCode);
 			instructions = decoder.process();
+			codeSize = instructions.length;
 
 			initTryCatches(mthCode);
 			initJumps();
@@ -348,6 +351,10 @@ public class MethodNode extends LineAttrNode implements ILoadable {
 
 	public boolean isNoCode() {
 		return noCode;
+	}
+
+	public int getCodeSize() {
+		return codeSize;
 	}
 
 	public InsnNode[] getInstructions() {

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/parser/LocalVar.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/parser/LocalVar.java
@@ -69,9 +69,20 @@ final class LocalVar {
 		this.startAddr = addr;
 	}
 
-	public void end(int addr, int line) {
-		this.isEnd = true;
-		this.endAddr = addr;
+	/**
+	 * Sets end address of local variable
+	 * @param addr address
+	 * @param line source line
+	 * @return <b>true</b> if local variable was active, else <b>false</b>
+	 */
+	public boolean end(int addr, int line) {
+		if (!isEnd) {
+			this.isEnd = true;
+			this.endAddr = addr;
+			return true;
+		}
+
+		return false;
 	}
 
 	public int getRegNum() {

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ssa/SSATransform.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ssa/SSATransform.java
@@ -80,6 +80,7 @@ public class SSATransform extends AbstractVisitor {
 		}
 		PhiInsn phiInsn = new PhiInsn(regNum, block.getPredecessors().size());
 		phiList.getList().add(phiInsn);
+		phiInsn.setOffset(block.getStartOffset());
 		block.getInstructions().add(0, phiInsn);
 	}
 


### PR DESCRIPTION
This patch fixes:
- bad type assigned to RegisterArg when DBG_RESTART_LOCAL found in debug info ([this code](https://github.com/NeoSpb/jadx/compare/skylot:master...NeoSpb:fix3?expand=1#diff-5212daa5c398f649d86387821fe5ad19R116) and [this code](https://github.com/NeoSpb/jadx/compare/skylot:master...NeoSpb:fix3?expand=1#diff-7c38cdae1bb9619c8ae8e25166854786R72))
- bad end address used for LocalVar if no DBG_END_LOCAL found ([this code](https://github.com/NeoSpb/jadx/compare/skylot:master...NeoSpb:fix3?expand=1#diff-5212daa5c398f649d86387821fe5ad19R165))
- bad type assigned to RegisterArg when DBG_END_LOCAL found after replace a register with new value
  (other code)

How to accept LocalVar to SSAVar when address range intersect:

// LocalVar
\\ SSAVar
accept
\/\/
/\\/
XX
\/X
/\X
X\/

not accept
X/\
/\/\
