### PR TITLE
Run indexJob before rename

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/CommonSearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/CommonSearchDialog.java
@@ -516,17 +516,15 @@ public abstract class CommonSearchDialog extends JDialog {
 		}
 	}
 
-	protected void loadStartCommon() {
+	private void loadStartCommon() {
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 		progressPane.setIndeterminate(true);
 		progressPane.setVisible(true);
-		resultsTable.setEnabled(false);
 		warnLabel.setVisible(false);
 	}
 
 	private void loadFinishedCommon() {
 		setCursor(null);
-		resultsTable.setEnabled(true);
 		progressPane.setVisible(false);
 
 		TextSearchIndex textIndex = cache.getTextIndex();

--- a/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
@@ -282,11 +282,13 @@ public class SearchDialog extends CommonSearchDialog {
 
 	@Override
 	protected void loadFinished() {
+		resultsTable.setEnabled(true);
 		searchField.setEnabled(true);
 	}
 
 	@Override
 	protected void loadStart() {
+		resultsTable.setEnabled(false);
 		searchField.setEnabled(false);
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/UsageDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/UsageDialog.java
@@ -30,12 +30,13 @@ public class UsageDialog extends CommonSearchDialog {
 
 	@Override
 	protected void loadFinished() {
+		resultsTable.setEnabled(true);
 		performSearch();
 	}
 
 	@Override
 	protected void loadStart() {
-		// no op
+		resultsTable.setEnabled(false);
 	}
 
 	@Override


### PR DESCRIPTION
The `Rename` function needs `usageInfo` to change all the references of the name changed. We need to make sure `indexJob` has completed before `Rename`.
Fix #907.