### PR TITLE
Performance issue when building strings

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/utils/CertificateManager.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/CertificateManager.java
@@ -193,7 +193,7 @@ public class CertificateManager {
 		char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
 				'A', 'B', 'C', 'D', 'E', 'F'};
 
-		StringBuffer buf = new StringBuffer(bytes.length * 3);
+		StringBuilder buf = new StringBuilder(bytes.length * 3);
 
 		for (int i = 0; i < bytes.length; ++i) {
 			buf.append(hexDigits[(bytes[i] & 0xf0) >> 4]);


### PR DESCRIPTION
Improve performance by using StringBuilder instead of StringBuffer.