### PR TITLE
fix(gui): sort classes by case insensitivity

### DIFF
--- a/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
+++ b/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
@@ -249,7 +249,7 @@ public final class JadxDecompiler {
 		}
 		Collections.sort(packages);
 		for (JavaPackage pkg : packages) {
-			pkg.getClasses().sort(Comparator.comparing(JavaClass::getName));
+			pkg.getClasses().sort(Comparator.comparing(JavaClass::getName, String.CASE_INSENSITIVE_ORDER));
 		}
 		return Collections.unmodifiableList(packages);
 	}


### PR DESCRIPTION
GUI-related: when there is long class names, upper cases are shown first, then followed by lower case.

I guess it is better to have them all sorted case insensitive, so the needed class can be easily found.