### PR TITLE
chore: move arithmetic parenthesis logic from InsnArg to PrepareForCodeGen

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/instructions/ArithOp.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/ArithOp.java
@@ -24,11 +24,4 @@ public enum ArithOp {
 	public String getSymbol() {
 		return this.symbol;
 	}
-
-	public boolean noWrapWith(ArithOp other) {
-		return (this == ADD && other == ADD)
-				|| (this == MUL && other == MUL)
-				|| (this == AND && other == AND)
-				|| (this == OR && other == OR);
-	}
 }

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/InsnArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/InsnArg.java
@@ -9,8 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jadx.core.dex.attributes.AFlag;
-import jadx.core.dex.instructions.ArithNode;
-import jadx.core.dex.instructions.InsnType;
 import jadx.core.dex.nodes.InsnNode;
 import jadx.core.utils.InsnUtils;
 
@@ -113,12 +111,6 @@ public abstract class InsnArg extends Typed {
 		insn.add(AFlag.WRAPPED);
 		InsnArg arg = wrapArg(insn);
 		parent.setArg(i, arg);
-
-		if (insn.getType() == InsnType.ARITH && parent.getType() == InsnType.ARITH
-				&& ((ArithNode) insn).getOp().noWrapWith(((ArithNode) parent).getOp())) {
-			insn.add(AFlag.DONT_WRAP);
-		}
-
 		return arg;
 	}
 


### PR DESCRIPTION
This PR moves changes from #559 from `InsnArg` and `ArithOp` to `PrepareForCodeGen`, which seems to be there before, but was incomplete.