### PR TITLE
fix: additionally show smali code of inner classes

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
@@ -1,5 +1,6 @@
 package jadx.core.dex.nodes;
 
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -533,9 +534,22 @@ public class ClassNode extends LineAttrNode implements ILoadable, ICodeNode {
 
 	public String getSmali() {
 		if (smali == null) {
-			smali = SmaliUtils.getSmaliCode(dex, clsDefOffset);
+			StringWriter stringWriter = new StringWriter(4096);
+			getSmali(this, stringWriter);
+			stringWriter.append(System.lineSeparator());
+			for (ClassNode innerClass : innerClasses) {
+				getSmali(innerClass, stringWriter);
+				stringWriter.append(System.lineSeparator());
+			}
+			smali = stringWriter.toString();
 		}
 		return smali;
+	}
+
+	protected static boolean getSmali(ClassNode classNode, StringWriter stringWriter) {
+		stringWriter.append(String.format("###### Class %s (%s)", classNode.getFullName(), classNode.getRawName()));
+		stringWriter.append(System.lineSeparator());
+		return SmaliUtils.getSmaliCode(classNode.dex, classNode.clsDefOffset, stringWriter);
 	}
 
 	public ProcessState getState() {

--- a/jadx-core/src/main/java/jadx/core/utils/SmaliUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/SmaliUtils.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Path;
 
-import org.jetbrains.annotations.NotNull;
 import org.jf.baksmali.Adaptors.ClassDefinition;
 import org.jf.baksmali.BaksmaliOptions;
 import org.jf.dexlib2.DexFileFactory;
@@ -34,24 +33,25 @@ public class SmaliUtils {
 		}
 	}
 
-	@NotNull
-	public static String getSmaliCode(DexNode dex, int clsDefOffset) {
+	public static boolean getSmaliCode(DexNode dex, int clsDefOffset, StringWriter stringWriter) {
 		try {
 			Path path = dex.getDexFile().getPath();
 			DexBackedDexFile dexFile = DexFileFactory.loadDexFile(path.toFile(), null);
 			DexBackedClassDef dexBackedClassDef = new DexBackedClassDef(dexFile, clsDefOffset);
-			return getSmaliCode(dexBackedClassDef);
+			getSmaliCode(dexBackedClassDef, stringWriter);
+			return true;
 		} catch (Exception e) {
 			LOG.error("Error generating smali", e);
-			return "Error generating smali code: " + e.getMessage()
-					+ '\n' + Utils.getStackTrace(e);
+			stringWriter.append("Error generating smali code: ");
+			stringWriter.append(e.getMessage());
+			stringWriter.append(System.lineSeparator());
+			stringWriter.append(Utils.getStackTrace(e));
+			return false;
 		}
 	}
 
-	private static String getSmaliCode(DexBackedClassDef classDef) throws IOException {
+	private static void getSmaliCode(DexBackedClassDef classDef, StringWriter stringWriter) throws IOException {
 		ClassDefinition classDefinition = new ClassDefinition(new BaksmaliOptions(), classDef);
-		StringWriter sw = new StringWriter();
-		classDefinition.writeTo(new IndentingWriter(sw));
-		return sw.toString();
+		classDefinition.writeTo(new IndentingWriter(stringWriter));
 	}
 }


### PR DESCRIPTION
This pull request solves bug #802

The smali code of inner classes is now appended to the shown smali code of non-inner class.