### PR TITLE
chore: use Path instead of File

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
@@ -1,6 +1,7 @@
 package jadx.core.deobf;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,7 +63,12 @@ public class Deobfuscator {
 	private int fldIndex = 0;
 	private int mthIndex = 0;
 
+	@Deprecated
 	public Deobfuscator(JadxArgs args, @NotNull List<DexNode> dexNodes, File deobfMapFile) {
+		this(args, dexNodes, deobfMapFile.toPath());
+	}
+
+	public Deobfuscator(JadxArgs args, @NotNull List<DexNode> dexNodes, Path deobfMapFile) {
 		this.args = args;
 		this.dexNodes = dexNodes;
 

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/RenameVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/RenameVisitor.java
@@ -1,11 +1,9 @@
 package jadx.core.dex.visitors;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.apache.commons.io.FilenameUtils;
 
 import jadx.api.JadxArgs;
 import jadx.core.Consts;
@@ -33,13 +31,14 @@ public class RenameVisitor extends AbstractVisitor {
 			return;
 		}
 		InputFile firstInputFile = dexNodes.get(0).getDexFile().getInputFile();
-		String firstInputFileName = firstInputFile.getFile().getAbsolutePath();
-		String inputPath = FilenameUtils.getFullPathNoEndSeparator(firstInputFileName);
-		String inputName = FilenameUtils.getBaseName(firstInputFileName);
+		Path inputFilePath = firstInputFile.getFile().toPath();
 
-		File deobfMapFile = new File(inputPath, inputName + ".jobf");
+		String inputName = inputFilePath.getFileName().toString();
+		inputName = inputName.substring(0, inputName.lastIndexOf('.'));
+
+		Path deobfMapPath = inputFilePath.getParent().resolve(inputName + ".jobf");
 		JadxArgs args = root.getArgs();
-		deobfuscator = new Deobfuscator(args, dexNodes, deobfMapFile);
+		deobfuscator = new Deobfuscator(args, dexNodes, deobfMapPath);
 		boolean deobfuscationOn = args.isDeobfuscationOn();
 		if (deobfuscationOn) {
 			deobfuscator.execute();


### PR DESCRIPTION
Java NIO Path is the new way to handle files.

This is a first step to move forward, more steps could be to change InputFile to have internal Path, but I am not sure about backward compatibility constraints for the API.

BTW, would it be helpful if Java 11 is used?