### PR TITLE
chore: add inlined class name as comment

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
@@ -223,10 +223,25 @@ public class ClassGen {
 	}
 
 	public void addClassBody(CodeWriter clsCode) throws CodegenException {
+		addClassBody(clsCode, false);
+	}
+
+	/**
+	 *
+	 * @param clsCode
+	 * @param printClassName allows to print the original class name as comment (e.g. for inlined
+	 *                       classes)
+	 * @throws CodegenException
+	 */
+	public void addClassBody(CodeWriter clsCode, boolean printClassName) throws CodegenException {
 		clsCode.add('{');
 		setBodyGenStarted(true);
 		clsDeclLine = clsCode.getLine();
 		clsCode.incIndent();
+		if (printClassName) {
+			clsCode.startLine();
+			clsCode.add("/* class " + cls.getFullName() + " */");
+		}
 		addFields(clsCode);
 		addInnerClsAndMethods(clsCode);
 		clsCode.decIndent();

--- a/jadx-core/src/main/java/jadx/core/codegen/InsnGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/InsnGen.java
@@ -675,7 +675,7 @@ public class InsnGen {
 		MethodNode callMth = mth.dex().resolveMethod(insn.getCallMth());
 		generateMethodArguments(code, insn, 0, callMth);
 		code.add(' ');
-		new ClassGen(cls, mgen.getClassGen().getParentGen()).addClassBody(code);
+		new ClassGen(cls, mgen.getClassGen().getParentGen()).addClassBody(code, true);
 	}
 
 	private void makeInvoke(InvokeNode insn, CodeWriter code) throws CodegenException {

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass14.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass14.java
@@ -22,6 +22,8 @@ public class TestAnonymousClass14 extends SmaliTest {
 
 			public void makeAnonymousCls() {
 				use(new Thread(this) {
+				/ * class inner.OuterCls.AnonymousClass1 * /
+
 					public void someMethod() {
 					}
 				});
@@ -44,6 +46,7 @@ public class TestAnonymousClass14 extends SmaliTest {
 	public void test() {
 		ClassNode clsNode = getClassNodeFromSmaliFiles("inner", "TestAnonymousClass14", "OuterCls");
 		String code = clsNode.getCode().toString();
+		code = code.replaceAll("/\\*.*?\\*/", ""); // remove block comments
 
 		assertThat(code, not(containsString("AnonymousClass1")));
 		assertThat(code, not(containsString("synthetic")));


### PR DESCRIPTION
When classes are inlined it is not that easy to get the original class name, e.g. if you want to compare it in a different decompiler or if you need the class name for a different purpose like an Xposed module or a Frida script.

Therefore I changed the code generator to add a comment line containing the full class name of the inlined class.