### PR TITLE
chore(gui): preferences dialog changed to two-column mode

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
@@ -1,6 +1,7 @@
 package jadx.gui.settings;
 
 import java.awt.*;
+import java.awt.event.ActionEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -20,6 +21,7 @@ import jadx.gui.ui.codearea.EditorTheme;
 import jadx.gui.utils.FontUtils;
 import jadx.gui.utils.LangLocale;
 import jadx.gui.utils.NLS;
+import jadx.gui.utils.UiUtils;
 
 public class JadxSettingsWindow extends JDialog {
 	private static final long serialVersionUID = -1804570470377354148L;
@@ -46,19 +48,29 @@ public class JadxSettingsWindow extends JDialog {
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 		setModalityType(ModalityType.APPLICATION_MODAL);
 		pack();
+		UiUtils.setWindowIcons(this);
 		setLocationRelativeTo(null);
 	}
 
 	private void initUI() {
 		JPanel panel = new JPanel();
-		panel.setLayout(new BoxLayout(panel, BoxLayout.PAGE_AXIS));
+		panel.setLayout(new BoxLayout(panel, BoxLayout.LINE_AXIS));
 		panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-		panel.add(makeDeobfuscationGroup());
-		panel.add(makeRenameGroup());
-		panel.add(makeDecompilationGroup());
-		panel.add(makeProjectGroup());
-		panel.add(makeEditorGroup());
-		panel.add(makeOtherGroup());
+
+		JPanel leftPanel = new JPanel();
+		JPanel rightPanel = new JPanel();
+		leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.PAGE_AXIS));
+		rightPanel.setLayout(new BoxLayout(rightPanel, BoxLayout.PAGE_AXIS));
+		panel.add(leftPanel);
+		panel.add(rightPanel);
+
+		leftPanel.add(makeDeobfuscationGroup());
+		leftPanel.add(makeRenameGroup());
+		leftPanel.add(makeProjectGroup());
+		leftPanel.add(makeEditorGroup());
+		leftPanel.add(makeOtherGroup());
+
+		rightPanel.add(makeDecompilationGroup());
 
 		JButton saveBtn = new JButton(NLS.str("preferences.save"));
 		saveBtn.addActionListener(event -> {
@@ -80,11 +92,7 @@ public class JadxSettingsWindow extends JDialog {
 			});
 		});
 		JButton cancelButton = new JButton(NLS.str("preferences.cancel"));
-		cancelButton.addActionListener(event -> {
-			JadxSettingsAdapter.fill(settings, startSettings);
-			mainWindow.loadSettings();
-			dispose();
-		});
+		cancelButton.addActionListener(event -> cancel());
 
 		JButton resetBtn = new JButton(NLS.str("preferences.reset"));
 		resetBtn.addActionListener(event -> {
@@ -107,7 +115,7 @@ public class JadxSettingsWindow extends JDialog {
 
 		JPanel buttonPane = new JPanel();
 		buttonPane.setLayout(new BoxLayout(buttonPane, BoxLayout.LINE_AXIS));
-		buttonPane.setBorder(BorderFactory.createEmptyBorder(0, 10, 10, 10));
+		buttonPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 		buttonPane.add(resetBtn);
 		buttonPane.add(Box.createHorizontalGlue());
 		buttonPane.add(saveBtn);
@@ -120,6 +128,22 @@ public class JadxSettingsWindow extends JDialog {
 		contentPane.add(scrollPane, BorderLayout.CENTER);
 		contentPane.add(buttonPane, BorderLayout.PAGE_END);
 		getRootPane().setDefaultButton(saveBtn);
+
+		KeyStroke strokeEsc = KeyStroke.getKeyStroke("ESCAPE");
+		InputMap inputMap = getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+		inputMap.put(strokeEsc, "ESCAPE");
+		getRootPane().getActionMap().put("ESCAPE", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				cancel();
+			}
+		});
+	}
+
+	private void cancel() {
+		JadxSettingsAdapter.fill(settings, startSettings);
+		mainWindow.loadSettings();
+		dispose();
 	}
 
 	private static void enableComponents(Container container, boolean enable) {


### PR DESCRIPTION
During the last months I had problems with the preferences dialog on my Full-HD monitor on Windows because of it's height:

The button bar at the bottom of the preferences dialog was always shown behind the Windows task bar and therefore inaccessible. I changed the layout to a two-column layout that IMHO fits better to the most monitors.
Additionally the ESC key allows to abort and close the preferences dialog.