### PR TITLE
Fix: escapeUnicode always-on for `c < 32`

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/StringUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/StringUtils.java
@@ -64,7 +64,7 @@ public class StringUtils {
 				break;
 
 			default:
-				if (c < 32 || c >= 127 && escapeUnicode) {
+				if ((c < 32 || c >= 127) && escapeUnicode) {
 					res.append("\\u").append(String.format("%04x", c));
 				} else {
 					res.append((char) c);


### PR DESCRIPTION
The escape unicode logic checks `c < 32` OR `c >= 127 && escapeUnicode`.

Maybe the feature should be on by default and the flag should be changed to `--no-escape-unicode` ?

I haven't run `gradle spotlessApply` as I can't get gradle to work probably.