### PR TITLE
GUI: disable package if "excluded"

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
@@ -1,11 +1,14 @@
 package jadx.gui;
 
-import javax.swing.*;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
+
+import javax.swing.ProgressMonitor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,20 +81,36 @@ public class JadxWrapper {
 	 */
 	public List<JavaClass> getIncludedClasses() {
 		List<JavaClass> classList = decompiler.getClasses();
-		String excludedPackages = settings.getExcludedPackages().trim();
-		if (excludedPackages.length() == 0) {
+		List<String> excludedPackages = getExcludedPackages();
+		if (excludedPackages.isEmpty()) {
 			return classList;
 		}
-		String[] excluded = excludedPackages.split("[ ]+");
 
 		return classList.stream().filter(cls -> {
-			for (String exclude : excluded) {
+			for (String exclude : excludedPackages) {
 				if (cls.getFullName().startsWith(exclude)) {
 					return false;
 				}
 			}
 			return true;
 		}).collect(Collectors.toList());
+	}
+
+	public List<String> getExcludedPackages() {
+		String excludedPackages = settings.getExcludedPackages().trim();
+		return Arrays.asList(excludedPackages.split("[ ]+"));
+	}
+
+	public void addExcludedPackage(String packageToExclude) {
+		settings.setExcludedPackages(settings.getExcludedPackages() + ' ' + packageToExclude);
+		settings.sync();
+	}
+
+	public void removeExcludedPackage(String packageToRemoveFromExclusion) {
+		List<String> list = new ArrayList<>(getExcludedPackages());
+		list.remove(packageToRemoveFromExclusion);
+		settings.setExcludedPackages(String.join(" ", list));
+		settings.sync();
 	}
 
 	public List<JavaPackage> getPackages() {

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -333,4 +333,5 @@ public class JadxSettings extends JadxCLIArgs {
 		settingsVersion = CURRENT_SETTINGS_VERSION;
 		sync();
 	}
+
 }

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
@@ -247,10 +247,14 @@ public class JadxSettingsWindow extends JDialog {
 		JButton editExcludedPackages = new JButton(NLS.str("preferences.excludedPackages.button"));
 		editExcludedPackages.addActionListener(event -> {
 
+			String oldExcludedPackages = settings.getExcludedPackages();
 			String result = JOptionPane.showInputDialog(this, NLS.str("preferences.excludedPackages.editDialog"),
 					settings.getExcludedPackages());
 			if (result != null) {
 				settings.setExcludedPackages(result);
+				if (!oldExcludedPackages.equals(result)) {
+					needReload();
+				}
 			}
 		});
 

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JPackage.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JPackage.java
@@ -1,13 +1,16 @@
 package jadx.gui.treemodel;
 
-import javax.swing.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 
 import org.jetbrains.annotations.NotNull;
 
 import jadx.api.JavaClass;
 import jadx.api.JavaPackage;
+import jadx.gui.JadxWrapper;
 import jadx.gui.utils.Utils;
 
 public class JPackage extends JNode implements Comparable<JPackage> {
@@ -15,12 +18,16 @@ public class JPackage extends JNode implements Comparable<JPackage> {
 
 	private static final ImageIcon PACKAGE_ICON = Utils.openIcon("package_obj");
 
+	private final String fullName;
 	private String name;
+	private boolean enabled;
 	private final List<JClass> classes;
 	private final List<JPackage> innerPackages = new ArrayList<>(1);
 
-	public JPackage(JavaPackage pkg) {
+	public JPackage(JavaPackage pkg, JadxWrapper wrapper) {
+		this.fullName = pkg.getName();
 		this.name = pkg.getName();
+		setEnabled(wrapper);
 		List<JavaClass> javaClasses = pkg.getClasses();
 		this.classes = new ArrayList<>(javaClasses.size());
 		for (JavaClass javaClass : javaClasses) {
@@ -29,26 +36,40 @@ public class JPackage extends JNode implements Comparable<JPackage> {
 		update();
 	}
 
-	public JPackage(String name) {
+	public JPackage(String name, JadxWrapper wrapper) {
+		this.fullName = name;
 		this.name = name;
+		setEnabled(wrapper);
 		this.classes = new ArrayList<>(1);
+	}
+
+	private void setEnabled(JadxWrapper wrapper) {
+		List<String> excludedPackages = wrapper.getExcludedPackages();
+		this.enabled = excludedPackages.isEmpty()
+				|| excludedPackages.stream().filter(p -> !p.isEmpty()).noneMatch(p -> name.startsWith(p));
 	}
 
 	public final void update() {
 		removeAllChildren();
-		for (JPackage pkg : innerPackages) {
-			pkg.update();
-			add(pkg);
-		}
-		for (JClass cls : classes) {
-			cls.update();
-			add(cls);
+		if (isEnabled()) {
+			for (JPackage pkg : innerPackages) {
+				pkg.update();
+				add(pkg);
+			}
+			for (JClass cls : classes) {
+				cls.update();
+				add(cls);
+			}
 		}
 	}
 
 	@Override
 	public String getName() {
 		return name;
+	}
+
+	public String getFullName() {
+		return fullName;
 	}
 
 	public void setName(String name) {
@@ -107,5 +128,9 @@ public class JPackage extends JNode implements Comparable<JPackage> {
 	@Override
 	public String makeLongString() {
 		return name;
+	}
+	
+	public boolean isEnabled() {
+		return enabled;
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JSources.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JSources.java
@@ -33,7 +33,7 @@ public class JSources extends JNode {
 		removeAllChildren();
 		if (flatPackages) {
 			for (JavaPackage pkg : wrapper.getPackages()) {
-				add(new JPackage(pkg));
+				add(new JPackage(pkg, wrapper));
 			}
 		} else {
 			// build packages hierarchy
@@ -54,7 +54,7 @@ public class JSources extends JNode {
 	List<JPackage> getHierarchyPackages(List<JavaPackage> packages) {
 		Map<String, JPackage> pkgMap = new HashMap<>();
 		for (JavaPackage pkg : packages) {
-			addPackage(pkgMap, new JPackage(pkg));
+			addPackage(pkgMap, new JPackage(pkg, wrapper));
 		}
 		// merge packages without classes
 		boolean repeat;
@@ -114,7 +114,7 @@ public class JSources extends JNode {
 			pkg.setName(shortName);
 			JPackage prevPkg = pkgs.get(prevPart);
 			if (prevPkg == null) {
-				prevPkg = new JPackage(prevPart);
+				prevPkg = new JPackage(prevPart, wrapper);
 				addPackage(pkgs, prevPkg);
 			}
 			prevPkg.getInnerPackages().add(pkg);


### PR DESCRIPTION
This is related to #423.

The changes does the following:
- On right-click of a package, it opens a menu to exclude/unexclude.
- Propagates this change to the settings.
- Refresh the tree.
- Excluded packages don't show children.