### PR TITLE
build: compile for Java 8; enable G1GC on Java 8

### DIFF
--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -7,6 +7,9 @@ apply plugin: 'application'
 
 mainClassName = 'jadx.gui.JadxGUI'
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile(project(":jadx-core"))
     compile(project(":jadx-cli"))
@@ -42,7 +45,8 @@ jar {
 }
 
 startScripts {
-    defaultJvmOpts = ['-Xms128M', '-Xmx4g', '-Dawt.useSystemAAFontSettings=lcd', '-Dswing.aatext=true']
+    // The option -XX:+UseG1GC is only relevant for Java 8. Starting with Java 9 G1GC is already the default GC
+    defaultJvmOpts = ['-Xms128M', '-Xmx4g', '-Dawt.useSystemAAFontSettings=lcd', '-Dswing.aatext=true', '-XX:+UseG1GC']
     doLast {
         def str = windowsScript.text
         str = str.replaceAll('java.exe', 'javaw.exe')
@@ -61,7 +65,8 @@ launch4j {
     copyright = 'Skylot'
     windowTitle = 'jadx'
     companyName = 'jadx'
-    jvmOptions = ['-Dawt.useSystemAAFontSettings=lcd', '-Dswing.aatext=true']
+    jreMinVersion = '1.8.0'
+    jvmOptions = ['-Dawt.useSystemAAFontSettings=lcd', '-Dswing.aatext=true', '-XX:+UseG1GC']
     jreRuntimeBits = "64"
     initialHeapPercent = 5
     maxHeapSize = 4096


### PR DESCRIPTION
The G1GC is way faster and therefore often helps to reduce the memory usage when running Jadx wit Java 8. On Java9+ G1GC is already the default GC, therefore the G1GC flags don't change anything for that runtime platforms. 

I had problems when compiling with OpenJDK 11. The created jadx-gui-dev.exe file said it requires Java 11 (and links to the Oracle Java 8 page) but it wasn't able to find the installed OpenJDK 11 version. With compilation target Java 8 it is at least able to find an installed Java 8 JRE.