### PR TITLE
feat(cli): decompile only a single class

### DIFF
--- a/jadx-cli/src/main/java/jadx/cli/JadxCLIArgs.java
+++ b/jadx-cli/src/main/java/jadx/cli/JadxCLIArgs.java
@@ -43,6 +43,9 @@ public class JadxCLIArgs {
 	@Parameter(names = { "-s", "--no-src" }, description = "do not decompile source code")
 	protected boolean skipSources = false;
 
+	@Parameter(names = { "--single-class" }, description = "decompile a single class")
+	protected String singleClass = null;
+
 	@Parameter(names = { "-e", "--export-gradle" }, description = "save as android gradle project")
 	protected boolean exportAsGradleProject = false;
 
@@ -173,6 +176,9 @@ public class JadxCLIArgs {
 		args.setOutDirRes(FileUtils.toFile(outDirRes));
 		args.setThreadsCount(threadsCount);
 		args.setSkipSources(skipSources);
+		if (singleClass != null) {
+			args.setClassFilter((className) -> singleClass.equals(className));
+		}
 		args.setSkipResources(skipResources);
 		args.setFallbackMode(fallbackMode);
 		args.setShowInconsistentCode(showInconsistentCode);

--- a/jadx-core/src/main/java/jadx/api/JadxArgs.java
+++ b/jadx-core/src/main/java/jadx/api/JadxArgs.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public class JadxArgs {
 
@@ -35,6 +36,11 @@ public class JadxArgs {
 
 	private boolean skipResources = false;
 	private boolean skipSources = false;
+
+	/**
+	 * Predicate that allows to filter the classes to be process based on their full name
+	 */
+	private Predicate<String> classFilter = null;
 
 	private boolean deobfuscationOn = false;
 	private boolean deobfuscationForceSave = false;
@@ -180,6 +186,14 @@ public class JadxArgs {
 
 	public void setSkipSources(boolean skipSources) {
 		this.skipSources = skipSources;
+	}
+
+	public Predicate<String> getClassFilter() {
+		return classFilter;
+	}
+
+	public void setClassFilter(Predicate<String> classFilter) {
+		this.classFilter = classFilter;
 	}
 
 	public boolean isDeobfuscationOn() {

--- a/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
+++ b/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import org.jf.baksmali.Adaptors.ClassDefinition;
 import org.jf.baksmali.BaksmaliOptions;
@@ -203,8 +204,12 @@ public final class JadxDecompiler {
 	}
 
 	private void appendSourcesSave(ExecutorService executor, File outDir) {
+		final Predicate<String> classFilter = args.getClassFilter();
 		for (JavaClass cls : getClasses()) {
 			if (cls.getClassNode().contains(AFlag.DONT_GENERATE)) {
+				continue;
+			}
+			if (classFilter != null && !classFilter.test(cls.getFullName())) {
 				continue;
 			}
 			executor.execute(() -> {


### PR DESCRIPTION
Decompilation a single single class only was not yet possible. In the backend a flexible Predicate<String> (String=full class name) is used. Therefore implementing different filters would be possible.