### PR TITLE
Make jadx-gui.jar runnable

### DIFF
--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -19,6 +19,15 @@ applicationDistribution.with {
     }
 }
 
+jar {
+    manifest {
+        attributes(
+			"Main-Class": mainClassName,
+			"Class-Path": configurations.compile.collect { it.getName() }.join(' ')
+		)
+    }
+}
+
 test {
     jacoco {
         // coveralls plugin not support multi-project


### PR DESCRIPTION
I dislike that currently you have to start jadx-gui using a very complex startup-script that in the end just sets the classpath and the main class, something Java can just read out from the MANIFEST.MF of the main jar file.

Therefore I extended the build.gradle script of the jadx-gui subproject to add the required entries to the MANIFEST.MF of jadx-gui.jar.

This allows to start jadx-gui simply by executing "`javaw -jar jadx-gui-0.6.1-dev.jar`"

Tested with gradle 2.3