### PR TITLE
gui: Fix --select-class option (regression)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -200,16 +200,19 @@ public class MainWindow extends JFrame {
 			openFileOrProject();
 		} else {
 			open(Paths.get(settings.getFiles().get(0)));
-			if (settings.getCmdSelectClass() != null) {
-				JavaNode javaNode = wrapper.searchJavaClassByClassName(settings.getCmdSelectClass());
-				if (javaNode == null) {
-					JOptionPane.showMessageDialog(this,
-							NLS.str("msg.cmd_select_class_error", settings.getCmdSelectClass()),
-							NLS.str("error_dialog.title"), JOptionPane.ERROR_MESSAGE);
-				} else {
-					JNode node = cacheObject.getNodeCache().makeFrom(javaNode);
-					tabbedPane.codeJump(new JumpPosition(node.getRootClass(), node.getLine()));
-				}
+		}
+	}
+
+	private void handleSelectClassOption() {
+		if (settings.getCmdSelectClass() != null) {
+			JavaNode javaNode = wrapper.searchJavaClassByClassName(settings.getCmdSelectClass());
+			if (javaNode == null) {
+				JOptionPane.showMessageDialog(this,
+						NLS.str("msg.cmd_select_class_error", settings.getCmdSelectClass()),
+						NLS.str("error_dialog.title"), JOptionPane.ERROR_MESSAGE);
+			} else {
+				JNode node = cacheObject.getNodeCache().makeFrom(javaNode);
+				tabbedPane.codeJump(new JumpPosition(node.getRootClass(), node.getLine()));
 			}
 		}
 	}
@@ -313,6 +316,7 @@ public class MainWindow extends JFrame {
 						deobfToggleBtn.setSelected(settings.isDeobfuscationOn());
 						initTree();
 						update();
+						handleSelectClassOption();
 						runBackgroundJobs();
 					});
 		}


### PR DESCRIPTION
:exclamation: Please review the [guidelines for contributing](../CONTRIBUTING.md#Pull-Request-Process)
Ok.
"./gradlew clean build dist" check passed.

### Description
Commit 9c88f70 broked "--select-class" command-line option for jadx-gui.
jadx-gui fails to open specified class, because file is not loaded yet and decompiler.getClasses() returns null, which causes NPE:
Exception in thread "AWT-EventQueue-1" java.lang.NullPointerException
at jadx.gui.JadxWrapper.searchJavaClassByClassName(JadxWrapper.java:146)
at jadx.gui.ui.MainWindow.processCommandLineArgs(MainWindow.java:204)
at jadx.gui.ui.MainWindow.init(MainWindow.java:195)
at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
at java.awt.EventQueue.access$500(EventQueue.java:97)
at java.awt.EventQueue$3.run(EventQueue.java:709)
at java.awt.EventQueue$3.run(EventQueue.java:703)
at java.security.AccessController.doPrivileged(Native Method)
at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
at org.GNOME.Accessibility.AtkWrapper$6.dispatchEvent(AtkWrapper.java:705)
at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

So, perform selection of specified class when file is loaded, but before starting background jobs.

Fixes https://github.com/skylot/jadx/issues/815