### PR TITLE
fix: better String constructor from byte and char arrays (#530)

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/info/MethodInfo.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/MethodInfo.java
@@ -33,6 +33,21 @@ public final class MethodInfo {
 		shortId = makeSignature(true);
 	}
 
+	private MethodInfo(ClassInfo declClass, String name, List<ArgType> args, ArgType retType) {
+		this.name = name;
+		alias = name;
+		aliasFromPreset = false;
+		this.declClass = declClass;
+
+		this.args = args;
+		this.retType = retType;
+		shortId = makeSignature(true);
+	}
+
+	public static MethodInfo externalMth(ClassInfo declClass, String name, List<ArgType> args, ArgType retType) {
+		return new MethodInfo(declClass, name, args, retType);
+	}
+
 	public static MethodInfo fromDex(DexNode dex, int mthIndex) {
 		MethodInfo mth = dex.root().getInfoStorage().getMethod(dex, mthIndex);
 		if (mth != null) {

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/InvokeNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/InvokeNode.java
@@ -36,7 +36,7 @@ public class InvokeNode extends InsnNode implements CallMthInterface {
 		}
 	}
 
-	private InvokeNode(MethodInfo mth, InvokeType invokeType, int argsCount) {
+	public InvokeNode(MethodInfo mth, InvokeType invokeType, int argsCount) {
 		super(InsnType.INVOKE, argsCount);
 		this.mth = mth;
 		this.type = invokeType;

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
@@ -110,7 +110,8 @@ public class SimplifyVisitor extends AbstractVisitor {
 	}
 
 	private static void simplfyConstructor(RootNode root, ConstructorInsn insn) {
-		if (insn.getCallMth().getDeclClass().getType().equals(ArgType.STRING)) {
+		if (insn.getArgsCount() != 0
+				&& insn.getCallMth().getDeclClass().getType().equals(ArgType.STRING)) {
 			InsnArg arg = insn.getArg(0);
 			InsnNode node = arg.isInsnWrap()
 					? ((InsnWrapArg) arg).getWrapInsn()

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestStringConstructor.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestStringConstructor.java
@@ -1,0 +1,63 @@
+package jadx.tests.integration.others;
+
+import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.IntegrationTest;
+
+public class TestStringConstructor extends IntegrationTest {
+
+	public static class TestCls {
+		public String tag = new String(new byte[] {'a', 'b', 'c'});
+	}
+
+	@Test
+	public void test() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("abc"));
+	}
+
+	public static class TestCls2 {
+		public String tag = new String(new byte[] {'a', 'b', 'c'}, StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls2.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("new String(\"abc\".getBytes(), StandardCharsets.UTF_8)"));
+	}
+
+	public static class TestCls3 {
+		public String tag = new String(new byte[] {1, 2, 3, 'a', 'b', 'c'});
+	}
+
+	@Test
+	public void test3() {
+		ClassNode cls = getClassNode(TestCls3.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("\\u0001\\u0002\\u0003"));
+	}
+
+	public static class TestCls4 {
+		public String tag = new String(new byte[] {0, 1, 2, 'a', 'b', 'c'});
+	}
+
+	@Test
+	public void test4() {
+		ClassNode cls = getClassNode(TestCls4.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("\\u0000\\u0001\\u0002abc"));
+	}
+
+}

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestStringConstructor.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestStringConstructor.java
@@ -45,11 +45,11 @@ public class TestStringConstructor extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls3.class);
 		String code = cls.getCode().toString();
 
-		assertThat(code, containsOne("\\u0001\\u0002\\u0003"));
+		assertThat(code, containsOne("\\u0001\\u0002\\u0003abc"));
 	}
 
 	public static class TestCls4 {
-		public String tag = new String(new byte[] {0, 1, 2, 'a', 'b', 'c'});
+		public String tag = new String(new char[] {1, 2, 3, 'a', 'b', 'c'});
 	}
 
 	@Test
@@ -57,7 +57,18 @@ public class TestStringConstructor extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls4.class);
 		String code = cls.getCode().toString();
 
-		assertThat(code, containsOne("\\u0000\\u0001\\u0002abc"));
+		assertThat(code, containsOne("\\u0001\\u0002\\u0003abc"));
 	}
 
+	public static class TestCls5 {
+		public String tag = new String(new char[] {1, 2, 3, 'a', 'b'});
+	}
+
+	@Test
+	public void test5() {
+		ClassNode cls = getClassNode(TestCls5.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("{1, 2, 3, 'a', 'b'}"));
+	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestStringConstructor.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestStringConstructor.java
@@ -71,4 +71,16 @@ public class TestStringConstructor extends IntegrationTest {
 
 		assertThat(code, containsOne("{1, 2, 3, 'a', 'b'}"));
 	}
+
+	public static class TestClsNegative {
+		public String tag = new String();
+	}
+
+	@Test
+	public void testNegative() {
+		ClassNode cls = getClassNode(TestClsNegative.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("tag = new String();"));
+	}
 }


### PR DESCRIPTION
Fixes #530

`test4()` fails, because I don't know how to get the actual value of the array.

In other words: the code generated is:

```
    public static class TestCls4 {
        public String tag = new String(new byte[] {0, 1, 2, 'a', 'b', 'c'});
    }

    public TestStringConstructor$TestCls4() {
        byte[] bArr = new byte[6];
        bArr[1] = (byte) 1;
        bArr[2] = (byte) 2;
        bArr[3] = (byte) 97;
        bArr[4] = (byte) 98;
        bArr[5] = (byte) 99;
        this.tag = new String(bArr);
    }
```

And in `SimplifyVisitor`, I don't know how to the the actual values of `bArr`, not its definition.