### PR TITLE
fix test and rename GUI message

### DIFF
--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryAfterDeclaration.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryAfterDeclaration.java
@@ -13,7 +13,20 @@ import jadx.tests.api.IntegrationTest;
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class TryAfterDeclaration extends IntegrationTest {
+public class TestTryAfterDeclaration extends IntegrationTest {
+
+	static class TestClass {
+		public static void consume() throws IOException {
+			InputStream bis = null;
+			try {
+				bis = new FileInputStream("1.txt");
+				while (bis != null) {
+					System.out.println("c");
+				}
+			} catch (final IOException e) {
+			}
+		}
+	}
 
 	/**
 	 * Issue #62.
@@ -28,16 +41,4 @@ public class TryAfterDeclaration extends IntegrationTest {
 	}
 }
 
-class TestClass {
-	public static void consume() throws IOException {
-		InputStream bis = null;
-		try {
-			bis = new FileInputStream("1.txt");
-			while (bis != null) {
-				System.out.println("c");
-			}
-		} catch (final IOException e) {
-		}
-	}
-}
 

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -135,7 +135,7 @@ popup.exclude=Exclude
 confirm.save_as_title=Confirm Save as
 confirm.save_as_message=%s already exists.\nDo you want to replace it?
 confirm.not_saved_title=Save project
-confirm.not_saved_message=Save the current project before opening the new one?
+confirm.not_saved_message=Save the current project before proceeding?
 
 certificate.title=Certificate
 certificate.cert_type=Type


### PR DESCRIPTION
test: fix after the new re-compiling.

Also, rename message in GUI (since it can be used while exiting the application).