### PR TITLE
fix(gui): Allow APK files without code (no contained dex files)

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/android/AndroidResourcesUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/android/AndroidResourcesUtils.java
@@ -54,6 +54,10 @@ public class AndroidResourcesUtils {
 		}
 		LOG.info("App 'R' class not found, put all resources ids to : '{}'", fullName);
 		resCls = makeClass(root, fullName, resStorage);
+		if (resCls == null) {
+			// We are in an APK without code therefore we don't have to update an 'R' class with the resources
+			return null;
+		}
 		addResourceFields(resCls, resStorage, false);
 		return resCls;
 	}
@@ -81,18 +85,18 @@ public class AndroidResourcesUtils {
 		return rCls;
 	}
 
-	private static void addResourceFields(ClassNode cls, ResourceStorage resStorage, boolean rClsExists) {
+	private static void addResourceFields(ClassNode resCls, ResourceStorage resStorage, boolean rClsExists) {
 		Map<String, ClassNode> innerClsMap = new TreeMap<>();
 		if (rClsExists) {
-			for (ClassNode innerClass : cls.getInnerClasses()) {
+			for (ClassNode innerClass : resCls.getInnerClasses()) {
 				innerClsMap.put(innerClass.getShortName(), innerClass);
 			}
 		}
 		for (ResourceEntry resource : resStorage.getResources()) {
 			ClassNode typeCls = innerClsMap.computeIfAbsent(resource.getTypeName(), name -> {
-				ClassNode newTypeCls = new ClassNode(cls.dex(), cls.getFullName() + "$" + name,
+				ClassNode newTypeCls = new ClassNode(resCls.dex(), resCls.getFullName() + "$" + name,
 						AccessFlags.ACC_PUBLIC | AccessFlags.ACC_STATIC | AccessFlags.ACC_FINAL);
-				cls.addInnerClass(newTypeCls);
+				resCls.addInnerClass(newTypeCls);
 				if (rClsExists) {
 					newTypeCls.addAttr(AType.COMMENTS, "added by JADX");
 				}

--- a/jadx-core/src/main/java/jadx/core/utils/files/InputFile.java
+++ b/jadx-core/src/main/java/jadx/core/utils/files/InputFile.java
@@ -77,8 +77,7 @@ public class InputFile {
 		if (skipSources) {
 			return;
 		}
-
-		throw new DecodeException("Unsupported input file format: " + file);
+		LOG.warn("No dex files found in {}", file);
 	}
 
 	private void addDexFile(Dex dexBuf) {


### PR DESCRIPTION
APKs without code are getting more and more common.
Originally this was only possible for apps that were implemented purely in native code (never encountered such an app) but nowadays because of the [App Bundle technology](https://developer.android.com/platform/technology/app-bundle/) a lot of apps are constructed out of multiple APK files (e.g. base bundle with the code, the images, the language strings and finally the native libraries).

This PR makes it possible to open such "resource APKs" in Jadx.