### PR TITLE
gui: disable all components on saving the settings

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
@@ -59,18 +59,22 @@ public class JadxSettingsWindow extends JDialog {
 		JButton saveBtn = new JButton(NLS.str("preferences.save"));
 		saveBtn.addActionListener(event -> {
 			settings.sync();
-			if (needReload) {
-				mainWindow.reOpenFile();
-			}
-			if (!settings.getLangLocale().equals(prevLang)) {
-				JOptionPane.showMessageDialog(
-						this,
-						NLS.str("msg.language_changed", settings.getLangLocale()),
-						NLS.str("msg.language_changed_title", settings.getLangLocale()),
-						JOptionPane.INFORMATION_MESSAGE
-				);
-			}
-			dispose();
+			enableComponents(this, false);
+
+			SwingUtilities.invokeLater(() -> {
+				if (needReload) {
+					mainWindow.reOpenFile();
+				}
+				if (!settings.getLangLocale().equals(prevLang)) {
+					JOptionPane.showMessageDialog(
+							this,
+							NLS.str("msg.language_changed", settings.getLangLocale()),
+							NLS.str("msg.language_changed_title", settings.getLangLocale()),
+							JOptionPane.INFORMATION_MESSAGE
+							);
+				}
+				dispose();
+			});
 		});
 		JButton cancelButton = new JButton(NLS.str("preferences.cancel"));
 		cancelButton.addActionListener(event -> {
@@ -114,6 +118,15 @@ public class JadxSettingsWindow extends JDialog {
 		contentPane.add(buttonPane, BorderLayout.PAGE_END);
 		getRootPane().setDefaultButton(saveBtn);
 	}
+
+	private static void enableComponents(Container container, boolean enable) {
+        for (Component component : container.getComponents()) {
+            if (component instanceof Container) {
+                enableComponents((Container) component, enable);
+            }
+            component.setEnabled(enable);
+        }
+    }
 
 	private SettingsGroup makeDeobfuscationGroup() {
 		JCheckBox deobfOn = new JCheckBox();


### PR DESCRIPTION
When opening big file, and changing settings, the window takes long time to reload the file, and user doesn't know if he clicked or not.

This change disables all subcomponents, before opening the file and ultimately close the settings window.