### PR TITLE
Try to restore opened tabs on file reload

### DIFF
--- a/jadx-core/src/main/java/jadx/api/JavaClass.java
+++ b/jadx-core/src/main/java/jadx/api/JavaClass.java
@@ -174,6 +174,10 @@ public final class JavaClass implements JavaNode {
 		return cls.getFullName();
 	}
 
+	public String getRealFullName() {
+		return cls.getRealFullName();
+	}
+
 	public String getPackage() {
 		return cls.getPackage();
 	}

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
@@ -517,6 +517,10 @@ public class ClassNode extends LineAttrNode implements ILoadable, ICodeNode {
 		return clsInfo.getAliasFullName();
 	}
 
+	public String getRealFullName() {
+		return clsInfo.getType().getObject();
+	}
+
 	public String getPackage() {
 		return clsInfo.getAliasPkg();
 	}

--- a/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
@@ -147,4 +147,13 @@ public class JadxWrapper {
 		return decompiler.getClasses().stream().filter(cls -> cls.getFullName().equals(fullName))
 				.findFirst().orElse(null);
 	}
+
+	/**
+	 * @param realName Real name of an outer class. Inner classes are not supported.
+	 * @return
+	 */
+	public @Nullable JavaClass searchJavaClassByRealName(String realName) {
+		return decompiler.getClasses().stream().filter(cls -> cls.getRealFullName().equals(realName))
+				.findFirst().orElse(null);
+	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/TabbedPane.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/TabbedPane.java
@@ -105,7 +105,7 @@ public class TabbedPane extends JTabbedPane {
 	}
 
 	@Nullable
-	private JumpPosition getCurrentPosition() {
+	JumpPosition getCurrentPosition() {
 		ContentPanel selectedCodePanel = getSelectedCodePanel();
 		if (selectedCodePanel instanceof AbstractCodeContentPanel) {
 			return ((AbstractCodeContentPanel) selectedCodePanel).getCodeArea().getCurrentPosition();


### PR DESCRIPTION
Try to reload opened tabs on file reload caused by toggling the Deobfuscation option.
Closes #792 issue.

Save a list of opened tabs and scroll positions for each tab, and try to restore opened tabs after reopening file.
Scroll position may be restored not exactly due to comments in the code (like "Renamed from:"), but usually it will be restored closely to original position.