### PR TITLE
fix(gui): exclusion disablement should be exact package match

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
@@ -99,7 +99,8 @@ public class JadxWrapper {
 
 	public List<String> getExcludedPackages() {
 		String excludedPackages = settings.getExcludedPackages().trim();
-		return Arrays.asList(excludedPackages.split("[ ]+"));
+		return Arrays.asList(excludedPackages.split("[ ]+"))
+				.stream().filter(s -> !s.isEmpty()).collect(Collectors.toList());
 	}
 
 	public void addExcludedPackage(String packageToExclude) {

--- a/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
@@ -88,7 +88,8 @@ public class JadxWrapper {
 
 		return classList.stream().filter(cls -> {
 			for (String exclude : excludedPackages) {
-				if (cls.getFullName().startsWith(exclude)) {
+				if (cls.getFullName().equals(exclude)
+						|| cls.getFullName().startsWith(exclude + '.')) {
 					return false;
 				}
 			}
@@ -102,7 +103,8 @@ public class JadxWrapper {
 	}
 
 	public void addExcludedPackage(String packageToExclude) {
-		settings.setExcludedPackages(settings.getExcludedPackages() + ' ' + packageToExclude);
+		String newExclusion = settings.getExcludedPackages() + ' ' + packageToExclude;
+		settings.setExcludedPackages(newExclusion.trim());
 		settings.sync();
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
@@ -99,8 +99,10 @@ public class JadxWrapper {
 
 	public List<String> getExcludedPackages() {
 		String excludedPackages = settings.getExcludedPackages().trim();
-		return Arrays.asList(excludedPackages.split("[ ]+"))
-				.stream().filter(s -> !s.isEmpty()).collect(Collectors.toList());
+		if (excludedPackages.isEmpty()) {
+			return Collections.emptyList();
+		}
+		return Arrays.asList(excludedPackages.split("[ ]+"));
 	}
 
 	public void addExcludedPackage(String packageToExclude) {

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JPackage.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JPackage.java
@@ -46,7 +46,8 @@ public class JPackage extends JNode implements Comparable<JPackage> {
 	private void setEnabled(JadxWrapper wrapper) {
 		List<String> excludedPackages = wrapper.getExcludedPackages();
 		this.enabled = excludedPackages.isEmpty()
-				|| excludedPackages.stream().filter(p -> !p.isEmpty()).noneMatch(p -> name.startsWith(p));
+				|| excludedPackages.stream().filter(p -> !p.isEmpty())
+					.noneMatch(p -> name.equals(p) || name.startsWith(p + '.'));
 	}
 
 	public final void update() {


### PR DESCRIPTION
1. In a previous commit, `JadxWrapper.getExcludedPackages()` would return a list of empty string"" when we have no exclusion, which causes `getIncludedClasses()` to always return empty list. This PR fixes it.

2. Currently, if we exclude `android`, then both `android` and `androidx` packages are disabled, which shouldn't be the case.

   The implementation checks if they both are exact match, or the full package name starts by the "exclusion" + '.'