### PR TITLE
test: use NYI instead of comment

### DIFF
--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith.java
@@ -1,7 +1,11 @@
 package jadx.tests.integration.arith;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
@@ -28,10 +32,16 @@ public class TestArith extends IntegrationTest {
 	public void test() {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
+	}
 
-		// TODO: reduce code vars by name
-//		assertThat(code, containsString("a += 2;"));
-//		assertThat(code, containsString("a++;"));
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("a += 2;"));
+		assertThat(code, containsString("a++;"));
 	}
 
 	@Test
@@ -39,9 +49,16 @@ public class TestArith extends IntegrationTest {
 		noDebugInfo();
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
+	}
 
-		// TODO: simplify for variables without debug names
-//		assertThat(code, containsString("i += 2;"));
-//		assertThat(code, containsString("i++;"));
+	@Test
+	@NotYetImplemented
+	public void testNoDebug2() {
+		noDebugInfo();
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("i += 2;"));
+		assertThat(code, containsString("i++;"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestArith2.java
@@ -1,11 +1,14 @@
 package jadx.tests.integration.arith;
 
-import jadx.core.dex.nodes.ClassNode;
-import jadx.tests.api.IntegrationTest;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.NotYetImplemented;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.IntegrationTest;
 
 public class TestArith2 extends IntegrationTest {
 
@@ -20,13 +23,20 @@ public class TestArith2 extends IntegrationTest {
 		}
 	}
 
-	//	@Test
+	@Test
 	public void test() {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
 
 		assertThat(code, containsString("return (a + 2) * 3;"));
 		assertThat(code, not(containsString("a + 2 * 3")));
+	}
+
+	@Test
+	@NotYetImplemented
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
 
 		assertThat(code, containsString("return a + b + c;"));
 		assertThat(code, not(containsString("return (a + b) + c;")));

--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestFieldIncrement3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestFieldIncrement3.java
@@ -19,25 +19,25 @@ public class TestFieldIncrement3 extends IntegrationTest {
 		static Vector2 directVect = new Vector2();
 		static Vector2 newPos = new Vector2();
 
-		private static void test() {
+		public static void test() {
 			Random rd = new Random();
 			int direction = rd.nextInt(7);
 			switch (direction) {
 				case 0:
-					targetPos.x = (float) (((tileX + 1) * 55) + 55);
-					targetPos.y = (float) (((tileY + 1) * 35) + 35);
+					targetPos.x = ((tileX + 1) * 55) + 55;
+					targetPos.y = ((tileY + 1) * 35) + 35;
 					break;
 				case 2:
-					targetPos.x = (float) (((tileX + 1) * 55) + 55);
-					targetPos.y = (float) (((tileY - 1) * 35) + 35);
+					targetPos.x = ((tileX + 1) * 55) + 55;
+					targetPos.y = ((tileY - 1) * 35) + 35;
 					break;
 				case 4:
-					targetPos.x = (float) (((tileX - 1) * 55) + 55);
-					targetPos.y = (float) (((tileY - 1) * 35) + 35);
+					targetPos.x = ((tileX - 1) * 55) + 55;
+					targetPos.y = ((tileY - 1) * 35) + 35;
 					break;
 				case 6:
-					targetPos.x = (float) (((tileX - 1) * 55) + 55);
-					targetPos.y = (float) (((tileY + 1) * 35) + 35);
+					targetPos.x = ((tileX - 1) * 55) + 55;
+					targetPos.y = ((tileY + 1) * 35) + 35;
 					break;
 				default:
 					break;
@@ -45,7 +45,7 @@ public class TestFieldIncrement3 extends IntegrationTest {
 			directVect.x = targetPos.x - newPos.x;
 			directVect.y = targetPos.y - newPos.y;
 
-			float hPos = (float) Math.sqrt((double) ((directVect.x * directVect.x) + (directVect.y * directVect.y)));
+			float hPos = (float) Math.sqrt((directVect.x * directVect.x) + (directVect.y * directVect.y));
 			directVect.x /= hPos;
 			directVect.y /= hPos;
 		}

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions16.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions16.java
@@ -2,6 +2,7 @@ package jadx.tests.integration.conditions;
 
 import org.junit.jupiter.api.Test;
 
+import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
@@ -26,11 +27,19 @@ public class TestConditions16 extends IntegrationTest {
 	}
 
 	@Test
+	@NotYetImplemented
 	public void test() {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
 
-//		assertThat(code, containsOne("return a < 0 || (b % 2 != 0 && a > 28) || b < 0;"));
+		assertThat(code, containsOne("return a < 0 || (b % 2 != 0 && a > 28) || b < 0;"));
+	}
+
+	@Test
+	public void test2() {
+		ClassNode cls = getClassNode(TestCls.class);
+		String code = cls.getCode().toString();
+
 		assertThat(code, containsOne("return a < 0 || ((b % 2 != 0 && a > 28) || b < 0);"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions8.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestConditions8.java
@@ -31,7 +31,6 @@ public class TestConditions8 extends IntegrationTest {
 		}
 
 		private void showMore() {
-
 		}
 
 		private int size() {


### PR DESCRIPTION
Changes in `TestFieldIncrement3` was done by Eclipse, since they are unneeded casts.