### PR TITLE
gui: better to show java version, instead of VM version

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/AboutDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/AboutDialog.java
@@ -34,7 +34,7 @@ class AboutDialog extends JDialog {
 		version.setAlignmentX(0.5f);
 
 		String javaVm = System.getProperty("java.vm.name");
-		String javaVer = System.getProperty("java.vm.version");
+		String javaVer = System.getProperty("java.version");
 
 		javaVm = javaVm == null ? "" : javaVm;
 


### PR DESCRIPTION
In the GUI "About" dialog: so the users sees something like `1.8.0_202` instead of `25.202-b08`
