### PR TITLE
Search causes NullPointerException

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
@@ -180,6 +180,7 @@ public class SearchDialog extends CommonSearchDialog {
 						.toList()
 						.toFlowable(), 1)
 				.observeOn(SwingSchedulers.edt())
+				.doOnError(e -> LOG.error("Error while searching: {}", e.getMessage(), e))
 				.subscribe(this::processSearchResults);
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/utils/search/CodeIndex.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/search/CodeIndex.java
@@ -23,7 +23,7 @@ public class CodeIndex<T> implements SearchIndex<T> {
 	}
 
 	@Override
-	public void put(StringRef str, T value) {
+	public synchronized void put(StringRef str, T value) {
 		if (str == null || str.length() == 0) {
 			return;
 		}


### PR DESCRIPTION
fix: unsynchronized search index creation results in NullPointerException upon performing search:

```
java.lang.NullPointerException: null
	at jadx.gui.utils.search.CodeIndex.isMatched(CodeIndex.java:40)
	at jadx.gui.utils.search.CodeIndex.lambda$search$0(CodeIndex.java:49)
	at io.reactivex.internal.operators.flowable.FlowableCreate.subscribeActual(FlowableCreate.java:71)
	at io.reactivex.Flowable.subscribe(Flowable.java:14805)
	at io.reactivex.Flowable.subscribe(Flowable.java:14752)
	at io.reactivex.internal.operators.flowable.FlowableConcatArray$ConcatArraySubscriber.onComplete(FlowableConcatArray.java:140)
	at io.reactivex.internal.operators.flowable.FlowableConcatArray.subscribeActual(FlowableConcatArray.java:40)
	at io.reactivex.Flowable.subscribe(Flowable.java:14805)
	at io.reactivex.Flowable.subscribe(Flowable.java:14752)
	at io.reactivex.internal.operators.flowable.FlowableSubscribeOn$SubscribeOnSubscriber.run(FlowableSubscribeOn.java:82)
	at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)
	at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The main reason is that when the keys and values are added without synchronization from multiple threads some array indices are unused and some used twice which end up in key values to be null.