### PR TITLE
fix(gui): NPE if the autosave is enabled, and project is initial

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
@@ -91,11 +91,13 @@ public class JadxProject {
 	}
 
 	public void save() {
-		try (BufferedWriter writer = Files.newBufferedWriter(getProjectPath())) {
-			writer.write(GSON.toJson(this));
-			saved = true;
-		} catch (Exception e) {
-			LOG.error("Error saving project", e);
+		if (getProjectPath() != null) {
+			try (BufferedWriter writer = Files.newBufferedWriter(getProjectPath())) {
+				writer.write(GSON.toJson(this));
+				saved = true;
+			} catch (Exception e) {
+				LOG.error("Error saving project", e);
+			}
 		}
 	}
 


### PR DESCRIPTION
When autosave option is enabled, and project is initial, any `changed()` activity will result in `NPE`.