### PR TITLE
fix: concurrent access may cause an java.lang.ClassCastException

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/utils/JNodeCache.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/JNodeCache.java
@@ -1,7 +1,7 @@
 package jadx.gui.utils;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import jadx.api.JavaClass;
 import jadx.api.JavaField;
@@ -15,7 +15,7 @@ import jadx.gui.treemodel.JNode;
 
 public class JNodeCache {
 
-	private final Map<JavaNode, JNode> cache = new HashMap<>();
+	private final Map<JavaNode, JNode> cache = new ConcurrentHashMap<>();
 
 	public JNode makeFrom(JavaNode javaNode) {
 		if (javaNode == null) {


### PR DESCRIPTION
By chance I encountered in the Jadx log several java.lang.ClassCastException java.util.HashMap$Node cannot be cast to java.util.HashMap$TreeNode in `JNodeCache.makeFrom()`.

Based on some research this can happen in case the HashMap is accesses concurrently. 
This seem to happen very very rarely as I wasn't able to reproduce this Exception in my further tests.

Nevertheless one time if failed and therefore I would suggest to better to use a ConcurrentHashMap for the JNodeCache.