### PR TITLE
chore: fix "unused" warnings

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocksmaker/BlockFinish.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocksmaker/BlockFinish.java
@@ -3,9 +3,6 @@ package jadx.core.dex.visitors.blocksmaker;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jadx.core.dex.attributes.AType;
 import jadx.core.dex.nodes.BlockNode;
 import jadx.core.dex.nodes.MethodNode;
@@ -15,8 +12,6 @@ import jadx.core.dex.visitors.AbstractVisitor;
 import jadx.core.utils.BlockUtils;
 
 public class BlockFinish extends AbstractVisitor {
-
-	private static final Logger LOG = LoggerFactory.getLogger(BlockFinish.class);
 
 	@Override
 	public void visit(MethodNode mth) {
@@ -33,7 +28,7 @@ public class BlockFinish extends AbstractVisitor {
 	}
 
 	/**
-	 * For evey exception handler must be only one splitter block,
+	 * For every exception handler must be only one splitter block,
 	 * select correct one and remove others if necessary.
 	 */
 	private static void fixSplitterBlock(MethodNode mth, BlockNode block) {

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/debuginfo/DebugInfoParser.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/debuginfo/DebugInfoParser.java
@@ -4,9 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.android.dex.Dex.Section;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jadx.core.dex.attributes.nodes.SourceFileAttr;
 import jadx.core.dex.instructions.args.RegisterArg;
 import jadx.core.dex.nodes.DexNode;
@@ -15,7 +12,6 @@ import jadx.core.dex.nodes.MethodNode;
 import jadx.core.utils.exceptions.DecodeException;
 
 public class DebugInfoParser {
-	private static final Logger LOG = LoggerFactory.getLogger(DebugInfoParser.class);
 	private static final int DBG_END_SEQUENCE = 0x00;
 	private static final int DBG_ADVANCE_PC = 0x01;
 	private static final int DBG_ADVANCE_LINE = 0x02;

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -31,6 +31,7 @@ import jadx.core.xmlgen.entry.ValuesParser;
 	Check Element chunk size
 */
 
+@SuppressWarnings("unused")
 public class BinaryXMLParser extends CommonBinaryParser {
 
 	private static final Logger LOG = LoggerFactory.getLogger(BinaryXMLParser.class);

--- a/jadx-core/src/main/java/jadx/core/xmlgen/CommonBinaryParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/CommonBinaryParser.java
@@ -11,6 +11,7 @@ public class CommonBinaryParser extends ParserConstants {
 		return parseStringPoolNoType();
 	}
 
+	@SuppressWarnings("unused")
 	protected String[] parseStringPoolNoType() throws IOException {
 		long start = is.getPos() - 2;
 		is.checkInt16(0x001c, "String pool header size not 0x001c");

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
@@ -164,6 +164,7 @@ public class ResTableParser extends CommonBinaryParser {
 		return pkg;
 	}
 
+	@SuppressWarnings("unused")
 	private void parseTypeSpecChunk() throws IOException {
 		is.checkInt16(0x0010, "Unexpected type spec header size");
 		/*int size = */

--- a/jadx-core/src/test/java/jadx/tests/integration/TestWrongCode.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/TestWrongCode.java
@@ -14,12 +14,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestWrongCode extends IntegrationTest {
 
 	public static class TestCls {
-		private int test() {
+		@SuppressWarnings("null")
+		public int test() {
 			int[] a = null;
 			return a.length;
 		}
 
-		private int test2(int a) {
+		public int test2(int a) {
 			if (a == 0) {
 			}
 			return a;

--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith3.java
@@ -13,9 +13,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestArith3 extends IntegrationTest {
 
 	public static class TestCls {
-		private int vp;
+		public int vp;
 
-		private void test(byte[] buffer) {
+		public void test(byte[] buffer) {
 			int n = ((buffer[3] & 255) + 4) + ((buffer[2] & 15) << 8);
 			while (n + 4 < buffer.length) {
 				int c = buffer[n] & 255;

--- a/jadx-core/src/test/java/jadx/tests/integration/debuginfo/TestLineNumbers2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/debuginfo/TestLineNumbers2.java
@@ -37,7 +37,6 @@ public class TestLineNumbers2 extends IntegrationTest {
 	public void test() {
 		ClassNode cls = getClassNode(TestCls.class);
 		CodeWriter codeWriter = cls.getCode();
-		String code = codeWriter.toString();
 
 		Map<Integer, Integer> lineMapping = codeWriter.getLineMapping();
 		assertEquals("{8=18, 11=22, 12=23, 13=24, 14=28, 16=25, 17=26, 18=28, 21=31, 22=32}",

--- a/jadx-core/src/test/java/jadx/tests/integration/generics/TestGenerics2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/generics/TestGenerics2.java
@@ -16,8 +16,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestGenerics2 extends IntegrationTest {
 
 	public static class TestCls {
-		private static class ItemReference<V> extends WeakReference<V> {
-			private Object id;
+		public static class ItemReference<V> extends WeakReference<V> {
+			public Object id;
 
 			public ItemReference(V item, Object objId, ReferenceQueue<? super V> queue) {
 				super(item, queue);

--- a/jadx-core/src/test/java/jadx/tests/integration/inline/TestIssue86.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inline/TestIssue86.java
@@ -24,7 +24,7 @@ public class TestIssue86 extends IntegrationTest {
 		private static final String WEATHER_TAG = "weather-tag";
 		private static final String DESC_TAG = "desc-tag";
 
-		private List<Day> test(String response) {
+		public List<Day> test(String response) {
 			List<Day> reportList = new ArrayList<>();
 			try {
 				System.out.println(response);

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass12.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass12.java
@@ -16,8 +16,8 @@ public class TestAnonymousClass12 extends IntegrationTest {
 			public abstract void doSomething();
 		}
 
-		private BasicAbstract outer;
-		private BasicAbstract inner;
+		public BasicAbstract outer;
+		public BasicAbstract inner;
 
 		public void test() {
 			outer = new BasicAbstract() {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass2.java
@@ -13,7 +13,7 @@ public class TestAnonymousClass2 extends IntegrationTest {
 
 	public static class TestCls {
 		public static class Inner {
-			private int f;
+			public int f;
 
 			public Runnable test() {
 				return new Runnable() {
@@ -27,6 +27,7 @@ public class TestAnonymousClass2 extends IntegrationTest {
 			public Runnable test2() {
 				return new Runnable() {
 					@Override
+					@SuppressWarnings("unused")
 					public void run() {
 						Object obj = Inner.this;
 					}

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass3.java
@@ -13,7 +13,7 @@ public class TestAnonymousClass3 extends IntegrationTest {
 	public static class TestCls {
 		public static class Inner {
 			private int f;
-			private double d;
+			public double d;
 
 			public void test() {
 				new Thread() {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass4.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestAnonymousClass4 extends IntegrationTest {
 
 	public static class TestCls {
+		@SuppressWarnings("unused")
 		public static class Inner {
 			private int f;
 			private double d;

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestInnerClass4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestInnerClass4.java
@@ -19,7 +19,7 @@ public class TestInnerClass4 extends IntegrationTest {
 			}
 		}
 
-		private String test() {
+		public String test() {
 			return new C().c;
 		}
 	}

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestOuterConstructorCall.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestOuterConstructorCall.java
@@ -17,6 +17,7 @@ public class TestOuterConstructorCall extends IntegrationTest {
 		}
 
 		private class Inner {
+			@SuppressWarnings("unused")
 			private TestCls test() {
 				return new TestCls(this);
 			}

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvoke1.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvoke1.java
@@ -16,7 +16,7 @@ public class TestInvoke1 extends IntegrationTest {
 
 		private A is;
 
-		private C test(int start) throws IOException {
+		public C test(int start) throws IOException {
 			int id = is.readInt32();
 			String name = is.readString16Fixed(128);
 

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvokeInCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestInvokeInCatch.java
@@ -17,7 +17,7 @@ public class TestInvokeInCatch extends IntegrationTest {
 	public static class TestCls {
 		private static final String TAG = "TAG";
 
-		private void test(int[] a, int b) {
+		public void test(int[] a, int b) {
 			try {
 				exc();
 			} catch (IOException e) {

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestSuperInvokeWithGenerics.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestSuperInvokeWithGenerics.java
@@ -7,7 +7,6 @@ import jadx.tests.api.IntegrationTest;
 
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anyOf;
 
 public class TestSuperInvokeWithGenerics extends IntegrationTest {
 

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach.java
@@ -12,7 +12,7 @@ public class TestArrayForEach extends IntegrationTest {
 
 	public static class TestCls {
 
-		private int test(int[] a) {
+		public int test(int[] a) {
 			int sum = 0;
 			for (int n : a) {
 				sum += n;

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEach2.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.not;
 public class TestArrayForEach2 extends IntegrationTest {
 
 	public static class TestCls {
-		private void test(String str) {
+		public void test(String str) {
 			for (String s : str.split("\n")) {
 				String t = s.trim();
 				if (t.length() > 0) {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
@@ -13,7 +13,7 @@ public class TestArrayForEachNegative extends IntegrationTest {
 
 	public static class TestCls {
 
-		private int test(int[] a, int[] b) {
+		public int test(int[] a, int[] b) {
 			int sum = 0;
 			for (int i = 0; i < a.length; i += 2) {
 				sum += a[i];

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestBreakInLoop.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestBreakInLoop.java
@@ -12,9 +12,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestBreakInLoop extends IntegrationTest {
 
 	public static class TestCls {
-		private int f;
+		public int f;
 
-		private void test(int[] a, int b) {
+		public void test(int[] a, int b) {
 			for (int i = 0; i < a.length; i++) {
 				a[i]++;
 				if (i < b) {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestContinueInLoop.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestContinueInLoop.java
@@ -11,9 +11,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestContinueInLoop extends IntegrationTest {
 
 	public static class TestCls {
-		private int f;
+		public int f;
 
-		private void test(int[] a, int b) {
+		public void test(int[] a, int b) {
 			for (int i = 0; i < a.length; i++) {
 				int v = a[i];
 				if (v < b) {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestIterableForEach extends IntegrationTest {
 
 	public static class TestCls {
-		private String test(Iterable<String> a) {
+		public String test(Iterable<String> a) {
 			StringBuilder sb = new StringBuilder();
 			for (String s : a) {
 				sb.append(s);

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestIterableForEach3.java
@@ -16,7 +16,7 @@ public class TestIterableForEach3 extends IntegrationTest {
 		private Set<T> a;
 		private Set<T> b;
 
-		private void test(T str) {
+		public void test(T str) {
 			Set<T> set = str.length() == 1 ? a : b;
 			for (T s : set) {
 				if (s.length() == str.length()) {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopCondition.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopCondition.java
@@ -16,7 +16,7 @@ public class TestLoopCondition extends IntegrationTest {
 		private void setEnabled(boolean r1z) {
 		}
 
-		private void testIfInLoop() {
+		public void testIfInLoop() {
 			int j = 0;
 			for (int i = 0; i < f.length(); i++) {
 				char ch = f.charAt(i);
@@ -31,7 +31,7 @@ public class TestLoopCondition extends IntegrationTest {
 			setEnabled(false);
 		}
 
-		private void testMoreComplexIfInLoop(java.util.ArrayList<String> list) throws Exception {
+		public void testMoreComplexIfInLoop(java.util.ArrayList<String> list) throws Exception {
 			for (int i = 0; i != 16 && i < 255; i++) {
 				list.set(i, "ABC");
 				if (i == 128) {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopCondition5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopCondition5.java
@@ -13,7 +13,7 @@ import static org.hamcrest.Matchers.anyOf;
 public class TestLoopCondition5 extends SmaliTest {
 
 	public static class TestCls {
-		private static int lastIndexOf(int[] array, int target, int start, int end) {
+		public static int lastIndexOf(int[] array, int target, int start, int end) {
 			for (int i = end - 1; i >= start; i--) {
 				if (array[i] == target) {
 					return i;

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopConditionInvoke.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopConditionInvoke.java
@@ -14,7 +14,7 @@ public class TestLoopConditionInvoke extends IntegrationTest {
 		private static final char STOP_CHAR = 0;
 		private int pos;
 
-		private boolean test(char lastChar) {
+		public boolean test(char lastChar) {
 			int startPos = pos;
 			char ch;
 			while ((ch = next()) != STOP_CHAR) {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection.java
@@ -13,7 +13,7 @@ public class TestLoopDetection extends IntegrationTest {
 
 	public static class TestCls {
 
-		private void test(int[] a, int b) {
+		public void test(int[] a, int b) {
 			int i = 0;
 			while (i < a.length && i < b) {
 				a[i]++;

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection3.java
@@ -13,7 +13,7 @@ public class TestLoopDetection3 extends IntegrationTest {
 
 	public static class TestCls {
 
-		private void test(TestCls parent, int pos) {
+		public void test(TestCls parent, int pos) {
 			Object item;
 			while (--pos >= 0) {
 				item = parent.get(pos);

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestLoopDetection4.java
@@ -16,7 +16,7 @@ public class TestLoopDetection4 extends IntegrationTest {
 		private Iterator<String> iterator;
 		private SomeCls filter;
 
-		private String test() {
+		public String test() {
 			while (iterator.hasNext()) {
 				String next = iterator.next();
 				String filtered = filter.filter(next);

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops.java
@@ -14,7 +14,7 @@ public class TestNestedLoops extends IntegrationTest {
 
 	public static class TestCls {
 
-		private void test(List<String> l1, List<String> l2) {
+		public void test(List<String> l1, List<String> l2) {
 			for (String s1 : l1) {
 				for (String s2 : l2) {
 					if (s1.equals(s2)) {

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestNestedLoops2.java
@@ -14,7 +14,7 @@ public class TestNestedLoops2 extends IntegrationTest {
 
 	public static class TestCls {
 
-		private boolean test(List<String> list) {
+		public boolean test(List<String> list) {
 			int j = 0;
 			for (int i = 0; i < list.size(); i++) {
 				String s = list.get(i);

--- a/jadx-core/src/test/java/jadx/tests/integration/names/TestNameAssign2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/names/TestNameAssign2.java
@@ -21,7 +21,7 @@ public class TestNameAssign2 extends IntegrationTest {
 
 	public static class TestCls {
 
-		private static void test(MethodNode mth, int regNum, LiveVarAnalysis la) {
+		public static void test(MethodNode mth, int regNum, LiveVarAnalysis la) {
 			List<BlockNode> blocks = mth.getBasicBlocks();
 			int blocksCount = blocks.size();
 			BitSet hasPhi = new BitSet(blocksCount);

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestDefConstructorNotRemoved.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestDefConstructorNotRemoved.java
@@ -19,7 +19,7 @@ public class TestDefConstructorNotRemoved extends IntegrationTest {
 		}
 
 		public static class A {
-			private final String s;
+			public final String s;
 
 			public A() {
 				s = "a";

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit.java
@@ -21,11 +21,11 @@ public class TestFieldInit extends IntegrationTest {
 		public class A {
 		}
 
-		private static List<String> s = new ArrayList<>();
+		public static List<String> s = new ArrayList<>();
 
-		private A a = new A();
-		private int i = 1 + Random.class.getSimpleName().length();
-		private int n = 0;
+		public A a = new A();
+		public int i = 1 + Random.class.getSimpleName().length();
+		public int n = 0;
 
 		public TestCls(int z) {
 			this.n = z;

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInit2.java
@@ -17,13 +17,13 @@ public class TestFieldInit2 extends IntegrationTest {
 			void doSomething();
 		}
 
-		private BasicAbstract x = new BasicAbstract() {
+		public BasicAbstract x = new BasicAbstract() {
 			@Override
 			public void doSomething() {
 				y = 1;
 			}
 		};
-		private int y = 0;
+		public int y = 0;
 
 		public TestCls() {
 		}

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInitInTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInitInTryCatch.java
@@ -15,7 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestFieldInitInTryCatch extends IntegrationTest {
 
 	public static class TestCls {
-		private static final URL a;
+		public static final URL a;
 
 		static {
 			try {
@@ -27,7 +27,7 @@ public class TestFieldInitInTryCatch extends IntegrationTest {
 	}
 
 	public static class TestCls2 {
-		private static final URL[] a;
+		public static final URL[] a;
 
 		static {
 			try {
@@ -39,7 +39,7 @@ public class TestFieldInitInTryCatch extends IntegrationTest {
 	}
 
 	public static class TestCls3 {
-		private static final String[] a;
+		public static final String[] a;
 
 		static {
 			try {
@@ -58,7 +58,7 @@ public class TestFieldInitInTryCatch extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
 
-		assertThat(code, containsOne("private static final URL a;"));
+		assertThat(code, containsOne("public static final URL a;"));
 		assertThat(code, containsOne("a = new URL(\"http://www.example.com/\");"));
 		assertThat(code, containsLines(2,
 				"try {",
@@ -82,6 +82,6 @@ public class TestFieldInitInTryCatch extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls3.class);
 		String code = cls.getCode().toString();
 
-		assertThat(code, containsOne("private static final String[] a = new String[]{\"a\"};"));
+		assertThat(code, containsOne("public static final String[] a = new String[]{\"a\"};"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIfInTry.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIfInTry.java
@@ -15,7 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestIfInTry extends IntegrationTest {
 
 	public static class TestCls {
-		private File dir;
+		public File dir;
 
 		public int test() {
 			try {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIfTryInCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIfTryInCatch.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestIfTryInCatch extends IntegrationTest {
 
 	public static class TestCls {
-		private Exception exception;
+		public Exception exception;
 		private java.lang.Object data;
 
 		public java.lang.Object test(final Object obj) {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13b.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestIssue13b.java
@@ -22,9 +22,9 @@ public class TestIssue13b extends IntegrationTest {
 		private static final String PROPERTIES_FILE = "";
 		private static final String TAG = "";
 		private final CountDownLatch mInitializedLatch = new CountDownLatch(1);
-		private int mC2KServerPort = 0;
+		public int mC2KServerPort = 0;
 		private String mSuplServerHost = "";
-		private int mSuplServerPort = 0;
+		public int mSuplServerPort = 0;
 		private String mC2KServerHost = "";
 
 		public TestCls() {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestLoopInTry2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestLoopInTry2.java
@@ -8,7 +8,6 @@ import com.android.dx.io.instructions.ShortArrayCodeInput;
 import org.junit.jupiter.api.Test;
 
 import jadx.core.dex.nodes.ClassNode;
-import jadx.core.dex.nodes.DexNode;
 import jadx.core.dex.nodes.MethodNode;
 import jadx.core.utils.exceptions.DecodeException;
 import jadx.tests.api.IntegrationTest;
@@ -20,8 +19,7 @@ public class TestLoopInTry2 extends IntegrationTest {
 
 	public static class TestCls {
 		private MethodNode method;
-		private DexNode dex;
-		private DecodedInstruction[] insnArr;
+		public DecodedInstruction[] insnArr;
 
 		public void test(Code mthCode) throws DecodeException {
 			short[] encodedInstructions = mthCode.getInstructions();

--- a/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized2.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestSynchronized2 extends IntegrationTest {
 
 	public static class TestCls {
+		@SuppressWarnings("unused")
 		private static synchronized boolean test(Object obj) {
 			return obj.toString() != null;
 		}

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestNestedTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestNestedTryCatch.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestNestedTryCatch extends IntegrationTest {
 
 	public static class TestCls {
-		private void f() {
+		public void f() {
 			try {
 				Thread.sleep(1);
 				try {

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch.java
@@ -12,7 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestTryCatch extends IntegrationTest {
 
 	public static class TestCls {
-		private void f() {
+		public void f() {
 			try {
 				Thread.sleep(50);
 			} catch (InterruptedException e) {

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch2.java
@@ -13,7 +13,7 @@ public class TestTryCatch2 extends IntegrationTest {
 	public static class TestCls {
 		private final static Object obj = new Object();
 
-		private static boolean test() {
+		public static boolean test() {
 			try {
 				synchronized (obj) {
 					obj.wait(5);

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch4.java
@@ -16,7 +16,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestTryCatch4 extends IntegrationTest {
 
 	public static class TestCls {
-		private Object test(Object obj) {
+		@SuppressWarnings({ "resource", "unused" })
+		public Object test(Object obj) {
 			FileOutputStream output = null;
 			try {
 				output = new FileOutputStream(new File("f"));

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch7.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatch7.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestTryCatch7 extends IntegrationTest {
 
 	public static class TestCls {
-		private Exception test() {
+		public Exception test() {
 			Exception e = new Exception();
 			try {
 				Thread.sleep(50);

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally5.java
@@ -15,7 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestTryCatchFinally5 extends IntegrationTest {
 
 	public static class TestCls {
-		private <E> List<E> test(A a, B<E> b) {
+		public <E> List<E> test(A a, B<E> b) {
 			C c = p(a);
 			if (c == null) {
 				return null;

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally8.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchFinally8.java
@@ -16,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestTryCatchFinally8 extends IntegrationTest {
 
 	public static class TestCls {
-		private Object test(Object obj) {
+		public Object test(Object obj) {
 			File file = new File("r");
 			FileOutputStream output = null;
 			try {

--- a/jadx-core/src/test/java/jadx/tests/integration/types/TestGenerics.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/types/TestGenerics.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestGenerics extends IntegrationTest {
 
 	public static class TestCls<T> {
-		private T data;
+		public T data;
 
 		public TestCls<T> data(T t) {
 			this.data = t;

--- a/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeInheritance.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeInheritance.java
@@ -25,7 +25,7 @@ public class TestTypeInheritance extends IntegrationTest {
 			public void b() {}
 		}
 
-		private static void test(boolean z) {
+		public static void test(boolean z) {
 			IBase impl;
 			if (z) {
 				impl = new A();

--- a/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver2.java
@@ -14,7 +14,7 @@ public class TestTypeResolver2 extends IntegrationTest {
 
 	public static class TestCls {
 
-		private static boolean test(Object obj) throws IOException {
+		public static boolean test(Object obj) throws IOException {
 			if (obj != null) {
 				return true;
 			}

--- a/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver6.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver6.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestTypeResolver6 extends IntegrationTest {
 
 	public static class TestCls {
-		private final Object obj;
+		public final Object obj;
 
 		public TestCls(boolean b) {
 			this.obj = b ? this : makeObj();

--- a/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver6a.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/types/TestTypeResolver6a.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestTypeResolver6a extends IntegrationTest {
 
 	public static class TestCls implements Runnable {
-		private final Runnable runnable;
+		public final Runnable runnable;
 
 		public TestCls(boolean b) {
 			this.runnable = b ? this : makeRunnable();

--- a/jadx-core/src/test/java/jadx/tests/integration/usethis/TestDontInlineThis.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/usethis/TestDontInlineThis.java
@@ -15,7 +15,7 @@ public class TestDontInlineThis extends IntegrationTest {
 	public static class TestCls {
 		public int field = new Random().nextInt();
 
-		private TestCls test() {
+		public TestCls test() {
 			TestCls res;
 			if (field == 7) {
 				res = this;

--- a/jadx-core/src/test/java/jadx/tests/integration/usethis/TestInlineThis.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/usethis/TestInlineThis.java
@@ -15,7 +15,7 @@ public class TestInlineThis extends IntegrationTest {
 	public static class TestCls {
 		public int field;
 
-		private void test() {
+		public void test() {
 			TestCls something = this;
 			something.method();
 			something.field = 123;

--- a/jadx-core/src/test/java/jadx/tests/integration/usethis/TestInlineThis2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/usethis/TestInlineThis2.java
@@ -17,7 +17,7 @@ public class TestInlineThis2 extends IntegrationTest {
 	public static class TestCls {
 		public int field;
 
-		private void test() {
+		public void test() {
 			TestCls thisVar = this;
 			if (Objects.isNull(thisVar)) {
 				System.out.println("null");

--- a/jadx-core/src/test/java/jadx/tests/integration/variables/TestVariables4.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/variables/TestVariables4.java
@@ -14,7 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class TestVariables4 extends IntegrationTest {
 
 	public static class TestCls {
-		private static boolean runTest(String clsName) {
+		public static boolean runTest(String clsName) {
 			try {
 				boolean pass = false;
 				String msg = null;

--- a/jadx-samples/src/main/java/jadx/samples/TestGenerics.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestGenerics.java
@@ -13,7 +13,7 @@ public class TestGenerics extends AbstractTest {
 	public Class<?>[] classes;
 
 	public interface MyComparable<T> {
-		public int compareTo(T o);
+		int compareTo(T o);
 	}
 
 	public static class GenericClass implements MyComparable<String> {
@@ -38,9 +38,9 @@ public class TestGenerics extends AbstractTest {
 	public static Box<Integer> integerBox = new Box<>();
 
 	public interface Pair<K, LongGenericType> {
-		public K getKey();
+		K getKey();
 
-		public LongGenericType getValue();
+		LongGenericType getValue();
 	}
 
 	public static class OrderedPair<K, V> implements Pair<K, V> {
@@ -133,7 +133,7 @@ public class TestGenerics extends AbstractTest {
 
 	public class Node<T extends Comparable<T>> {
 		private final T data;
-		private final Node<T> next;
+		public final Node<T> next;
 
 		public Node(T data, Node<T> next) {
 			this.data = data;
@@ -145,8 +145,8 @@ public class TestGenerics extends AbstractTest {
 		}
 	}
 
-	private class TestConstructor implements Enumeration<String> {
-		private final TestGenerics a;
+	public class TestConstructor implements Enumeration<String> {
+		public final TestGenerics a;
 
 		TestConstructor(TestGenerics a) {
 			this.a = a;

--- a/jadx-samples/src/main/java/jadx/samples/TestTypeResolver.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestTypeResolver.java
@@ -2,7 +2,7 @@ package jadx.samples;
 
 public class TestTypeResolver extends AbstractTest {
 
-	private final int f1;
+	public final int f1;
 
 	public TestTypeResolver() {
 		this.f1 = 2;

--- a/jadx-samples/src/main/java/jadx/samples/TestTypeResolver2.java
+++ b/jadx-samples/src/main/java/jadx/samples/TestTypeResolver2.java
@@ -21,11 +21,11 @@ public class TestTypeResolver2 extends AbstractTest {
 		}
 	}
 
-	private static void doPrint(String s1) {
+	public static void doPrint(String s1) {
 		fail();
 	}
 
-	private static void doPrint(Integer s1) {
+	public static void doPrint(Integer s1) {
 		fail();
 	}
 
@@ -43,6 +43,6 @@ public class TestTypeResolver2 extends AbstractTest {
 	}
 
 	public static void main(String[] args) throws Exception {
-		(new TestTypeResolver2()).testRun();
+		new TestTypeResolver2().testRun();
 	}
 }


### PR DESCRIPTION
The only test which was changed to `public` expectations is `TestFieldInitInTryCatch`
