### PR TITLE
fix: remove static field redundant array type when initialized

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ExtractFieldInit.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ExtractFieldInit.java
@@ -92,6 +92,10 @@ public class ExtractFieldInit extends AbstractVisitor {
 				if (initInsns.size() == 1) {
 					InsnNode insn = initInsns.get(0);
 					if (checkInsn(insn)) {
+						InsnArg arg = insn.getArg(0);
+						if (arg instanceof InsnWrapArg) {
+							((InsnWrapArg) arg).getWrapInsn().add(AFlag.DECLARE_VAR);
+						}
 						InsnRemover.remove(classInitMth, insn);
 						addFieldInitAttr(classInitMth, field, insn);
 					}

--- a/jadx-core/src/test/java/jadx/tests/integration/arrays/TestArrayInitField.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arrays/TestArrayInitField.java
@@ -11,7 +11,8 @@ public class TestArrayInitField extends IntegrationTest {
 
 	public static class TestCls {
 
-		byte[] bytes = new byte[]{10, 20, 30};
+		static byte[] a = new byte[]{10, 20, 30};
+		byte[] b = new byte[]{40, 50, 60};
 	}
 
 	@Test
@@ -20,5 +21,6 @@ public class TestArrayInitField extends IntegrationTest {
 		String code = cls.getCode().toString();
 
 		assertThat(code, containsString("= {10, 20, 30};"));
+		assertThat(code, containsString("= {40, 50, 60};"));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInitInTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestFieldInitInTryCatch.java
@@ -82,6 +82,6 @@ public class TestFieldInitInTryCatch extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls3.class);
 		String code = cls.getCode().toString();
 
-		assertThat(code, containsOne("public static final String[] a = new String[]{\"a\"};"));
+		assertThat(code, containsOne("public static final String[] a = {\"a\"};"));
 	}
 }


### PR DESCRIPTION
Similar to #567, but for `static` fields.