### PR TITLE
Allow to search for full method/field signature

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JField.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JField.java
@@ -1,6 +1,7 @@
 package jadx.gui.treemodel;
 
-import javax.swing.*;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 
 import jadx.api.JavaField;
 import jadx.api.JavaNode;
@@ -66,8 +67,18 @@ public class JField extends JNode {
 	}
 
 	@Override
+	public String makeStringHtml() {
+		return UiUtils.typeFormatHtml(field.getName(), field.getType());
+	}
+
+	@Override
 	public String makeLongString() {
 		return UiUtils.typeFormat(field.getFullName(), field.getType());
+	}
+
+	@Override
+	public String makeLongStringHtml() {
+		return UiUtils.typeFormatHtml(field.getFullName(), field.getType());
 	}
 
 	@Override

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JMethod.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JMethod.java
@@ -2,7 +2,8 @@ package jadx.gui.treemodel;
 
 import java.util.Iterator;
 
-import javax.swing.*;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 
 import jadx.api.JavaMethod;
 import jadx.api.JavaNode;
@@ -90,13 +91,21 @@ public class JMethod extends JNode {
 
 	@Override
 	public String makeString() {
-		return UiUtils.typeFormat(makeBaseString(), getReturnType());
+		return UiUtils.typeFormatHtml(makeBaseString(), getReturnType());
+	}
+
+	public String makeLongStringWithoutFormat() {
+		return mth.getDeclaringClass().getFullName() + '.' + makeBaseString();
 	}
 
 	@Override
 	public String makeLongString() {
-		String name = mth.getDeclaringClass().getFullName() + '.' + makeBaseString();
-		return UiUtils.typeFormat(name, getReturnType());
+		return UiUtils.typeFormat(makeLongStringWithoutFormat(), getReturnType());
+	}
+
+	@Override
+	public String makeLongStringHtml() {
+		return UiUtils.typeFormatHtml(makeLongStringWithoutFormat(), getReturnType());
 	}
 
 	@Override

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JMethod.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JMethod.java
@@ -91,11 +91,12 @@ public class JMethod extends JNode {
 
 	@Override
 	public String makeString() {
-		return UiUtils.typeFormatHtml(makeBaseString(), getReturnType());
+		return UiUtils.typeFormat(makeBaseString(), getReturnType());
 	}
 
-	public String makeLongStringWithoutFormat() {
-		return mth.getDeclaringClass().getFullName() + '.' + makeBaseString();
+	@Override
+	public String makeStringHtml() {
+		return UiUtils.typeFormatHtml(makeBaseString(), getReturnType());
 	}
 
 	@Override

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JMethod.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JMethod.java
@@ -100,12 +100,14 @@ public class JMethod extends JNode {
 
 	@Override
 	public String makeLongString() {
-		return UiUtils.typeFormat(makeLongStringWithoutFormat(), getReturnType());
+		String name = mth.getDeclaringClass().getFullName() + '.' + makeBaseString();
+		return UiUtils.typeFormat(name, getReturnType());
 	}
 
 	@Override
 	public String makeLongStringHtml() {
-		return UiUtils.typeFormatHtml(makeLongStringWithoutFormat(), getReturnType());
+		String name = mth.getDeclaringClass().getFullName() + '.' + makeBaseString();
+		return UiUtils.typeFormatHtml(name, getReturnType());
 	}
 
 	@Override

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JNode.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JNode.java
@@ -1,6 +1,6 @@
 package jadx.gui.treemodel;
 
-import javax.swing.*;
+import javax.swing.Icon;
 import javax.swing.tree.DefaultMutableTreeNode;
 
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
@@ -77,6 +77,10 @@ public abstract class JNode extends DefaultMutableTreeNode {
 
 	public abstract String makeString();
 
+	public String makeStringHtml() {
+		return makeString();
+	}
+
 	public String makeDescString() {
 		return null;
 	}
@@ -86,6 +90,10 @@ public abstract class JNode extends DefaultMutableTreeNode {
 	}
 
 	public String makeLongString() {
+		return makeString();
+	}
+
+	public String makeLongStringHtml() {
 		return makeString();
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/CommonSearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/CommonSearchDialog.java
@@ -446,7 +446,7 @@ public abstract class CommonSearchDialog extends JDialog {
 
 		private Component makeCell(JNode node, int column) {
 			if (column == 0) {
-				JLabel label = new JLabel(node.makeLongString() + "  ", node.getIcon(), SwingConstants.LEFT);
+				JLabel label = new JLabel(node.makeLongStringHtml() + "  ", node.getIcon(), SwingConstants.LEFT);
 				label.setFont(font);
 				label.setOpaque(true);
 				label.setToolTipText(label.getText());

--- a/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
@@ -196,7 +196,7 @@ public class RenameDialog extends JDialog {
 
 	private void initUI() {
 		JLabel lbl = new JLabel(NLS.str("popup.rename"));
-		JLabel nodeLabel = new JLabel(this.node.makeLongString(), this.node.getIcon(), SwingConstants.LEFT);
+		JLabel nodeLabel = new JLabel(this.node.makeLongStringHtml(), this.node.getIcon(), SwingConstants.LEFT);
 		lbl.setLabelFor(nodeLabel);
 
 		renameField = new JTextField(40);

--- a/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
@@ -47,7 +47,7 @@ public class TabComponent extends JPanel {
 		panel.setOpaque(false);
 
 		JNode node = contentPanel.getNode();
-		label = new JLabel(node.makeLongString());
+		label = new JLabel(node.makeLongStringHtml());
 		label.setFont(getLabelFont());
 		String toolTip = contentPanel.getTabTooltip();
 		if (toolTip != null) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/UsageDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/UsageDialog.java
@@ -54,7 +54,7 @@ public class UsageDialog extends CommonSearchDialog {
 
 	private void initUI() {
 		JLabel lbl = new JLabel(NLS.str("usage_dialog.label"));
-		JLabel nodeLabel = new JLabel(this.node.makeLongString(), this.node.getIcon(), SwingConstants.LEFT);
+		JLabel nodeLabel = new JLabel(this.node.makeLongStringHtml(), this.node.getIcon(), SwingConstants.LEFT);
 		lbl.setLabelFor(nodeLabel);
 
 		JPanel searchPane = new JPanel();

--- a/jadx-gui/src/main/java/jadx/gui/utils/UiUtils.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/UiUtils.java
@@ -65,6 +65,10 @@ public class UiUtils {
 	}
 
 	public static String typeFormat(String name, ArgType type) {
+		return name + typeStr(type);
+	}
+
+	public static String typeFormatHtml(String name, ArgType type) {
 		return "<html><body><nobr>" + escapeHtml(name)
 				+ "<span style='color:#888888;'> " + escapeHtml(typeStr(type)) + "</span>"
 				+ "</nobr></body></html>";

--- a/jadx-gui/src/main/java/jadx/gui/utils/search/TextSearchIndex.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/search/TextSearchIndex.java
@@ -37,8 +37,8 @@ public class TextSearchIndex {
 	private final JNodeCache nodeCache;
 
 	private SearchIndex<JNode> clsNamesIndex;
-	private SearchIndex<JNode> mthNamesIndex;
-	private SearchIndex<JNode> fldNamesIndex;
+	private SearchIndex<JNode> mthSignaturesIndex;
+	private SearchIndex<JNode> fldSignaturesIndex;
 	private SearchIndex<CodeNode> codeIndex;
 
 	private List<JavaClass> skippedClasses = new ArrayList<>();
@@ -46,18 +46,20 @@ public class TextSearchIndex {
 	public TextSearchIndex(JNodeCache nodeCache) {
 		this.nodeCache = nodeCache;
 		this.clsNamesIndex = new SimpleIndex<>();
-		this.mthNamesIndex = new SimpleIndex<>();
-		this.fldNamesIndex = new SimpleIndex<>();
+		this.mthSignaturesIndex = new SimpleIndex<>();
+		this.fldSignaturesIndex = new SimpleIndex<>();
 		this.codeIndex = new CodeIndex<>();
 	}
 
 	public void indexNames(JavaClass cls) {
 		clsNamesIndex.put(cls.getFullName(), nodeCache.makeFrom(cls));
 		for (JavaMethod mth : cls.getMethods()) {
-			mthNamesIndex.put(mth.getName(), nodeCache.makeFrom(mth));
+			JNode mthNode = nodeCache.makeFrom(mth);
+			mthSignaturesIndex.put(mthNode.makeLongString(), mthNode);
 		}
 		for (JavaField fld : cls.getFields()) {
-			fldNamesIndex.put(fld.getName(), nodeCache.makeFrom(fld));
+			JNode fldNode = nodeCache.makeFrom(fld);
+			fldSignaturesIndex.put(fldNode.makeLongString(), fldNode);
 		}
 		for (JavaClass innerCls : cls.getInnerClasses()) {
 			indexNames(innerCls);
@@ -97,10 +99,10 @@ public class TextSearchIndex {
 			result = Flowable.concat(result, clsNamesIndex.search(text, ignoreCase));
 		}
 		if (options.contains(METHOD)) {
-			result = Flowable.concat(result, mthNamesIndex.search(text, ignoreCase));
+			result = Flowable.concat(result, mthSignaturesIndex.search(text, ignoreCase));
 		}
 		if (options.contains(FIELD)) {
-			result = Flowable.concat(result, fldNamesIndex.search(text, ignoreCase));
+			result = Flowable.concat(result, fldSignaturesIndex.search(text, ignoreCase));
 		}
 		if (options.contains(CODE)) {
 			if (codeIndex.size() > 0) {


### PR DESCRIPTION
The search for methods/fields currently only allows to search for the method/field name, but not for the type or the method arguments.

I extended the text index so that the search text is identical to the displayed text (just without the HTML formatting). This allows to search for methods with a specific method signature.

Because the `JMethod` and `JField` `makeLongString()` implementations were returning HTML formatted text I has to introduce the new methods, `makeStringHtml()` and `makeLongStringHtml()` can be used to return a html formatted representation. Therefore the default implementations now only return plain text data. I only needed `makeLongString()` / `makeLongStringHtml()` but for consistency I also applied this scheme to `makeString()` / `makeStringHtml()`.