### PR TITLE
fix(gui): closing jadx main should terminate the JVM (#639)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -967,6 +967,7 @@ public class MainWindow extends JFrame {
 		settings.setMainWindowExtendedState(getExtendedState());
 		cancelBackgroundJobs();
 		dispose();
+		System.exit(0);
 	}
 
 	public JadxWrapper getWrapper() {


### PR DESCRIPTION
Fix #639 