### PR TITLE
XML parsing: handling of TYPE_DYNAMIC_REFERENCE entries

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
@@ -48,6 +48,18 @@ public class ParserConstants {
 	protected static final int TYPE_DIMENSION = 0x05;
 	// The 'data' holds a complex number encoding a fraction of a container.
 	protected static final int TYPE_FRACTION = 0x06;
+
+	/**
+	 * The 'data' holds a dynamic reference, a reference to another resource table entry.
+	 * See https://github.com/skylot/jadx/issues/919
+	 */
+	protected static final int TYPE_DYNAMIC_REFERENCE = 0x07;
+
+	/**
+	 * According to the sources of apktool this type seem to be related to themes
+	 * See https://github.com/skylot/jadx/issues/919
+	 */
+	protected static final int TYPE_DYNAMIC_ATTRIBUTE = 0x08;
 	// Beginning of integer flavors...
 	protected static final int TYPE_FIRST_INT = 0x10;
 	// The 'data' is a raw integer value of the form n..n.

--- a/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
@@ -100,6 +100,7 @@ public class ValuesParser extends ParserConstants {
 			case TYPE_INT_COLOR_RGB4:
 				return String.format("#%03x", data & 0xFFF);
 
+			case TYPE_DYNAMIC_REFERENCE:
 			case TYPE_REFERENCE: {
 				String ri = resMap.get(data);
 				if (ri == null) {
@@ -131,6 +132,9 @@ public class ValuesParser extends ParserConstants {
 				return decodeComplex(data, false);
 			case TYPE_FRACTION:
 				return decodeComplex(data, true);
+			case TYPE_DYNAMIC_ATTRIBUTE:
+				LOG.warn("Data type TYPE_DYNAMIC_ATTRIBUTE not yet supported: {}", data);
+				return "  TYPE_DYNAMIC_ATTRIBUTE: " + data;
 
 			default:
 				LOG.warn("Unknown data type: 0x{} {}", Integer.toHexString(dataType), data);


### PR DESCRIPTION
A first attempt to fix #919

In the end `TYPE_DYNAMIC_REFERENCE` seem to work identical to `TYPE_REFERENCE`. Not sure if Jadx already resolves those resources and therefore we don't have to make a difference...

The type `TYPE_DYNAMIC_ATTRIBUTE` has been added, but resources of that type can't be processed yet. An example APK would be helpful for this type. 