### PR TITLE
chore: use functional interface instead of ISettingsUpdater

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/ISettingsUpdater.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/ISettingsUpdater.java
@@ -1,5 +1,0 @@
-package jadx.gui.settings;
-
-public interface ISettingsUpdater {
-	void update(JadxSettings settings);
-}

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.jetbrains.annotations.Nullable;
@@ -67,9 +68,9 @@ public class JadxSettings extends JadxCLIArgs {
 		JadxSettingsAdapter.store(this);
 	}
 
-	public void partialSync(ISettingsUpdater updater) {
+	private void partialSync(Consumer<JadxSettings> updater) {
 		JadxSettings settings = JadxSettingsAdapter.load();
-		updater.update(settings);
+		updater.accept(settings);
 		JadxSettingsAdapter.store(settings);
 	}
 


### PR DESCRIPTION
And make `JadxSettings.partialSync` private, as I guess it is meant to be internally used.