### PR TITLE
fix: unsynchronized search index creation 

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/HeapUsageBar.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/HeapUsageBar.java
@@ -35,7 +35,7 @@ public class HeapUsageBar extends JProgressBar implements ActionListener {
 		setMaximum(maxKB);
 		maxGB = maxKB / TWO_TO_20;
 		update();
-		timer = new Timer(1000, this);
+		timer = new Timer(2000, this);
 	}
 
 	public void update() {
@@ -44,7 +44,7 @@ public class HeapUsageBar extends JProgressBar implements ActionListener {
 		setValue(usedKB);
 		setString(String.format(textFormat, (usedKB / TWO_TO_20), maxGB));
 
-		if (used > r.totalMemory() * 0.8) {
+		if (used > r.maxMemory() * 0.8) {
 			setForeground(RED);
 		} else {
 			setForeground(GREEN);

--- a/jadx-gui/src/main/java/jadx/gui/utils/CodeUsageInfo.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/CodeUsageInfo.java
@@ -47,18 +47,11 @@ public class CodeUsageInfo {
 
 	private void addUsage(JNode jNode, JavaClass javaClass,
 	                      CodeLinesInfo linesInfo, CodePosition codePosition, List<StringRef> lines) {
-        UsageInfo usageInfo;
-        synchronized (jNode) {
-            usageInfo = usageMap.get(jNode);
-            if (usageInfo == null) {
-                usageInfo = new UsageInfo();
-                usageMap.put(jNode, usageInfo);
-            }
-        }
-		int line = codePosition.getLine();
-		JavaNode javaNodeByLine = linesInfo.getJavaNodeByLine(line);
-		StringRef codeLine = lines.get(line - 1);
-		JNode node = nodeCache.makeFrom(javaNodeByLine == null ? javaClass : javaNodeByLine);
+        UsageInfo usageInfo = usageMap.computeIfAbsent(jNode, key -> new UsageInfo());
+        int line = codePosition.getLine();
+        JavaNode javaNodeByLine = linesInfo.getJavaNodeByLine(line);
+        StringRef codeLine = lines.get(line - 1);
+        JNode node = nodeCache.makeFrom(javaNodeByLine == null ? javaClass : javaNodeByLine);
 		CodeNode codeNode = new CodeNode(node, line, codeLine);
 		usageInfo.addUsage(codeNode);
 	}

--- a/jadx-gui/src/main/java/jadx/gui/utils/CodeUsageInfo.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/CodeUsageInfo.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import jadx.api.CodePosition;
 import jadx.api.JavaClass;
@@ -21,6 +22,10 @@ public class CodeUsageInfo {
 		public List<CodeNode> getUsageList() {
 			return usageList;
 		}
+
+		public synchronized void addUsage(CodeNode codeNode) {
+			usageList.add(codeNode);
+		}
 	}
 
 	private final JNodeCache nodeCache;
@@ -29,7 +34,7 @@ public class CodeUsageInfo {
 		this.nodeCache = nodeCache;
 	}
 
-	private final Map<JNode, UsageInfo> usageMap = new HashMap<>();
+	private final Map<JNode, UsageInfo> usageMap = new ConcurrentHashMap<>();
 
 	public void processClass(JavaClass javaClass, CodeLinesInfo linesInfo, List<StringRef> lines) {
 		Map<CodePosition, JavaNode> usage = javaClass.getUsageMap();
@@ -42,17 +47,20 @@ public class CodeUsageInfo {
 
 	private void addUsage(JNode jNode, JavaClass javaClass,
 	                      CodeLinesInfo linesInfo, CodePosition codePosition, List<StringRef> lines) {
-		UsageInfo usageInfo = usageMap.get(jNode);
-		if (usageInfo == null) {
-			usageInfo = new UsageInfo();
-			usageMap.put(jNode, usageInfo);
-		}
+        UsageInfo usageInfo;
+        synchronized (jNode) {
+            usageInfo = usageMap.get(jNode);
+            if (usageInfo == null) {
+                usageInfo = new UsageInfo();
+                usageMap.put(jNode, usageInfo);
+            }
+        }
 		int line = codePosition.getLine();
 		JavaNode javaNodeByLine = linesInfo.getJavaNodeByLine(line);
 		StringRef codeLine = lines.get(line - 1);
 		JNode node = nodeCache.makeFrom(javaNodeByLine == null ? javaClass : javaNodeByLine);
 		CodeNode codeNode = new CodeNode(node, line, codeLine);
-		usageInfo.getUsageList().add(codeNode);
+		usageInfo.addUsage(codeNode);
 	}
 
 	public List<CodeNode> getUsageList(JNode node) {


### PR DESCRIPTION
Unsynchronized search index creation (code usage) results in ArrayIndexOutOfBoundsException makes the index creation stuck at 99%

This also fixes #354 (Facebook messenger using -Xmx12g using Java 11) in my tests.

Additionally I included a small fix for the heap usage bar which turned "red" too early.