### PR TITLE
fix(gui): detect if a window is opened inside a visible screen

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -1,6 +1,9 @@
 package jadx.gui.settings;
 
-import java.awt.*;
+import java.awt.Font;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Window;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -142,12 +145,23 @@ public class JadxSettings extends JadxCLIArgs {
 
 	public boolean loadWindowPos(Window window) {
 		WindowLocation pos = windowPos.get(window.getClass().getSimpleName());
-		if (pos == null) {
+		if (pos == null || !isContainedInAnyScreen(pos)) {
 			return false;
 		}
+
 		window.setLocation(pos.getX(), pos.getY());
 		window.setSize(pos.getWidth(), pos.getHeight());
 		return true;
+	}
+
+	private static boolean isContainedInAnyScreen(WindowLocation pos) {
+		for (GraphicsDevice gd : GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
+			if (gd.getDefaultConfiguration().getBounds().contains(
+					pos.getX(), pos.getY(), pos.getWidth(), pos.getHeight())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public boolean isShowHeapUsageBar() {


### PR DESCRIPTION
This change accepts the stored windows positions only if they are completely inside one of the visible screens, otherwise show it by the default location in the default screen.

The reason of this, if a user changes from two screens to one screen, then he won't be able to see the windows at all.

Ideally, we should check if a part of the window is inside the screen, or if the window is split between two screens, but I don't think this is necessary at this time.