### PR TITLE
fix: replace dot character with underscore in style resource name

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/android/AndroidResourcesUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/android/AndroidResourcesUtils.java
@@ -99,11 +99,17 @@ public class AndroidResourcesUtils {
 			}
 		}
 		for (ResourceEntry resource : resStorage.getResources()) {
+			final String resTypeName = resource.getTypeName();
 			ClassNode typeCls = innerClsMap.computeIfAbsent(
-					resource.getTypeName(),
+					resTypeName,
 					name -> addClassForResType(resCls, rClsExists, name)
 			);
-			String resName = resource.getKeyName();
+			final String resName;
+			if ("style".equals(resTypeName)) {
+				resName = resource.getKeyName().replace('.', '_');
+			} else {
+				resName = resource.getKeyName();
+			}
 			FieldNode rField = typeCls.searchFieldByName(resName);
 			if (rField == null) {
 				FieldInfo rFieldInfo = FieldInfo.from(typeCls.dex(), typeCls.getClassInfo(), resName, ArgType.INT);


### PR DESCRIPTION
Hello, current generated field name for style resources in R class
```
/* added by JADX */
/* renamed from: Base.Widget.AppCompat.ImageButton */
public static final int f3775BaseWidgetAppCompatImageButton = 2131624131;
```
Should be:
```
public static final int Base_Widget_AppCompat_ImageButton = 2131624131;
```