### PR TITLE
settingsVersion field unset leads to settings overwritten

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsAdapter.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsAdapter.java
@@ -46,7 +46,8 @@ public class JadxSettingsAdapter {
 			String jsonSettings = PREFS.get(JADX_GUI_KEY, "");
 			JadxSettings settings = fromString(jsonSettings);
 			if (settings == null) {
-				return new JadxSettings();
+				LOG.debug("Created new settings.");
+				settings = new JadxSettings();
 			}
 			LOG.debug("Loaded settings: {}", makeString(settings));
 			settings.fixOnLoad();


### PR DESCRIPTION
`JadxSettings` object created at the first time hasn't been initialized completely so `settingsVersion` of it is 0 (we can use `Preferences.userNodeForPackage(JadxGUI.class).clear()` to simulate this situation), so when app starts the next time, `upgradeSettings()` will overwrite what saved the last time because previous settings are considered as low version.
And now `settings.fixOnLoad()` will be called to do initialization works following JadxSettings created.
I think this bug is hard to discover because there are always settings with latest `settingsVersion` saved in the storage and therefore `upgradeSettings` won't be called.