### PR TITLE
core: show warning when failed to detect out node in non trivial switch

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/regions/RegionMaker.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/regions/RegionMaker.java
@@ -705,6 +705,9 @@ public class RegionMaker {
 		stack.push(sw);
 		if (out != null) {
 			stack.addExit(out);
+		} else {
+			LOG.warn("Can't detect out node for switch block: {} in {}",
+					block.toString(), mth.toString());
 		}
 
 		if (!stack.containsExit(defCase)) {


### PR DESCRIPTION
See [issue #38](https://github.com/skylot/jadx/issues/38)
