### PR TITLE
Use env %JAVA_HOME% as the JrePath

### DIFF
--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -70,6 +70,7 @@ launch4j {
 	maxHeapSize = 4096
 	maxHeapPercent = 70
 	downloadUrl = 'https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=hotspot#x64_win'
+	bundledJrePath = '%JAVA_HOME%'
 }
 
 test {


### PR DESCRIPTION
In this way, people can execute jadx-gui-1.1.0-no-jre.exe easily.  
@see Respect JAVA_HOME environment variable in Windows intead of Windows Registry #890