### PR TITLE
fix(gui): jadx-gui.bat does not work (#692)

### DIFF
--- a/jadx-cli/build.gradle
+++ b/jadx-cli/build.gradle
@@ -22,7 +22,6 @@ startScripts {
     defaultJvmOpts = ['-Xms128M', '-Xmx4g', '-XX:+UseG1GC']
     doLast {
         def str = windowsScript.text
-        str = str.replaceAll('set JAVA_EXE=%JAVA_HOME%/bin/java.exe', 'set JAVA_EXE="%JAVA_HOME%/bin/java.exe"')
         windowsScript.text = str
     }
 }

--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -51,7 +51,7 @@ startScripts {
         def str = windowsScript.text
         str = str.replaceAll('java.exe', 'javaw.exe')
         str = str.replaceAll('"%JAVA_EXE%" %DEFAULT_JVM_OPTS%', 'start "jadx-gui" /B "%JAVA_EXE%" %DEFAULT_JVM_OPTS%')
-        str = str.replaceAll('set JAVA_EXE=%JAVA_HOME%/bin/javaw.exe', 'set JAVA_EXE="%JAVA_HOME%/bin/javaw.exe"')
+        str = str.replaceAll('set JAVA_EXE=%JAVA_HOME%/bin/javaw.exe', 'set JAVA_EXE=%JAVA_HOME%/bin/javaw.exe')
         windowsScript.text = str
     }
 }

--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -51,7 +51,6 @@ startScripts {
         def str = windowsScript.text
         str = str.replaceAll('java.exe', 'javaw.exe')
         str = str.replaceAll('"%JAVA_EXE%" %DEFAULT_JVM_OPTS%', 'start "jadx-gui" /B "%JAVA_EXE%" %DEFAULT_JVM_OPTS%')
-        str = str.replaceAll('set JAVA_EXE=%JAVA_HOME%/bin/javaw.exe', 'set JAVA_EXE=%JAVA_HOME%/bin/javaw.exe')
         windowsScript.text = str
     }
 }


### PR DESCRIPTION
In `jadx-gui.bat` the command for starting `javaw.exe` contains in the end double double quotes which prevents starting jadx-gui.

This is the fix for issue #692 