### PR TITLE
Added temporarily node hiding

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -311,6 +311,15 @@ public class MainWindow extends JFrame {
 		}
 	}
 
+	private void treeRightClickAction(){
+		try {
+			DefaultMutableTreeNode node = (DefaultMutableTreeNode)tree.getLastSelectedPathComponent();
+			treeModel.removeNodeFromParent(node);
+		} catch (Exception e) {
+			LOG.error("Content removing error", e);
+		}
+	}
+
 	private void syncWithEditor() {
 		ContentPanel selectedContentPanel = tabbedPane.getSelectedCodePanel();
 		if (selectedContentPanel == null) {
@@ -568,10 +577,18 @@ public class MainWindow extends JFrame {
 		tree = new JTree(treeModel);
 		tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
 		tree.addMouseListener(new MouseAdapter() {
+
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				treeClickAction();
+
+				if (SwingUtilities.isRightMouseButton(e)) {
+					treeRightClickAction();
+				}
+				else{
+					treeClickAction();
+				}
 			}
+
 		});
 		tree.addKeyListener(new KeyAdapter() {
 			@Override


### PR DESCRIPTION
Right clicking on a node in the jtree gets it removed, making it disapear until a tree reload. 
This makes handling big projects cleaner where you want to exclude certain packages.