### PR TITLE
Decompilation and indexing are messed-up for large apps

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/jobs/BackgroundJob.java
+++ b/jadx-gui/src/main/java/jadx/gui/jobs/BackgroundJob.java
@@ -44,7 +44,7 @@ public abstract class BackgroundJob {
 				public Boolean call() throws Exception {
 					runJob();
 					executor.shutdown();
-					return executor.awaitTermination(5, TimeUnit.MINUTES);
+					return executor.awaitTermination(5, TimeUnit.DAYS);
 				}
 			});
 		}


### PR DESCRIPTION
Currently the DecompileJob generates the background jobs for decompiling the classes and then returns. 
Then the ShutdownTask is triggered which waits up to 5 minutes and then continues even if decompile jobs are still running.
If the decompilation of the remaining jobs requires more than 5 minutes Jadx is running into troubles:
This means that it starts indexing when decompilation is still running and therefore all data structures by Jadx don't cover the whole app. 

Alls this is visible to the user as the progress bar disappears way too early. Even is the CPU utilization shows that decompilation is still running.

For large APKs 5 minutes is way too less. I used the Facebook app linked in #354 and was still busy processing decompile job 5077 of 104946 when the ShutdownTask finally triggered (and that was with already re-enabled multi-threaded decompilation in MainGui.resetCache() - BTW: did you set the decompilation threads to one only because of memory problems or are there real multi-threading issues in Jadx decompilation?).

Therefore I increased the wait time to 5 days which should be enough even for large apps.