### PR TITLE
chore: don't create unneeded StringBuilder

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/StringUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/StringUtils.java
@@ -16,11 +16,13 @@ public class StringUtils {
 			return "\"\"";
 		}
 		StringBuilder res = new StringBuilder();
+		res.append('"');
 		for (int i = 0; i < len; i++) {
 			int c = str.charAt(i) & 0xFFFF;
 			processChar(c, res);
 		}
-		return '"' + res.toString() + '"';
+		res.append('"');
+		return res.toString();
 	}
 
 	public String unescapeChar(char ch) {
@@ -28,8 +30,10 @@ public class StringUtils {
 			return "'\\\''";
 		}
 		StringBuilder res = new StringBuilder();
+		res.append('\'');
 		processChar(ch, res);
-		return '\'' + res.toString() + '\'';
+		res.append('\'');
+		return res.toString();
 	}
 
 	private void processChar(int c, StringBuilder res) {


### PR DESCRIPTION
The reason is, if `.toString()` is called with string concatenation, then a `StringBuilder` is used. In the changed code, we already have a `StringBuilder`.

To verify this: the java bytecode of:

```
	public String test() {
		StringBuilder b = new StringBuilder();
		return '"' + b.toString() + '"';
	}
```

is:

```
  public java.lang.String test();
    Code:
       0: new           #2                  // class java/lang/StringBuilder
       3: dup
       4: invokespecial #3                  // Method java/lang/StringBuilder."<init>":()V
       7: astore_1
       8: new           #2                  // class java/lang/StringBuilder
      11: dup
      12: invokespecial #3                  // Method java/lang/StringBuilder."<init>":()V
      15: bipush        34
      17: invokevirtual #4                  // Method java/lang/StringBuilder.append:(C)Ljava/lang/StringBuilder;
      20: aload_1
      21: invokevirtual #5                  // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
      24: invokevirtual #6                  // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
      27: bipush        34
      29: invokevirtual #4                  // Method java/lang/StringBuilder.append:(C)Ljava/lang/StringBuilder;
      32: invokevirtual #5                  // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
      35: areturn
```