### PR TITLE
test: use @NYI instead of commented TODO

### DIFF
--- a/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
+++ b/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
@@ -14,6 +14,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.jar.JarOutputStream;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jadx.NotYetImplementedExtension;
 import jadx.api.JadxArgs;
 import jadx.api.JadxDecompiler;
 import jadx.api.JadxInternalAccess;

--- a/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
+++ b/jadx-core/src/test/java/jadx/tests/api/IntegrationTest.java
@@ -14,9 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.jar.JarOutputStream;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import jadx.NotYetImplementedExtension;
 import jadx.api.JadxArgs;
 import jadx.api.JadxDecompiler;
 import jadx.api.JadxInternalAccess;

--- a/jadx-core/src/test/java/jadx/tests/api/utils/TestUtils.java
+++ b/jadx-core/src/test/java/jadx/tests/api/utils/TestUtils.java
@@ -1,7 +1,11 @@
 package jadx.tests.api.utils;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import jadx.NotYetImplementedExtension;
 import jadx.core.codegen.CodeWriter;
 
+@ExtendWith(NotYetImplementedExtension.class)
 public class TestUtils {
 
 	public static String indent(int indent) {

--- a/jadx-core/src/test/java/jadx/tests/integration/TestStaticFieldsInit.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/TestStaticFieldsInit.java
@@ -34,7 +34,6 @@ public class TestStaticFieldsInit extends IntegrationTest {
 		String code = cls.getCode().toString();
 
 		assertThat(code, not(containsString("public static final String s2 = null;")));
-		// TODO:
-		// assertThat(code, containsString("public static final String s3 = null;"));
+		assertThat(code, containsString("public static final String s3 = null;"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestFieldIncrement2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestFieldIncrement2.java
@@ -1,12 +1,13 @@
 package jadx.tests.integration.arith;
 
-import org.junit.jupiter.api.Test;
-
-import jadx.core.dex.nodes.ClassNode;
-import jadx.tests.api.IntegrationTest;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.NotYetImplemented;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.IntegrationTest;
 
 public class TestFieldIncrement2 extends IntegrationTest {
 
@@ -33,7 +34,14 @@ public class TestFieldIncrement2 extends IntegrationTest {
 
 		assertThat(code, containsString("this.a.f += n;"));
 		assertThat(code, containsString("a.f *= n;"));
-		// TODO
-		// assertThat(code, containsString("this.a.f *= n;"));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("this.a.f *= n;"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/arrays/TestArrayFill2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arrays/TestArrayFill2.java
@@ -1,12 +1,13 @@
 package jadx.tests.integration.arrays;
 
-import org.junit.jupiter.api.Test;
-
-import jadx.core.dex.nodes.ClassNode;
-import jadx.tests.api.IntegrationTest;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.NotYetImplemented;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.IntegrationTest;
 
 public class TestArrayFill2 extends IntegrationTest {
 
@@ -15,11 +16,6 @@ public class TestArrayFill2 extends IntegrationTest {
 		public int[] test(int a) {
 			return new int[]{1, a + 1, 2};
 		}
-
-		// TODO
-//		public int[] test2(int a) {
-//			return new int[]{1, a++, a * 2};
-//		}
 	}
 
 	@Test
@@ -28,8 +24,22 @@ public class TestArrayFill2 extends IntegrationTest {
 		String code = cls.getCode().toString();
 
 		assertThat(code, containsString("return new int[]{1, a + 1, 2};"));
-
-		// TODO
-		// assertThat(code, containsString("return new int[]{1, a++, a * 2};"));
 	}
+
+	public static class TestCls2 {
+
+		public int[] test2(int a) {
+			return new int[]{1, a++, a * 2};
+		}
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls2.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("return new int[]{1, a++, a * 2};"));
+	}
+
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions3.java
@@ -65,7 +65,6 @@ public class TestConditions3 extends IntegrationTest {
 		assertThat(code, containsString("return null;"));
 		assertThat(code, not(containsString("else")));
 
-		// TODO: fix constant inline
-//		assertThat(code, not(containsString("AnonymousClass_1")));
+		assertThat(code, not(containsString("AnonymousClass_1")));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestNestedIf2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestNestedIf2.java
@@ -52,6 +52,5 @@ public class TestNestedIf2 extends IntegrationTest {
 		assertThat(code, containsOne("if (executedCount != repeatCount && isRun(delta, object)) {"));
 		assertThat(code, containsOne("if (finished) {"));
 		assertThat(code, not(containsString("else")));
-
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestTernary2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestTernary2.java
@@ -1,12 +1,15 @@
 package jadx.tests.integration.conditions;
 
-import org.junit.jupiter.api.Test;
-
-import jadx.core.dex.nodes.ClassNode;
-import jadx.tests.api.IntegrationTest;
-
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.NotYetImplemented;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.IntegrationTest;
 
 public class TestTernary2 extends IntegrationTest {
 
@@ -28,7 +31,14 @@ public class TestTernary2 extends IntegrationTest {
 
 		assertEquals(1, count(code, "assertTrue"));
 		assertEquals(1, count(code, "f(1, 0)"));
-		// TODO:
-//		assertThat(code, containsString("assertTrue(f(1, 0) == 0);"));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("assertTrue(f(1, 0) == 0);"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/debuginfo/TestReturnSourceLine.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/debuginfo/TestReturnSourceLine.java
@@ -1,17 +1,18 @@
 package jadx.tests.integration.debuginfo;
 
+import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.codegen.CodeWriter;
 import jadx.core.dex.attributes.nodes.LineAttrNode;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.core.dex.nodes.MethodNode;
 import jadx.tests.api.IntegrationTest;
-
-import static jadx.tests.api.utils.JadxMatchers.containsOne;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestReturnSourceLine extends IntegrationTest {
 
@@ -59,10 +60,18 @@ public class TestReturnSourceLine extends IntegrationTest {
 
 		MethodNode test2 = cls.searchMethodByName("test2(I)I");
 		checkLine(lines, codeWriter, test2, 3, "return v - 1;");
+	}
 
-//		TODO:
-//		MethodNode test3 = cls.searchMethodByName("test3(I)I");
-//		checkLine(lines, codeWriter, test3, 3, "return v;");
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		CodeWriter codeWriter = cls.getCode();
+		String code = codeWriter.toString();
+		String[] lines = code.split(CodeWriter.NL);
+
+		MethodNode test3 = cls.searchMethodByName("test3(I)I");
+		checkLine(lines, codeWriter, test3, 3, "return v;");
 	}
 
 	private static void checkLine(String[] lines, CodeWriter cw, LineAttrNode node, int offset, String str) {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass5.java
@@ -79,7 +79,6 @@ public class TestAnonymousClass5 extends IntegrationTest {
 		assertThat(code, containsOne("map.get(name);"));
 		assertThat(code, not(containsString("access$008")));
 
-		// TODO
-//		assertThat(code, not(containsString("synthetic")));
+		assertThat(code, not(containsString("synthetic")));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestCastInOverloadedInvoke.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestCastInOverloadedInvoke.java
@@ -1,21 +1,18 @@
 package jadx.tests.integration.invoke;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import jadx.NotYetImplemented;
-import jadx.NotYetImplementedExtension;
-import jadx.core.dex.nodes.ClassNode;
-import jadx.tests.api.IntegrationTest;
-
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@ExtendWith(NotYetImplementedExtension.class)
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.NotYetImplemented;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.IntegrationTest;
+
 public class TestCastInOverloadedInvoke extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection3.java
@@ -1,7 +1,10 @@
 package jadx.tests.integration.loops;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import jadx.NotYetImplemented;
+import jadx.NotYetImplementedExtension;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
@@ -37,7 +40,14 @@ public class TestLoopDetection3 extends IntegrationTest {
 		String code = cls.getCode().toString();
 
 		assertThat(code, containsString("while"));
-		// TODO
-		// assertThat(code, containsString("while (--pos >= 0) {"));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("while (--pos >= 0) {"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestSynchronizedInEndlessLoop.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestSynchronizedInEndlessLoop.java
@@ -1,17 +1,14 @@
 package jadx.tests.integration.loops;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
-import jadx.NotYetImplemented;
-import jadx.NotYetImplementedExtension;
-import jadx.core.dex.nodes.ClassNode;
-import jadx.tests.api.IntegrationTest;
-
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-@ExtendWith(NotYetImplementedExtension.class)
+import org.junit.jupiter.api.Test;
+
+import jadx.NotYetImplemented;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.IntegrationTest;
+
 public class TestSynchronizedInEndlessLoop extends IntegrationTest {
 
 	public static class TestCls {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13a.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13a.java
@@ -1,5 +1,10 @@
 package jadx.tests.integration.others;
 
+import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.lang.reflect.Field;
 import java.util.HashMap;
 
@@ -7,9 +12,6 @@ import org.junit.jupiter.api.Test;
 
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
-
-import static jadx.tests.api.utils.JadxMatchers.containsOne;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestIssue13a extends IntegrationTest {
 
@@ -97,6 +99,6 @@ public class TestIssue13a extends IntegrationTest {
 		}
 
 		// TODO: add additional checks
-//		assertThat(code, not(containsString("Throwable")));
+		assertThat(code, not(containsString("Throwable")));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized2.java
@@ -2,10 +2,12 @@ package jadx.tests.integration.synchronize;
 
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestSynchronized2 extends IntegrationTest {
@@ -23,8 +25,15 @@ public class TestSynchronized2 extends IntegrationTest {
 
 		assertThat(code, containsString("private static synchronized boolean test(Object obj) {"));
 		assertThat(code, containsString("obj.toString() != null;"));
-		// TODO
-//		assertThat(code, containsString("return obj.toString() != null;"));
-//		assertThat(code, not(containsString("synchronized (")));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("return obj.toString() != null;"));
+		assertThat(code, not(containsString("synchronized (")));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestFinally2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestFinally2.java
@@ -6,10 +6,12 @@ import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestFinally2 extends IntegrationTest {
@@ -57,7 +59,14 @@ public class TestFinally2 extends IntegrationTest {
 		String code = cls.getCode().toString();
 
 		assertThat(code, containsOne("decode(inputStream);"));
-		// TODO
-		// assertThat(code, not(containsOne("result =")));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, not(containsOne("result =")));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch5.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
@@ -48,9 +49,17 @@ public class TestTryCatch5 extends IntegrationTest {
 		String code = cls.getCode().toString();
 
 		assertThat(code, containsString("try {"));
-		// TODO:
-//		assertThat(code, containsString("output = new FileOutputStream(file);"));
-//		assertThat(code, containsString("} catch (IOException e) {"));
 		assertThat(code, containsString("file.delete();"));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		disableCompilation();
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("output = new FileOutputStream(file);"));
+		assertThat(code, containsString("} catch (IOException e) {"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally2.java
@@ -1,17 +1,19 @@
 package jadx.tests.integration.trycatch;
 
+import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static jadx.tests.api.utils.JadxMatchers.countString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.clsp.NClass;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
-
-import static jadx.tests.api.utils.JadxMatchers.containsOne;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestTryCatchFinally2 extends IntegrationTest {
 
@@ -52,9 +54,16 @@ public class TestTryCatchFinally2 extends IntegrationTest {
 
 		assertThat(code, containsOne("for (NClass parent : parents) {"));
 
-		// TODO
-//		assertThat(code, countString(2, "for (NClass cls : classes) {"));
 		assertThat(code, containsOne("for (NClass cls : this.classes) {"));
 		assertThat(code, containsOne("for (NClass cls2 : this.classes) {"));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, countString(2, "for (NClass cls : classes) {"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally5.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
@@ -65,7 +66,14 @@ public class TestTryCatchFinally5 extends IntegrationTest {
 		String code = cls.getCode().toString();
 
 		assertThat(code, containsOne("} finally {"));
-		// TODO: remove duplicates on multiple paths
-//		assertThat(code, containsOne("d.close();"));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("d.close();"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TryAfterDeclaration.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TryAfterDeclaration.java
@@ -8,14 +8,11 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import jadx.NotYetImplemented;
-import jadx.NotYetImplementedExtension;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
-@ExtendWith(NotYetImplementedExtension.class)
 public class TryAfterDeclaration extends IntegrationTest {
 
 	/**

--- a/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver3.java
@@ -2,6 +2,7 @@ package jadx.tests.integration.types;
 
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
@@ -26,8 +27,16 @@ public class TestTypeResolver3 extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
 
-		// TODO inline into return
 		assertThat(code, containsOne("s1.length() == s2.length() ? 0 : s1.length() < s2.length() ? -1 : 1;"));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test3() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("return s1.length() == s2.length() ? 0 : s1.length() < s2.length() ? -1 : 1;"));
 	}
 
 	@Test


### PR DESCRIPTION
This change does two things:

1. Replaces commented `TODO` to a `@NotYetImplemented` tests
2. Add the `@ExtendWith(NotYetImplementedExtension.class)` to TestUtils, so we we don't need to add it to every sub-class.