### PR TITLE
Directory Bug

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/files/FileUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/files/FileUtils.java
@@ -57,7 +57,7 @@ public class FileUtils {
 	public static void makeDirs(@Nullable File dir) {
 		if (dir != null) {
 			synchronized (MKDIR_SYNC) {
-				if (!dir.exists() && !dir.mkdirs()) {
+				if (!dir.mkdirs() && !dir.isDirectory()) {
 					throw new JadxRuntimeException("Can't create directory " + dir);
 				}
 			}


### PR DESCRIPTION
The correct pattern to make a directory is: `if (!dir.mkdirs() && !dir.isDirectory()) { error }` mkdirs checks for exists so the exists check is redundant.