### PR TITLE
Deobfuscation fixes

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
@@ -339,6 +339,10 @@ public class ClassGen {
 				continue;
 			}
 			annotationGen.addForField(code, f);
+
+			if(f.getFieldInfo().isRenamed()) {
+				code.startLine("/* renamed from: ").add(f.getName()).add(" */");
+			}
 			code.startLine(f.getAccessFlags().makeString());
 			useType(code, f.getType());
 			code.add(' ');
@@ -586,9 +590,8 @@ public class ClassGen {
 
 	private void insertRenameInfo(CodeWriter code, ClassNode cls) {
 		ClassInfo classInfo = cls.getClassInfo();
-		if (classInfo.isRenamed()
-				&& !cls.getShortName().equals(cls.getAlias().getShortName())) {
-			code.startLine("/* renamed from: ").add(classInfo.getFullName()).add(" */");
+		if (classInfo.isRenamed()) {
+			code.startLine("/* renamed from: ").add(classInfo.getType().getObject()).add(" */");
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/codegen/MethodGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/MethodGen.java
@@ -80,6 +80,10 @@ public class MethodGen {
 		if (clsAccFlags.isAnnotation()) {
 			ai = ai.remove(AccessFlags.ACC_PUBLIC);
 		}
+
+		if(mth.getMethodInfo().isRenamed()) {
+			code.startLine("/* renamed from: ").add(mth.getName()).add(" */");
+		}
 		code.startLineWithNum(mth.getSourceLine());
 		code.add(ai.makeString());
 

--- a/jadx-core/src/main/java/jadx/core/codegen/NameGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/NameGen.java
@@ -164,6 +164,7 @@ public class NameGen {
 			if (vName != null) {
 				return vName;
 			}
+			return StringUtils.escape(shortName.toLowerCase());
 		}
 		return StringUtils.escape(type.toString());
 	}

--- a/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -111,22 +110,23 @@ public class Deobfuscator {
 	private void postProcess() {
 		int id = 1;
 		for (OverridedMethodsNode o : ovrd) {
-
-			Iterator<MethodInfo> it = o.getMethods().iterator();
-			if (it.hasNext()) {
-				MethodInfo mth = it.next();
-
-				if (mth.isRenamed() && !mth.isAliasFromPreset()) {
-					mth.setAlias(String.format("mo%d%s", id, makeName(mth.getName())));
+			boolean aliasFromPreset = false;
+			String aliasToUse = null;
+			for(MethodInfo mth : o.getMethods()){
+				if(mth.isAliasFromPreset()) {
+					aliasToUse = mth.getAlias();
+					aliasFromPreset = true;
 				}
-				String firstMethodAlias = mth.getAlias();
-
-				while (it.hasNext()) {
-					mth = it.next();
-					if (!mth.getAlias().equals(firstMethodAlias)) {
-						mth.setAlias(firstMethodAlias);
+			}
+			for(MethodInfo mth : o.getMethods()){
+				if(aliasToUse == null) {
+					if (mth.isRenamed() && !mth.isAliasFromPreset()) {
+						mth.setAlias(String.format("mo%d%s", id, makeName(mth.getName())));
 					}
+					aliasToUse = mth.getAlias();
 				}
+				mth.setAlias(aliasToUse);
+				mth.setAliasFromPreset(aliasFromPreset);
 			}
 
 			id++;

--- a/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
@@ -89,6 +89,10 @@ public final class ClassInfo {
 		int sep = clsName.lastIndexOf('$');
 		if (canBeInner && sep > 0 && sep != clsName.length() - 1) {
 			String parClsName = pkg + "." + clsName.substring(0, sep);
+			if(pkg.length() == 0) {
+				parClsName = clsName.substring(0, sep);
+			}
+
 			parentClass = fromName(dex, parClsName);
 			clsName = clsName.substring(sep + 1);
 		} else {

--- a/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
@@ -35,12 +35,12 @@ public final class ClassInfo {
 		if (type.isArray()) {
 			type = ArgType.OBJECT;
 		}
-		ClassInfo cls = dex.getInfoStorage().getCls(type);
+		ClassInfo cls = dex.root().getInfoStorage().getCls(type);
 		if (cls != null) {
 			return cls;
 		}
 		cls = new ClassInfo(dex, type);
-		return dex.getInfoStorage().putCls(cls);
+		return dex.root().getInfoStorage().putCls(cls);
 	}
 
 	public static ClassInfo fromDex(DexNode dex, int clsIndex) {

--- a/jadx-core/src/main/java/jadx/core/dex/info/FieldInfo.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/FieldInfo.java
@@ -22,7 +22,7 @@ public final class FieldInfo {
 
 	public static FieldInfo from(DexNode dex, ClassInfo declClass, String name, ArgType type) {
 		FieldInfo field = new FieldInfo(declClass, name, type);
-		return dex.getInfoStorage().getField(field);
+		return dex.root().getInfoStorage().getField(field);
 	}
 
 	public static FieldInfo fromDex(DexNode dex, int index) {

--- a/jadx-core/src/main/java/jadx/core/dex/info/InfoStorage.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/InfoStorage.java
@@ -1,6 +1,7 @@
 package jadx.core.dex.info;
 
 import jadx.core.dex.instructions.args.ArgType;
+import jadx.core.dex.nodes.DexNode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,13 +23,17 @@ public class InfoStorage {
 		}
 	}
 
-	public MethodInfo getMethod(int mtdId) {
-		return methods.get(mtdId);
+	private int generateMethodLookupId(DexNode dex, int mthId) {
+		return (dex.getDexId()<<16)|mthId;
 	}
 
-	public MethodInfo putMethod(int mthId, MethodInfo mth) {
+	public MethodInfo getMethod(DexNode dex, int mtdId) {
+		return methods.get(generateMethodLookupId(dex,mtdId));
+	}
+
+	public MethodInfo putMethod(DexNode dex, int mthId, MethodInfo mth) {
 		synchronized (methods) {
-			MethodInfo prev = methods.put(mthId, mth);
+			MethodInfo prev = methods.put(generateMethodLookupId(dex,mthId), mth);
 			return prev == null ? mth : prev;
 		}
 	}

--- a/jadx-core/src/main/java/jadx/core/dex/info/MethodInfo.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/MethodInfo.java
@@ -34,12 +34,12 @@ public final class MethodInfo {
 	}
 
 	public static MethodInfo fromDex(DexNode dex, int mthIndex) {
-		MethodInfo mth = dex.getInfoStorage().getMethod(mthIndex);
+		MethodInfo mth = dex.root().getInfoStorage().getMethod(dex, mthIndex);
 		if (mth != null) {
 			return mth;
 		}
 		mth = new MethodInfo(dex, mthIndex);
-		return dex.getInfoStorage().putMethod(mthIndex, mth);
+		return dex.root().getInfoStorage().putMethod(dex, mthIndex, mth);
 	}
 
 	public String makeSignature(boolean includeRetType) {

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/DexNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/DexNode.java
@@ -35,16 +35,16 @@ public class DexNode implements IDexNode {
 	private final RootNode root;
 	private final Dex dexBuf;
 	private final DexFile file;
+	private final int dexId;
 
 	private final List<ClassNode> classes = new ArrayList<ClassNode>();
 	private final Map<ClassInfo, ClassNode> clsMap = new HashMap<ClassInfo, ClassNode>();
 
-	private final InfoStorage infoStorage = new InfoStorage();
-
-	public DexNode(RootNode root, DexFile input) {
+	public DexNode(RootNode root, DexFile input, int dexId) {
 		this.root = root;
 		this.file = input;
 		this.dexBuf = input.getDexBuf();
+		this.dexId = dexId;
 	}
 
 	public void loadClasses() throws DecodeException {
@@ -153,10 +153,6 @@ public class DexNode implements IDexNode {
 		return null;
 	}
 
-	public InfoStorage getInfoStorage() {
-		return infoStorage;
-	}
-
 	public DexFile getDexFile() {
 		return file;
 	}
@@ -212,6 +208,10 @@ public class DexNode implements IDexNode {
 	@Override
 	public DexNode dex() {
 		return this;
+	}
+
+	public int getDexId() {
+		return dexId;
 	}
 
 	@Override

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
@@ -7,6 +7,7 @@ import jadx.api.ResourcesLoader;
 import jadx.core.clsp.ClspGraph;
 import jadx.core.dex.info.ClassInfo;
 import jadx.core.dex.info.ConstStorage;
+import jadx.core.dex.info.InfoStorage;
 import jadx.core.utils.ErrorsCounter;
 import jadx.core.utils.StringUtils;
 import jadx.core.utils.android.AndroidResourcesUtils;
@@ -34,6 +35,7 @@ public class RootNode {
 	private final IJadxArgs args;
 	private final StringUtils stringUtils;
 	private final ConstStorage constValues;
+	private final InfoStorage infoStorage = new InfoStorage();
 
 	private List<DexNode> dexNodes;
 	@Nullable
@@ -53,7 +55,7 @@ public class RootNode {
 			for (DexFile dexFile : input.getDexFiles()) {
 				try {
 					LOG.debug("Load: {}", dexFile);
-					DexNode dexNode = new DexNode(this, dexFile);
+					DexNode dexNode = new DexNode(this, dexFile, dexNodes.size());
 					dexNodes.add(dexNode);
 				} catch (Exception e) {
 					throw new DecodeException("Error decode file: " + dexFile, e);
@@ -197,4 +199,9 @@ public class RootNode {
 	public ConstStorage getConstValues() {
 		return constValues;
 	}
+
+	public InfoStorage getInfoStorage() {
+		return infoStorage;
+	}
+
 }


### PR DESCRIPTION
Fixes the following issues with deobfuscation:
- Name generation on variables of deobfuscated objects were sometimes based off of the original class name, and not the alias.
- Renamed classes/methods referenced in a different dex file would not be renamed properly.
- Deobfuscator.postProcess may overwrite Deobfuscated method names for overriden methods.

Also fixes one issue not related to the  deobfuscation:
- Inner classes residing in an empty package name were not being linked to their parent class due to an issue with ClassInfo.splitNames


Thanks for this project!