### PR TITLE
fix: don't stop loading classes in case of an error

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/DexNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/DexNode.java
@@ -7,9 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jadx.core.utils.exceptions.JadxRuntimeException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.android.dex.ClassData;
 import com.android.dex.ClassData.Method;
@@ -26,9 +27,8 @@ import jadx.core.dex.info.ClassInfo;
 import jadx.core.dex.info.FieldInfo;
 import jadx.core.dex.info.MethodInfo;
 import jadx.core.dex.instructions.args.ArgType;
+import jadx.core.utils.exceptions.JadxRuntimeException;
 import jadx.core.utils.files.DexFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DexNode implements IDexNode {
 	private static final Logger LOG = LoggerFactory.getLogger(DexNode.class);

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/DexNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/DexNode.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jadx.core.utils.exceptions.JadxRuntimeException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,8 +27,11 @@ import jadx.core.dex.info.FieldInfo;
 import jadx.core.dex.info.MethodInfo;
 import jadx.core.dex.instructions.args.ArgType;
 import jadx.core.utils.files.DexFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DexNode implements IDexNode {
+	private static final Logger LOG = LoggerFactory.getLogger(DexNode.class);
 
 	public static final int NO_INDEX = -1;
 
@@ -50,7 +54,12 @@ public class DexNode implements IDexNode {
 
 	public void loadClasses() {
 		for (ClassDef cls : dexBuf.classDefs()) {
-			addClassNode(new ClassNode(this, cls));
+			try {
+				addClassNode(new ClassNode(this, cls));
+			} catch (JadxRuntimeException e) {
+				// TODO: Add dummy class node displaying the error message
+				LOG.error("Class loading failed - {}", e.getMessage(), e);
+			}
 		}
 		// sort classes by name, expect top classes before inner
 		classes.sort(Comparator.comparing(ClassNode::getFullName));


### PR DESCRIPTION
As described in #763 Jadx silently stops loading classes form an APK like com.whatsapp 2.19.274 (452992) which causes one class loading to fail.

This PR changes the class loading behavior in a way that only the affected class is not loaded. In case of an error the error is logged and class loading continues.