### PR TITLE
GUI: Sort resources according to their type, then name

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
@@ -3,6 +3,7 @@ package jadx.gui.treemodel;
 import javax.swing.*;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -68,6 +69,14 @@ public class JResource extends JLoadableNode implements Comparable<JResource> {
 			}
 		} else {
 			removeAllChildren();
+
+			Comparator<JResource> typeComparator
+				= (r1, r2) -> r1.type.ordinal() - r2.type.ordinal();
+			Comparator<JResource> nameComparator
+				= Comparator.comparing(JResource::getName, String.CASE_INSENSITIVE_ORDER);
+
+			files.sort(typeComparator.thenComparing(nameComparator));
+
 			for (JResource res : files) {
 				res.update();
 				add(res);


### PR DESCRIPTION
The Resources section should be sorted, for better experience.

They are made sorted according to their type (ROOT, then DIR, then FILE), then sorted by name (case-insensitive).