### PR TITLE
fix deobfuscation

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/PackageNode.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/PackageNode.java
@@ -61,10 +61,15 @@ public class PackageNode {
 		if (cachedPackageFullAlias == null) {
 			Stack<PackageNode> pp = getParentPackages();
 			StringBuilder result = new StringBuilder();
-			result.append(pp.pop().getAlias());
-			while (pp.size() > 0) {
-				result.append(SEPARATOR_CHAR);
+
+			if (pp.size() > 0) {
 				result.append(pp.pop().getAlias());
+				while (pp.size() > 0) {
+					result.append(SEPARATOR_CHAR);
+					result.append(pp.pop().getAlias());
+				}
+			} else {
+				result.append(this.getAlias());
 			}
 			cachedPackageFullAlias = result.toString();
 		}


### PR DESCRIPTION
Deobfuscation terminated when the APK file has classes that is in the root package

```
16:55:52 ERROR - Visitor init failed: RenameVisitor
java.util.EmptyStackException: null
	at java.util.Stack.peek(Unknown Source) ~[na:1.7.0_71]
	at java.util.Stack.pop(Unknown Source) ~[na:1.7.0_71]
	at jadx.core.deobf.PackageNode.getFullAlias(PackageNode.java:64) ~[jadx-core-0.6.1-dev.jar:na]
	at jadx.core.deobf.DeobfClsInfo.getFullName(DeobfClsInfo.java:36) ~[jadx-core-0.6.1-dev.jar:na]
	at jadx.core.deobf.Deobfuscator.getClassFullName(Deobfuscator.java:526) ~[jadx-core-0.6.1-dev.jar:na]
	at jadx.core.deobf.Deobfuscator.processClass(Deobfuscator.java:237) ~[jadx-core-0.6.1-dev.jar:na]
	at jadx.core.deobf.Deobfuscator.process(Deobfuscator.java:105) ~[jadx-core-0.6.1-dev.jar:na]
	at jadx.core.deobf.Deobfuscator.execute(Deobfuscator.java:78) ~[jadx-core-0.6.1-dev.jar:na]
	at jadx.core.dex.visitors.RenameVisitor.init(RenameVisitor.java:43) ~[jadx-core-0.6.1-dev.jar:na]
```

