### PR TITLE
fix: resource entry with -1 key (#556)

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
@@ -214,6 +214,9 @@ public class ResTableParser extends CommonBinaryParser {
 		int size = is.readInt16();
 		int flags = is.readInt16();
 		int key = is.readInt32();
+		if (key == -1) {
+			return;
+		}
 
 		int resRef = pkg.getId() << 24 | typeId << 16 | entryId;
 		String typeName = pkg.getTypeStrings()[typeId - 1];


### PR DESCRIPTION
Fix #556 

I am not sure about the format of the resource table format, but key can be -1.