### PR TITLE
fix: handle unknown opcodes (#342)

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
@@ -579,7 +579,14 @@ public class InsnDecoder {
 						InsnArg.reg(insn, 0, ArgType.UNKNOWN_OBJECT));
 
 			default:
-				throw new DecodeException("Unknown instruction: '" + OpcodeInfo.getName(insn.getOpcode()) + '\'');
+				String opcode;
+				try {
+					opcode = OpcodeInfo.getName(insn.getOpcode());
+				} catch (IllegalArgumentException e) {
+					opcode = "0x" + Integer.toHexString(insn.getOpcode());
+				}
+				LOG.warn("Unknown instruction: '" + opcode + "', replaced with NOP");
+				return new InsnNode(InsnType.NOP, 0);
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
@@ -579,14 +579,13 @@ public class InsnDecoder {
 						InsnArg.reg(insn, 0, ArgType.UNKNOWN_OBJECT));
 
 			default:
-				String opcode;
 				try {
-					opcode = OpcodeInfo.getName(insn.getOpcode());
+					throw new DecodeException("Unknown instruction: '" + OpcodeInfo.getName(insn.getOpcode()) + '\'');
 				} catch (IllegalArgumentException e) {
-					opcode = "0x" + Integer.toHexString(insn.getOpcode());
+					String opcode = "0x" + Integer.toHexString(insn.getOpcode());
+					LOG.warn("Unknown instruction: '" + opcode + "', replaced with NOP");
+					return new InsnNode(InsnType.NOP, 0);
 				}
-				LOG.warn("Unknown instruction: '" + opcode + "', replaced with NOP");
-				return new InsnNode(InsnType.NOP, 0);
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
@@ -579,13 +579,7 @@ public class InsnDecoder {
 						InsnArg.reg(insn, 0, ArgType.UNKNOWN_OBJECT));
 
 			default:
-				try {
-					throw new DecodeException("Unknown instruction: '" + OpcodeInfo.getName(insn.getOpcode()) + '\'');
-				} catch (IllegalArgumentException e) {
-					String opcode = "0x" + Integer.toHexString(insn.getOpcode());
-					LOG.warn("Unknown instruction: '" + opcode + "', replaced with NOP");
-					return new InsnNode(InsnType.NOP, 0);
-				}
+				throw new DecodeException("Unknown instruction: '" + OpcodeInfo.getName(insn.getOpcode()) + '\'');
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ExtractFieldInit.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ExtractFieldInit.java
@@ -51,7 +51,8 @@ public class ExtractFieldInit extends AbstractVisitor {
 		MethodNode clinit = cls.getClassInitMth();
 		if (clinit == null
 				|| !clinit.getAccessFlags().isStatic()
-				|| clinit.isNoCode()) {
+				|| clinit.isNoCode()
+				|| clinit.getBasicBlocks() == null) {
 			return;
 		}
 
@@ -231,7 +232,7 @@ public class ExtractFieldInit extends AbstractVisitor {
 	}
 
 	private static List<InsnNode> getFieldAssigns(MethodNode mth, FieldNode field, InsnType putInsn) {
-		if (mth.isNoCode()) {
+		if (mth.isNoCode() || mth.getBasicBlocks() == null) {
 			return Collections.emptyList();
 		}
 		List<InsnNode> assignInsns = new ArrayList<>();

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ReSugarCode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ReSugarCode.java
@@ -218,7 +218,7 @@ public class ReSugarCode extends AbstractVisitor {
 
 	private static void initClsEnumMap(ClassNode enumCls) {
 		MethodNode clsInitMth = enumCls.getClassInitMth();
-		if (clsInitMth == null || clsInitMth.isNoCode()) {
+		if (clsInitMth == null || clsInitMth.isNoCode() || clsInitMth.getBasicBlocks() == null) {
 			return;
 		}
 		EnumMapAttr mapAttr = new EnumMapAttr();


### PR DESCRIPTION
Fix #342 

If an opcode is incorrect, then we shouldn't throw Exception, because this will make the method has no blocks.

Instead, print warning, and replace it with `NOP`, this is also what apktool does.