### PR TITLE
fix: R class fields alias

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import jadx.core.dex.attributes.AFlag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -225,6 +226,8 @@ public class Deobfuscator {
 			clsInfo.rename(cls.dex().root(), fullName);
 		}
 		for (FieldNode field : cls.getFields()) {
+			if (field.contains(AFlag.DONT_RENAME))
+			    continue;
 			renameField(field);
 		}
 		for (MethodNode mth : cls.getMethods()) {
@@ -404,12 +407,6 @@ public class Deobfuscator {
 		FieldInfo fieldInfo = field.getFieldInfo();
 		String alias = fldMap.get(fieldInfo);
 		if (alias != null) {
-			return alias;
-		}
-		//check if field already has alias, because alias can be set from AndroidResourcesUtils
-		alias = fieldInfo.getAlias();
-		if (alias != null) {
-			fldMap.put(fieldInfo, alias);
 			return alias;
 		}
 		alias = deobfPresets.getForFld(fieldInfo);

--- a/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
@@ -406,6 +406,12 @@ public class Deobfuscator {
 		if (alias != null) {
 			return alias;
 		}
+		//check if field already has alias, because alias can be set from AndroidResourcesUtils
+		alias = fieldInfo.getAlias();
+		if (alias != null) {
+			fldMap.put(fieldInfo, alias);
+			return alias;
+		}
 		alias = deobfPresets.getForFld(fieldInfo);
 		if (alias != null) {
 			fldMap.put(fieldInfo, alias);

--- a/jadx-core/src/main/java/jadx/core/dex/attributes/AFlag.java
+++ b/jadx-core/src/main/java/jadx/core/dex/attributes/AFlag.java
@@ -19,6 +19,7 @@ public enum AFlag {
 	DONT_SHRINK,
 	DONT_INLINE,
 	DONT_GENERATE,
+	DONT_RENAME, // do not rename during deobfuscation
 	SKIP,
 	REMOVE,
 

--- a/jadx-core/src/main/java/jadx/core/utils/android/AndroidResourcesUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/android/AndroidResourcesUtils.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import com.android.dx.rop.code.AccessFlags;
+import jadx.core.dex.attributes.AFlag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -124,6 +125,7 @@ public class AndroidResourcesUtils {
 			if (fieldNode != null
 					&& !fieldNode.getName().equals(resName)
 					&& NameMapper.isValidIdentifier(resName)) {
+				fieldNode.add(AFlag.DONT_RENAME);
 				fieldNode.getFieldInfo().setAlias(resName);
 			}
 		}


### PR DESCRIPTION
Hello, when deobfuscation processes fields, it does not check whether alias is already set in `FieldInfo`. As a result, you can see that the class R fields are renamed twice.
Without deobfuscation (alias set by `AndroidResourcesUtils`):
```
    public static final class array {
        /* renamed from: enum */
        public static final int pref_widget_font_sizes = 2131689474;
        /* renamed from: ll1l */
        public static final int widget_theme_entries = 2131689473;
        /* renamed from: null */
        public static final int pref_widget_font_families = 2131689475;
    }
```
With deobfuscation (alias set by `AndroidResourcesUtils` and then replaced by `Deobfuscator`):
```
    public static final class array {
        /* renamed from: enum */
        public static final int f2654enum = 2131689474;
        /* renamed from: ll1l */
        public static final int widget_theme_entries = 2131689473;
        /* renamed from: null */
        public static final int f2655null = 2131689475;
    }
```