### PR TITLE
Increase heap limit to avoid most OOMs in Gradle

### DIFF
--- a/jadx-cli/build.gradle
+++ b/jadx-cli/build.gradle
@@ -18,3 +18,6 @@ applicationDistribution.with {
     }
 }
 
+startScripts {
+    defaultJvmOpts = [ '-Xms2g', '-Xmx4g' ]
+}

--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -30,6 +30,7 @@ jar {
 }
 
 startScripts {
+    defaultJvmOpts = [ '-Xms2g', '-Xmx4g' ]
     doLast {
         def str = windowsScript.text
         str = str.replaceAll('java.exe', 'javaw.exe')


### PR DESCRIPTION
Hi I tune the heap limit for jadx-cli and jadx-gui to get rid of most OOMs encountered when dealing with real-world apks.
Both would have Xms=2G and Xmx=4G, reasonable for dev PCs nowadays.