### PR TITLE
feat(gui): Support for APK signature v3 added

### DIFF
--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 	compile 'io.reactivex.rxjava2:rxjava:2.2.11'
 	compile "com.github.akarnokd:rxjava2-swing:0.3.7"
-	compile 'com.android.tools.build:apksig:3.4.2'
+	compile 'com.android.tools.build:apksig:3.5.1'
 }
 
 application {

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/ApkSignature.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/ApkSignature.java
@@ -5,7 +5,8 @@ import java.security.cert.Certificate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.swing.*;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -83,7 +84,6 @@ public class ApkSignature extends JNode {
 			final String sigFailKey = "apkSignature.signatureFailed";
 
 			writeIssues(builder, err, result.getErrors());
-			writeIssues(builder, warn, result.getWarnings());
 
 			if (!result.getV1SchemeSigners().isEmpty()) {
 				builder.append("<h2>");
@@ -124,6 +124,26 @@ public class ApkSignature extends JNode {
 				}
 				builder.append("</blockquote>");
 			}
+			if (!result.getV3SchemeSigners().isEmpty()) {
+				builder.append("<h2>");
+				builder.escape(NLS.str(result.isVerifiedUsingV3Scheme() ? sigSuccKey : sigFailKey, 3));
+				builder.append("</h2>\n");
+
+				builder.append("<blockquote>");
+				for (ApkVerifier.Result.V3SchemeSignerInfo signer : result.getV3SchemeSigners()) {
+					builder.append("<h3>");
+					builder.escape(NLS.str("apkSignature.signer"));
+					builder.append(" ");
+					builder.append(Integer.toString(signer.getIndex() + 1));
+					builder.append("</h3>");
+					writeCertificate(builder, signer.getCertificate());
+					writeIssues(builder, err, signer.getErrors());
+					writeIssues(builder, warn, signer.getWarnings());
+				}
+				builder.append("</blockquote>");
+			}
+			writeIssues(builder, warn, result.getWarnings());
+
 			this.content = builder.toString();
 		} catch (Exception e) {
 			LOG.error(e.getMessage(), e);


### PR DESCRIPTION
The old apk signature test had problems if the APK contained a v3 signature. 
The updated apksig library can handle v1-v3 signatures correctly. 
Furthermore I moved the verification warnings below the signature block as there are usually a lot of them, but they are not more important that the signature verification result.