### PR TITLE
Avoid warnings

### DIFF
--- a/jadx-core/src/main/java/jadx/api/ResourcesLoader.java
+++ b/jadx-core/src/main/java/jadx/api/ResourcesLoader.java
@@ -112,8 +112,9 @@ public final class ResourcesLoader {
 
 			case ARSC:
 				return new ResTableParser().decodeFiles(inputStream);
+			default:
+				return ResContainer.singleFile(rf.getName(), loadToCodeWriter(inputStream));
 		}
-		return ResContainer.singleFile(rf.getName(), loadToCodeWriter(inputStream));
 	}
 
 	private void loadFile(List<ResourceFile> list, File file) {

--- a/jadx-core/src/main/java/jadx/core/codegen/AnnotationGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/AnnotationGen.java
@@ -156,7 +156,7 @@ public class AnnotationGen {
 			InsnGen.makeStaticFieldAccess(code, field, classGen);
 		} else if (val instanceof Iterable) {
 			code.add('{');
-			Iterator<?> it = ((Iterable) val).iterator();
+			Iterator<?> it = ((Iterable<?>) val).iterator();
 			while (it.hasNext()) {
 				Object obj = it.next();
 				encodeValue(code, obj);

--- a/jadx-core/src/main/java/jadx/core/codegen/ConditionGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ConditionGen.java
@@ -179,6 +179,8 @@ public class ConditionGen extends InsnGen {
 				case DIV:
 				case REM:
 					return false;
+				default:
+					break;
 			}
 		} else {
 			switch (insnType) {

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
@@ -368,6 +368,8 @@ public class ClassNode extends LineAttrNode implements ILoadable {
 			case DOUBLE:
 				double d = Double.longBitsToDouble(literal);
 				return getConstField(d, d != 0);
+			default:
+				break;
 		}
 		return null;
 	}

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/PrepareForCodeGen.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/PrepareForCodeGen.java
@@ -70,6 +70,8 @@ public class PrepareForCodeGen extends AbstractVisitor {
 						it.remove();
 					}
 					break;
+				default:
+					break;
 			}
 		}
 	}

--- a/jadx-core/src/main/java/jadx/core/utils/InsnUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/InsnUtils.java
@@ -90,6 +90,9 @@ public class InsnUtils {
 					LOG.warn("Field {} not found in dex {}", f, dex);
 				}
 				break;
+			default:
+				LOG.warn("Unknown instruction type " + insn.getType());
+				break;
 		}
 		return null;
 	}

--- a/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
+++ b/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
@@ -228,12 +228,12 @@ public abstract class IntegrationTest extends TestUtils {
 		return invoke(method, new Class<?>[0]);
 	}
 
-	public Object invoke(String method, Class[] types, Object... args) throws Exception {
+	public Object invoke(String method, Class<?>[] types, Object... args) throws Exception {
 		Method mth = getReflectMethod(method, types);
 		return invoke(mth, args);
 	}
 
-	public Method getReflectMethod(String method, Class... types) {
+	public Method getReflectMethod(String method, Class<?>... types) {
 		assertNotNull("dynamicCompiler not ready", dynamicCompiler);
 		try {
 			return dynamicCompiler.getMethod(method, types);

--- a/jadx-core/src/test/java/jadx/tests/api/compiler/DynamicCompiler.java
+++ b/jadx-core/src/test/java/jadx/tests/api/compiler/DynamicCompiler.java
@@ -57,7 +57,7 @@ public class DynamicCompiler {
 		return instance;
 	}
 
-	public Method getMethod(String method, Class[] types) throws Exception {
+	public Method getMethod(String method, Class<?>[] types) throws Exception {
 		for (Class<?> type : types) {
 			checkType(type);
 		}

--- a/jadx-core/src/test/java/jadx/tests/integration/TestWrongCode.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/TestWrongCode.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings({ "null", "unused" })
 public class TestWrongCode extends IntegrationTest {
 
 	public static class TestCls {
@@ -18,7 +19,6 @@ public class TestWrongCode extends IntegrationTest {
 			return a.length;
 		}
 
-		@SuppressWarnings("empty")
 		private int test2(int a) {
 			if (a == 0) {
 				;

--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith3.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestArith3 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestFieldIncrement3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestFieldIncrement3.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestFieldIncrement3 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestConditions extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions15.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions15.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestConditions15 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/enums/TestSwitchOverEnum.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/enums/TestSwitchOverEnum.java
@@ -15,6 +15,7 @@ public class TestSwitchOverEnum extends IntegrationTest {
 		ONE, TWO, THREE
 	}
 
+	@SuppressWarnings("incomplete-switch")
 	public int testEnum(Count c) {
 		switch (c) {
 			case ONE:

--- a/jadx-core/src/test/java/jadx/tests/integration/enums/TestSwitchOverEnum2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/enums/TestSwitchOverEnum2.java
@@ -9,6 +9,7 @@ import static jadx.tests.api.utils.JadxMatchers.countString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("incomplete-switch")
 public class TestSwitchOverEnum2 extends IntegrationTest {
 
 	public enum Count {

--- a/jadx-core/src/test/java/jadx/tests/integration/generics/TestGenerics2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/generics/TestGenerics2.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestGenerics2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/inline/TestIssue86.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inline/TestIssue86.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestIssue86 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass12.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass12.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestAnonymousClass12 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass2.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestAnonymousClass2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass3.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestAnonymousClass3 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass4.java
@@ -9,6 +9,7 @@ import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static jadx.tests.api.utils.JadxMatchers.countString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestAnonymousClass4 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestInnerClass4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestInnerClass4.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestInnerClass4 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestConstructorInvoke.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestConstructorInvoke.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestConstructorInvoke extends IntegrationTest {
 
 	public class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvoke1.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvoke1.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestInvoke1 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvokeInCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvokeInCatch.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestInvokeInCatch extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsLines;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestArrayForEach extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach2.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsLines;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestArrayForEach2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestArrayForEachNegative extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestBreakInLoop.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestBreakInLoop.java
@@ -9,6 +9,7 @@ import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static jadx.tests.api.utils.JadxMatchers.countString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestBreakInLoop extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestContinueInLoop.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestContinueInLoop.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestContinueInLoop extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestContinueInLoop2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestContinueInLoop2.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestContinueInLoop2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestIndexForLoop.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestIndexForLoop.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsLines;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestIndexForLoop extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsLines;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestIterableForEach extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach3.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestIterableForEach3 extends IntegrationTest {
 
 	public static class TestCls<T extends String> {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopCondition.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopCondition.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestLoopCondition extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopConditionInvoke.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopConditionInvoke.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestLoopConditionInvoke extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection.java
@@ -9,6 +9,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestLoopDetection extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection3.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestLoopDetection3 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection4.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestLoopDetection4 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestNestedLoops extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops2.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestNestedLoops2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/names/TestNameAssign2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/names/TestNameAssign2.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestNameAssign2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestFieldInit extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit2.java
@@ -9,6 +9,7 @@ import static jadx.tests.api.utils.JadxMatchers.containsLines;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestFieldInit2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInitInTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInitInTryCatch.java
@@ -12,6 +12,7 @@ import static jadx.tests.api.utils.JadxMatchers.containsLines;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestFieldInitInTryCatch extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIfInTry.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIfInTry.java
@@ -12,6 +12,7 @@ import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static jadx.tests.api.utils.JadxMatchers.countString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestIfInTry extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIfTryInCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIfTryInCatch.java
@@ -9,6 +9,7 @@ import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static jadx.tests.api.utils.JadxMatchers.countString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestIfTryInCatch extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13a.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13a.java
@@ -37,7 +37,7 @@ public class TestIssue13a extends IntegrationTest {
 						Class<?> c = loader == null ?
 								Class.forName(name) : Class.forName(name, true, loader);
 						Field f = c.getField("CREATOR");
-						creator = (Parcelable.Creator) f.get(null);
+						creator = (Parcelable.Creator<T>) f.get(null);
 					} catch (IllegalAccessException e) {
 						Log.e(TAG, "1" + name + ", e: " + e);
 						throw new RuntimeException("2" + name);

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13b.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13b.java
@@ -15,6 +15,7 @@ import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static jadx.tests.api.utils.JadxMatchers.countString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestIssue13b extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestLoopInTry2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestLoopInTry2.java
@@ -17,6 +17,7 @@ import com.android.dx.io.instructions.ShortArrayCodeInput;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestLoopInTry2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/switches/TestSwitchReturnFromCase.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/switches/TestSwitchReturnFromCase.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestSwitchReturnFromCase extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized2.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestSynchronized2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestNestedTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestNestedTryCatch.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertThat;
 public class TestNestedTryCatch extends IntegrationTest {
 
 	public static class TestCls {
+		@SuppressWarnings("unused")
 		private void f() {
 			try {
 				Thread.sleep(1);

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertThat;
 public class TestTryCatch extends IntegrationTest {
 
 	public static class TestCls {
+		@SuppressWarnings("unused")
 		private void f() {
 			try {
 				Thread.sleep(50);

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch2.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestTryCatch2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch4.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertThat;
 public class TestTryCatch4 extends IntegrationTest {
 
 	public static class TestCls {
+		@SuppressWarnings({ "resource", "unused" })
 		private Object test(Object obj) {
 			FileOutputStream output = null;
 			try {

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch5.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestTryCatch5 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch7.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch7.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestTryCatch7 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally5.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestTryCatchFinally5 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver2.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestTypeResolver2 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/usethis/TestInlineThis.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/usethis/TestInlineThis.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestInlineThis extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/variables/TestVariables4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/variables/TestVariables4.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("unused")
 public class TestVariables4 extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
@@ -155,6 +155,8 @@ public class JResource extends JNode implements Comparable<JResource> {
 			case MANIFEST:
 			case XML:
 				return SyntaxConstants.SYNTAX_STYLE_XML;
+			default:
+				break;
 		}
 		String syntax = getSyntaxByExtension(resFile.getName());
 		if (syntax != null) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/LogViewer.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/LogViewer.java
@@ -41,8 +41,7 @@ class LogViewer extends JDialog {
 
 		JPanel controlPane = new JPanel();
 		controlPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-		@SuppressWarnings("unchecked")
-		final JComboBox cb = new JComboBox(LEVEL_ITEMS);
+		final JComboBox<Level> cb = new JComboBox<Level>(LEVEL_ITEMS);
 		cb.setSelectedItem(level);
 		cb.addActionListener(new ActionListener() {
 			@Override

--- a/jadx-samples/src/main/java/jadx/samples/TestCF3.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestCF3.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+@SuppressWarnings("unused")
 public class TestCF3 extends AbstractTest {
 
 	public String f = "str//ing";

--- a/jadx-samples/src/main/java/jadx/samples/TestDeadCode.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestDeadCode.java
@@ -1,5 +1,6 @@
 package jadx.samples;
 
+@SuppressWarnings("unused")
 public class TestDeadCode extends AbstractTest {
 
 	private void test1(int i) {

--- a/jadx-samples/src/main/java/jadx/samples/TestGenerics.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestGenerics.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@SuppressWarnings("unused")
 public class TestGenerics extends AbstractTest {
 
 	public List<String> strings;

--- a/jadx-samples/src/main/java/jadx/samples/TestTypeResolver2.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestTypeResolver2.java
@@ -5,6 +5,7 @@ package jadx.samples;
  * <a href="http://stackoverflow.com/questions/2840183/is-there-any-java-decompiler-that-can-correctly-decompile-calls-to-overloaded-me">
  * stackoverflow question</a>
  */
+@SuppressWarnings("unused")
 public class TestTypeResolver2 extends AbstractTest {
 
 	private static String result = "";


### PR DESCRIPTION
Avoid simple warnings in eclipse
Including supressing unused warnings in test classes, and addition of default label for switches.