### PR TITLE
Decode attributes which may contain either enums or values, e.g. layo…

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ManifestAttributes.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ManifestAttributes.java
@@ -168,10 +168,7 @@ public class ManifestAttributes {
 			return null;
 		}
 		if (attr.getType() == MAttrType.ENUM) {
-			String name = attr.getValues().get(value);
-			if (name != null) {
-				return name;
-			}
+			return attr.getValues().get(value);
 		} else if (attr.getType() == MAttrType.FLAG) {
 			StringBuilder sb = new StringBuilder();
 			for (Map.Entry<Long, String> entry : attr.getValues().entrySet()) {


### PR DESCRIPTION
…ut_width

android:layout_width="UNKNOWN_DATA_0x6401" becomes android:layout_width="100dp".

This works, because the upper layer already handles 'null' return values.