### PR TITLE
chore: use lambda

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/regions/DepthRegionTraversal.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/regions/DepthRegionTraversal.java
@@ -63,7 +63,7 @@ public class DepthRegionTraversal {
 	private static boolean traverseIterativeStepInternal(MethodNode mth, IRegionIterativeVisitor visitor, IContainer container) {
 		if (container instanceof IRegion) {
 			IRegion region = (IRegion) container;
-			if (visitor.visitRegion(mth, region)) {
+			if (visitor.visitRegion(region)) {
 				return true;
 			}
 			for (IContainer subCont : region.getSubBlocks()) {

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/regions/IRegionIterativeVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/regions/IRegionIterativeVisitor.java
@@ -1,12 +1,11 @@
 package jadx.core.dex.visitors.regions;
 
 import jadx.core.dex.nodes.IRegion;
-import jadx.core.dex.nodes.MethodNode;
 
 public interface IRegionIterativeVisitor {
 
 	/**
 	 * If return 'true' traversal will be restarted.
 	 */
-	boolean visitRegion(MethodNode mth, IRegion region);
+	boolean visitRegion(IRegion region);
 }

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/regions/ProcessTryCatchRegions.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/regions/ProcessTryCatchRegions.java
@@ -38,14 +38,10 @@ public class ProcessTryCatchRegions extends AbstractRegionVisitor {
 		Map<BlockNode, TryCatchBlock> tryBlocksMap = new HashMap<>(2);
 		searchTryCatchDominators(mth, tryBlocksMap);
 
-		IRegionIterativeVisitor visitor = new IRegionIterativeVisitor() {
-			@Override
-			public boolean visitRegion(MethodNode mth, IRegion region) {
-				boolean changed = checkAndWrap(mth, tryBlocksMap, region);
-				return changed && !tryBlocksMap.isEmpty();
-			}
-		};
-		DepthRegionTraversal.traverseIncludingExcHandlers(mth, visitor);
+		DepthRegionTraversal.traverseIncludingExcHandlers(mth, region -> {
+			boolean changed = checkAndWrap(mth, tryBlocksMap, region);
+			return changed && !tryBlocksMap.isEmpty();
+		});
 	}
 
 	private static void searchTryCatchDominators(MethodNode mth, Map<BlockNode, TryCatchBlock> tryBlocksMap) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -85,8 +85,6 @@ import jadx.gui.treemodel.JPackage;
 import jadx.gui.treemodel.JResource;
 import jadx.gui.treemodel.JRoot;
 import jadx.gui.update.JadxUpdate;
-import jadx.gui.update.JadxUpdate.IUpdateCallback;
-import jadx.gui.update.data.Release;
 import jadx.gui.utils.CacheObject;
 import jadx.gui.utils.FontUtils;
 import jadx.gui.utils.JumpPosition;
@@ -186,14 +184,11 @@ public class MainWindow extends JFrame {
 		if (!settings.isCheckForUpdates()) {
 			return;
 		}
-		JadxUpdate.check(new IUpdateCallback() {
-			@Override
-			public void onUpdate(final Release r) {
-				SwingUtilities.invokeLater(() -> {
-					updateLink.setText(NLS.str("menu.update_label", r.getName()));
-					updateLink.setVisible(true);
-				});
-			}
+		JadxUpdate.check(release -> {
+			SwingUtilities.invokeLater(() -> {
+				updateLink.setText(NLS.str("menu.update_label", release.getName()));
+				updateLink.setVisible(true);
+			});
 		});
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/update/JadxUpdate.java
+++ b/jadx-gui/src/main/java/jadx/gui/update/JadxUpdate.java
@@ -9,11 +9,13 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jadx.api.JadxDecompiler;
 import jadx.gui.update.data.Release;
@@ -34,19 +36,15 @@ public class JadxUpdate {
 	private static final Comparator<Release> RELEASE_COMPARATOR = (o1, o2) ->
 			VersionComparator.checkAndCompare(o1.getName(), o2.getName());
 
-	public interface IUpdateCallback {
-		void onUpdate(Release r);
-	}
-
 	private JadxUpdate() {
 	}
 
-	public static void check(final IUpdateCallback callback) {
+	public static void check(final Consumer<Release> callback) {
 		Runnable run = () -> {
 			try {
 				Release release = checkForNewRelease();
 				if (release != null) {
-					callback.onUpdate(release);
+					callback.accept(release);
 				}
 			} catch (Exception e) {
 				LOG.debug("Jadx update error", e);


### PR DESCRIPTION
This change does two things:

- Replace the three implementations of `IRegionIterativeVisitor` with lambda, and removing its `mth` parameter, since it is redundant.
- Replace `IUpdateCallback` with `Consumer<Release>`, since it is used only once, and it is in the GUI area.