### PR TITLE
tests: fix building on Windows (Uri using issue)

### DIFF
--- a/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
+++ b/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
@@ -312,11 +312,11 @@ public abstract class IntegrationTest extends TestUtils {
 		File outTmp = createTempDir("jadx-tmp-classes");
 		outTmp.deleteOnExit();
 		List<File> files = StaticCompiler.compile(Arrays.asList(file), outTmp, withDebugInfo);
-		String filter = outTmp.getAbsolutePath() + File.separator + cls.getName().replace('.', '/');
+		String filter = (outTmp.getAbsolutePath() + File.separator + cls.getName().replace('.', '/')).replace('\\','/');
 		Iterator<File> iterator = files.iterator();
 		while (iterator.hasNext()) {
 			File next = iterator.next();
-			if (!next.getAbsolutePath().startsWith(filter)) {
+			if (!next.getAbsolutePath().replace('\\', '/').startsWith(filter)) {
 				iterator.remove();
 			} else {
 				next.deleteOnExit();

--- a/jadx-core/src/test/java/jadx/tests/api/compiler/StaticCompiler.java
+++ b/jadx-core/src/test/java/jadx/tests/api/compiler/StaticCompiler.java
@@ -72,8 +72,12 @@ public class StaticCompiler {
 	private static class ClassFileObject extends SimpleJavaFileObject {
 		private File file;
 
+		private static final boolean isWindowsOS = (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0); 
+
 		protected ClassFileObject(File file, Kind kind) {
-			super(URI.create("file://" + file.getAbsolutePath()), kind);
+			super((isWindowsOS)
+						? URI.create("file:///" + file.getAbsolutePath().replace('\\', '/')) 
+						: URI.create("file://" + file.getAbsolutePath()), kind); 
 			this.file = file;
 		}
 


### PR DESCRIPTION
Test fails with an exception:

```
java.lang.IllegalArgumentException: Illegal character in authority at index 7: file://C:\Users\ ...
```

This patch provides hotfix.
