### PR TITLE
feat(gui): make search bar usable for smali code

### DIFF
--- a/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
+++ b/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
@@ -2,9 +2,7 @@ package jadx.api;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -312,7 +310,7 @@ public final class JadxDecompiler {
 		Path path = cls.dex().getDexFile().getPath();
 		String className = cls.getAlias().makeRawFullName();
 		className = 'L' + className.replace('.', '/') + ';';
-		try (InputStream in = Files.newInputStream(path)) {
+		try {
 			DexBackedDexFile dexFile = DexFileFactory.loadDexFile(path.toFile(), Opcodes.getDefault());
 			boolean decompiled = false;
 			for (DexBackedClassDef classDef : dexFile.getClasses()) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
@@ -45,11 +45,16 @@ public final class CodePanel extends ContentPanel {
 		add(areaTabbedPane);
 
 		KeyStroke key = KeyStroke.getKeyStroke(KeyEvent.VK_F, Utils.ctrlButton());
-		Utils.addKeyBinding(codeArea, key, "SearchAction", new SearchAction());
+		SearchAction searchAction = new SearchAction();
+		Utils.addKeyBinding(codeArea, key, "SearchAction", searchAction);
+		Utils.addKeyBinding(smaliArea, key, "SearchAction", searchAction);
 
 		areaTabbedPane.addChangeListener(e -> {
 			if (areaTabbedPane.getSelectedComponent() == smaliScrollPane) {
 				smaliArea.load();
+				searchBar.setRTextArea(smaliArea);
+			} else if (areaTabbedPane.getSelectedComponent() == codeScrollPane) {
+				searchBar.setRTextArea(codeArea);
 			}
 		});
 	}

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/SearchBar.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/SearchBar.java
@@ -32,7 +32,7 @@ class SearchBar extends JToolBar {
 	private static final Icon ICON_DOWN = Utils.openIcon("arrow_down");
 	private static final Icon ICON_CLOSE = Utils.openIcon("cross");
 
-	private final RSyntaxTextArea rTextArea;
+	private RSyntaxTextArea rTextArea;
 
 	private final JTextField searchField;
 	private final JCheckBox markAllCB;
@@ -166,6 +166,13 @@ class SearchBar extends JToolBar {
 			searchField.setBackground(COLOR_BG_ERROR);
 		} else {
 			searchField.setBackground(COLOR_BG_NORMAL);
+		}
+	}
+
+	public void setRTextArea(RSyntaxTextArea rTextArea) {
+		this.rTextArea = rTextArea;
+		if (isVisible()) {
+			this.search(0);
 		}
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/SmaliArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/SmaliArea.java
@@ -18,6 +18,7 @@ public final class SmaliArea extends RSyntaxTextArea {
 	void load() {
 		if (getText().isEmpty()) {
 			setText(node.getSmali());
+			setCaretPosition(0);
 		}
 	}
 }


### PR DESCRIPTION
Additionally this PR includes a small fixe (start with line 0) for the smali tab and some unnecessary code in JadxDecompiler.java is removed.