### PR TITLE
Generates XML key names if empty

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
@@ -221,6 +221,9 @@ public class ResTableParser extends CommonBinaryParser {
 		int resRef = pkg.getId() << 24 | typeId << 16 | entryId;
 		String typeName = pkg.getTypeStrings()[typeId - 1];
 		String keyName = pkg.getKeyStrings()[key];
+		if(keyName.isEmpty()) {
+			keyName = "RES_" + resRef; // autogenerate key name
+		}
 		ResourceEntry ri = new ResourceEntry(resRef, pkg.getName(), typeName, keyName);
 		ri.setConfig(config);
 


### PR DESCRIPTION
Issue https://github.com/skylot/jadx/issues/394

Before
```xml
    <string name="">Navigate home</string>
    <string name="">Navigate up</string>
```

Now
```xml
    <string name="RES_2131755008">Navigate home</string>
    <string name="RES_2131755009">Navigate up</string>
```