### PR TITLE
chore(core): resource XML generation for parent attribute added

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -17,6 +17,7 @@ import jadx.core.xmlgen.entry.ResourceEntry;
 import jadx.core.xmlgen.entry.ValuesParser;
 
 import static jadx.core.xmlgen.ParserConstants.PLURALS_MAP;
+import static jadx.core.xmlgen.ParserConstants.TYPE_REFERENCE;
 
 public class ResXmlGen {
 
@@ -85,10 +86,16 @@ public class ResXmlGen {
 				if (formatValue != null) {
 					cw.add("\" format=\"").add(formatValue);
 				}
-				cw.add("\">");
+				cw.add("\"");
 			} else {
-				cw.add("name=\"").add(ri.getKeyName()).add("\">");
+				cw.add("name=\"").add(ri.getKeyName()).add('\"');
 			}
+			if (ri.getParentRef() != 0) {
+				String parent = vp.decodeValue(TYPE_REFERENCE, ri.getParentRef());
+				cw.add(" parent=\"").add(parent).add('\"');
+			}
+			cw.add(">");
+
 			cw.incIndent();
 			for (RawNamedValue value : ri.getNamedValues()) {
 				addItem(cw, itemTag, ri.getTypeName(), value);


### PR DESCRIPTION
This PR added the missing functionality identified in #931 

@skylot I am not sure why but I had some serious problems with the `gradlew check -x test` test. Unless I make a clean before executing this the test very often fails because of format violations in the `:spotlessMisc` test for the files `jadx-cli\build\reports\checkstyle\*.xml` (e.g. main.xml). 

I am not sure if the test is designed to also include the build directory (hence generated files), I would have assumed it is only for checking src files. Is it possible to exclude the build directories from code style tests?