### PR TITLE
Fixed adding this. instead of super. when super member is shadowed

### DIFF
--- a/jadx-core/src/main/java/jadx/core/Jadx.java
+++ b/jadx-core/src/main/java/jadx/core/Jadx.java
@@ -7,11 +7,11 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.Manifest;
 
-import jadx.core.dex.visitors.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jadx.api.JadxArgs;
+import jadx.core.dex.visitors.*;
 import jadx.core.dex.visitors.blocksmaker.BlockExceptionHandler;
 import jadx.core.dex.visitors.blocksmaker.BlockFinish;
 import jadx.core.dex.visitors.blocksmaker.BlockProcessor;

--- a/jadx-core/src/main/java/jadx/core/Jadx.java
+++ b/jadx-core/src/main/java/jadx/core/Jadx.java
@@ -7,32 +7,11 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.Manifest;
 
+import jadx.core.dex.visitors.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jadx.api.JadxArgs;
-import jadx.core.dex.visitors.AttachMethodDetails;
-import jadx.core.dex.visitors.ClassModifier;
-import jadx.core.dex.visitors.ConstInlineVisitor;
-import jadx.core.dex.visitors.ConstructorVisitor;
-import jadx.core.dex.visitors.DeboxingVisitor;
-import jadx.core.dex.visitors.DependencyCollector;
-import jadx.core.dex.visitors.DotGraphVisitor;
-import jadx.core.dex.visitors.EnumVisitor;
-import jadx.core.dex.visitors.ExtractFieldInit;
-import jadx.core.dex.visitors.FallbackModeVisitor;
-import jadx.core.dex.visitors.FixAccessModifiers;
-import jadx.core.dex.visitors.IDexTreeVisitor;
-import jadx.core.dex.visitors.InitCodeVariables;
-import jadx.core.dex.visitors.MarkFinallyVisitor;
-import jadx.core.dex.visitors.MethodInlineVisitor;
-import jadx.core.dex.visitors.MethodInvokeVisitor;
-import jadx.core.dex.visitors.ModVisitor;
-import jadx.core.dex.visitors.PrepareForCodeGen;
-import jadx.core.dex.visitors.ProcessAnonymous;
-import jadx.core.dex.visitors.ReSugarCode;
-import jadx.core.dex.visitors.RenameVisitor;
-import jadx.core.dex.visitors.SimplifyVisitor;
 import jadx.core.dex.visitors.blocksmaker.BlockExceptionHandler;
 import jadx.core.dex.visitors.blocksmaker.BlockFinish;
 import jadx.core.dex.visitors.blocksmaker.BlockProcessor;
@@ -71,6 +50,7 @@ public class Jadx {
 				passes.add(new DebugInfoParseVisitor());
 			}
 
+			passes.add(new FindSuperUsageVisitor());
 			passes.add(new BlockSplitter());
 			if (args.isRawCFGOutput()) {
 				passes.add(DotGraphVisitor.dumpRaw());

--- a/jadx-core/src/main/java/jadx/core/dex/attributes/AFlag.java
+++ b/jadx-core/src/main/java/jadx/core/dex/attributes/AFlag.java
@@ -33,6 +33,7 @@ public enum AFlag {
 	ANONYMOUS_CLASS,
 
 	THIS,
+	SUPER,
 
 	/**
 	 * RegisterArg attribute for method arguments

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/RegisterArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/RegisterArg.java
@@ -11,6 +11,7 @@ import jadx.core.utils.exceptions.JadxRuntimeException;
 
 public class RegisterArg extends InsnArg implements Named {
 	public static final String THIS_ARG_NAME = "this";
+	public static final String SUPER_ARG_NAME = "super";
 
 	protected final int regNum;
 	// not null after SSATransform pass
@@ -87,6 +88,9 @@ public class RegisterArg extends InsnArg implements Named {
 
 	@Override
 	public String getName() {
+		if(isSuper()){
+			return SUPER_ARG_NAME;
+		}
 		if (isThis()) {
 			return THIS_ARG_NAME;
 		}
@@ -94,6 +98,10 @@ public class RegisterArg extends InsnArg implements Named {
 			return null;
 		}
 		return sVar.getName();
+	}
+
+	private boolean isSuper() {
+		return contains(AFlag.SUPER);
 	}
 
 	@Override

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/RegisterArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/RegisterArg.java
@@ -88,7 +88,7 @@ public class RegisterArg extends InsnArg implements Named {
 
 	@Override
 	public String getName() {
-		if(isSuper()){
+		if (isSuper()) {
 			return SUPER_ARG_NAME;
 		}
 		if (isThis()) {

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/FindSuperUsageVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/FindSuperUsageVisitor.java
@@ -1,0 +1,49 @@
+package jadx.core.dex.visitors;
+
+import jadx.core.dex.attributes.AFlag;
+import jadx.core.dex.instructions.args.ArgType;
+import jadx.core.dex.instructions.args.InsnArg;
+import jadx.core.dex.instructions.args.RegisterArg;
+import jadx.core.dex.nodes.InsnNode;
+import jadx.core.dex.nodes.MethodNode;
+import jadx.core.dex.visitors.blocksmaker.BlockSplitter;
+import jadx.core.utils.exceptions.JadxException;
+
+@JadxVisitor(
+		name = "FindSuperUsageVisitor",
+		desc = "Finds variables where a member of the super class is used and marks them.",
+		runBefore = BlockSplitter.class
+)
+public class FindSuperUsageVisitor extends AbstractVisitor {
+
+	@Override
+	public void visit(MethodNode mth) throws JadxException {
+		if (mth.isNoCode()) {
+			return;
+		}
+		process(mth);
+	}
+
+	private static void process(MethodNode methodNode) {
+		ArgType superClass = methodNode.getParentClass().getSuperClass();
+		if (superClass == null) {
+			return;
+		}
+		String superClassName = superClass.getObject();
+		if (superClassName.equals("java.lang.Object")) {
+			return;
+		}
+		for (InsnNode instruction : methodNode.getInstructions()) {
+			if (instruction != null) {
+				for (InsnArg argument : instruction.getArguments()) {
+					if (argument.isRegister()) {
+						ArgType argumentType = ((RegisterArg) argument).getInitType();
+						if (argumentType.isObject() && argumentType.getObject().equals(superClassName)) {
+							argument.add(AFlag.SUPER);
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
@@ -1,0 +1,46 @@
+package jadx.tests.integration.others;
+
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.SmaliTest;
+import org.junit.jupiter.api.Test;
+
+import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestShadowingSuperMember extends SmaliTest {
+	// @formatter:off
+	/*
+
+		public class C {
+			public C(String s) {
+			}
+		}
+
+		public class A {
+			public int a;
+			public A(String s) {
+			}
+		}
+
+		public class B extends A {
+			public C a;
+			public B(String str) {
+				super(str);
+			}
+
+			public int add(int b) {
+				return super.a + b;
+			}
+		}
+	*/
+	// @formatter:on
+
+	@Test
+	public void test() {
+		allowWarnInCode();
+		ClassNode cls = getClassNodeFromSmaliFiles("B");
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("return super.a + b;"));
+	}
+}

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
@@ -17,19 +17,19 @@ public class TestShadowingSuperMember extends SmaliTest {
 		}
 
 		public class A {
-			public int a;
+			public int A00;
 			public A(String s) {
 			}
 		}
 
 		public class B extends A {
-			public C a;
+			public C A00;
 			public B(String str) {
 				super(str);
 			}
 
 			public int add(int b) {
-				return super.a + b;
+				return super.A00 + b;
 			}
 		}
 	*/

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
@@ -41,6 +41,6 @@ public class TestShadowingSuperMember extends SmaliTest {
 		ClassNode cls = getClassNodeFromSmaliFiles("B");
 		String code = cls.getCode().toString();
 
-		assertThat(code, containsOne("return super.a + b;"));
+		assertThat(code, containsOne("return super.A00 + "));
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java
@@ -1,8 +1,9 @@
 package jadx.tests.integration.others;
 
+import org.junit.jupiter.api.Test;
+
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.SmaliTest;
-import org.junit.jupiter.api.Test;
 
 import static jadx.tests.api.utils.JadxMatchers.containsOne;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/jadx-core/src/test/smali/others/TestShadowingSuperMember/A.smali
+++ b/jadx-core/src/test/smali/others/TestShadowingSuperMember/A.smali
@@ -1,0 +1,16 @@
+.class public Lothers/A;
+.super Ljava/lang/Object;
+
+# instance fields
+.field public A00:I
+
+# direct methods
+.method public constructor <init>(Ljava/lang/String;)V
+    .registers 3
+
+    .prologue
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    return-void
+.end method

--- a/jadx-core/src/test/smali/others/TestShadowingSuperMember/B.smali
+++ b/jadx-core/src/test/smali/others/TestShadowingSuperMember/B.smali
@@ -1,0 +1,25 @@
+.class public Lothers/B;
+.super Lothers/A;
+
+.field public A00:Lothers/C;
+
+# direct methods
+.method public constructor <init>(Ljava/lang/String;)V
+    .registers 3
+
+    .prologue
+    invoke-direct {p0, p1}, Lothers/A;-><init>(Ljava/lang/String;)V
+
+    return-void
+.end method
+
+
+.method public add(I)I
+    .registers 3
+
+    iget v1, p0, Lothers/A;->A00:I
+
+    add-int/2addr v1, p1
+
+	return v1
+.end method

--- a/jadx-core/src/test/smali/others/TestShadowingSuperMember/C.smali
+++ b/jadx-core/src/test/smali/others/TestShadowingSuperMember/C.smali
@@ -1,0 +1,12 @@
+.class public Lothers/C;
+.super Ljava/lang/Object;
+
+.method public constructor <init>(Ljava/lang/String;)V
+    .registers 3
+
+    .prologue
+
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    return-void
+.end method


### PR DESCRIPTION
#### Description
The library erroneously used `this.` modifier before a member variable even if the member variable was declared in the super class (for an example, see the [comment](https://github.com/acsbendi/jadx/blob/88e1e7277b9ec7d53749011761b7c89c1795f6d6/jadx-core/src/test/java/jadx/tests/integration/others/TestShadowingSuperMember.java#L14) in the test I added). The modifications I made will put replace `this.` with the correct `super.` keyword in these cases. I found this issue in a real, obfuscated Android APK where the member variable of the super class was shadowed by that of the subclass.

I added a test including smali files. These present the issue quite well, since without the changes I made, the library fails to even create code that compiles.