### PR TITLE
Remove unneeded cast.

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
@@ -215,7 +215,7 @@ public class ValuesParser extends ParserConstants {
 	}
 
 	private static String floatToString(float value) {
-		return doubleToString((double) value);
+		return doubleToString(value);
 	}
 
 	public static Map<Integer, String> getAndroidResMap() {

--- a/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
@@ -53,7 +53,7 @@ public class JadxWrapper {
 					while (ex.isTerminating()) {
 						long total = ex.getTaskCount();
 						long done = ex.getCompletedTaskCount();
-						progressMonitor.setProgress((int) (done * 100.0 / (double) total));
+						progressMonitor.setProgress((int) (done * 100.0 / total));
 						Thread.sleep(500);
 					}
 					progressMonitor.close();

--- a/jadx-samples/src/main/java/jadx/samples/TestCF4.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestCF4.java
@@ -21,13 +21,13 @@ public class TestCF4 extends AbstractTest {
 		f = null;
 		c = 2;
 		testComplexIf("abcdef", 0);
-		assertEquals(c, (int) 'c');
+		assertEquals(c, 'c');
 
 		d = "";
 		f = null;
 		c = 0;
 		testComplexIf("abcdef", 0);
-		assertEquals(c, (int) 'a');
+		assertEquals(c, 'a');
 
 		d = "";
 		f = "1";


### PR DESCRIPTION
As detected by Eclipse, and the test case doesn't depend on the explicit
casting.