### PR TITLE
Enable file drop operation for loading it.

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/MainDropTarget.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainDropTarget.java
@@ -1,0 +1,79 @@
+package jadx.gui.ui;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetDropEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.dnd.DropTargetListener;
+import java.io.File;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Enables drop support from external applications for the {@link MainWindow} (load dropped APK file)
+ */
+public class MainDropTarget implements DropTargetListener {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MainDropTarget.class);
+
+	private final MainWindow mainWindow;
+
+	public MainDropTarget(MainWindow mainWindow) {
+		super();
+		this.mainWindow = mainWindow;
+	}
+
+	protected void processDrag(DropTargetDragEvent dtde) {
+		if (dtde.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+			dtde.acceptDrag(DnDConstants.ACTION_COPY);
+		} else {
+			dtde.rejectDrag();
+		}
+	}
+
+	@Override
+	public void dragEnter(DropTargetDragEvent dtde) {
+		processDrag(dtde);
+	}
+
+	@Override
+	public void dragOver(DropTargetDragEvent dtde) {
+		processDrag(dtde);
+	}
+
+	@Override
+	public void dropActionChanged(DropTargetDragEvent dtde) {
+	}
+
+	@Override
+	public void drop(DropTargetDropEvent dtde) {
+		if (!dtde.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+			dtde.rejectDrop();
+			return;
+		}
+		dtde.acceptDrop(dtde.getDropAction());
+		try {
+
+			Transferable transferable = dtde.getTransferable();
+			List<File> transferData = (List<File>) transferable.getTransferData(DataFlavor.javaFileListFlavor);
+			if (transferData != null && transferData.size() > 0) {
+				dtde.dropComplete(true);
+				// load first file
+				mainWindow.openFile(transferData.get(0));
+			}
+
+		} catch (Exception e) {
+			LOG.error("File drop operation failed", e);
+		}
+	}
+
+	@Override
+	public void dragExit(DropTargetEvent dte) {
+
+	}
+
+}

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -48,12 +48,15 @@ import javax.swing.tree.ExpandVetoException;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
+
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.DisplayMode;
 import java.awt.Font;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
@@ -108,6 +111,8 @@ public class MainWindow extends JFrame {
 	private JToggleButton deobfToggleBtn;
 	private boolean isFlattenPackage;
 	private Link updateLink;
+	
+	private DropTarget dropTarget;
 
 	public MainWindow(JadxSettings settings) {
 		this.wrapper = new JadxWrapper(settings);
@@ -540,6 +545,8 @@ public class MainWindow extends JFrame {
 		tabbedPane = new TabbedPane(this);
 		splitPane.setRightComponent(tabbedPane);
 
+		dropTarget = new DropTarget(this, DnDConstants.ACTION_COPY, new MainDropTarget(this));
+		
 		setContentPane(mainPanel);
 		setTitle(DEFAULT_TITLE);
 	}


### PR DESCRIPTION
This patch enabled Jadx-gui to accept files via drag & drop from external applications (e.g. file explorer). The dropped file will be loaded.