### PR TITLE
fix(gui): remove tree children expansions as well

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
@@ -78,11 +78,24 @@ public class JadxProject {
 
 	public void removeTreeExpansion(String[] expansion) {
 		for (Iterator<String[]> it = treeExpansions.iterator(); it.hasNext(); ) {
-			if (Arrays.equals(it.next(), expansion)) {
+			if (isParentOfExpansion(expansion, it.next())) {
 				it.remove();
 			}
 		}
 		changed();
+	}
+
+	private boolean isParentOfExpansion(String[] parent, String[] child) {
+		if (Arrays.equals(parent, child)) {
+			return true;
+		}
+		for (int i = child.length - parent.length; i > 0; i--) {
+			String[] arr = Arrays.copyOfRange(child, i, child.length);
+			if (Arrays.equals(parent, arr)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private void changed() {


### PR DESCRIPTION
When a tree node is collapsed, we remove it from the "tree expansions", however opened children still remain in the saved values.

This change recursively removes all sub-children from being saved when a node is collapses.