### PR TITLE
gui: RenameDialog: Warn user if deobfuscation settings are invalid.

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
@@ -31,6 +31,7 @@ import jadx.core.utils.files.InputFile;
 import jadx.gui.jobs.IndexJob;
 import jadx.gui.jobs.RefreshJob;
 import jadx.gui.jobs.UnloadJob;
+import jadx.gui.settings.JadxSettings;
 import jadx.gui.treemodel.JClass;
 import jadx.gui.treemodel.JField;
 import jadx.gui.treemodel.JMethod;
@@ -39,10 +40,7 @@ import jadx.gui.treemodel.JPackage;
 import jadx.gui.ui.codearea.ClassCodeContentPanel;
 import jadx.gui.ui.codearea.CodeArea;
 import jadx.gui.ui.codearea.CodePanel;
-import jadx.gui.utils.CacheObject;
-import jadx.gui.utils.CodeUsageInfo;
-import jadx.gui.utils.NLS;
-import jadx.gui.utils.TextStandardActions;
+import jadx.gui.utils.*;
 
 public class RenameDialog extends JDialog {
 	private static final long serialVersionUID = -3269715644416902410L;
@@ -62,8 +60,39 @@ public class RenameDialog extends JDialog {
 		mainWindow = codeArea.getMainWindow();
 		this.codeArea = codeArea;
 		this.node = node;
-		initUI();
-		loadWindowPos();
+		if (isDeobfuscationSettingsValid()) {
+			initUI();
+			loadWindowPos();
+		} else {
+			LOG.error("Deobfuscation settings are invalid - please enable deobfuscation and disable force rewrite deobfuscation map");
+		}
+	}
+
+	private boolean isDeobfuscationSettingsValid() {
+		boolean valid = true;
+		String errorMessage = null;
+		JadxSettings settings = mainWindow.getSettings();
+		final LangLocale langLocale = settings.getLangLocale();
+		if (settings.isDeobfuscationForceSave()) {
+			valid = false;
+			errorMessage = NLS.str("msg.rename_disabled_force_rewrite_enabled", langLocale);
+		}
+		if (!settings.isDeobfuscationOn()) {
+			valid = false;
+			errorMessage = NLS.str("msg.rename_disabled_deobfuscation_disabled", langLocale);
+		}
+		if (errorMessage != null) {
+			showRenameDisabledErrorMessage(langLocale, errorMessage);
+		}
+		return valid;
+	}
+
+	private void showRenameDisabledErrorMessage(LangLocale langLocale, String message) {
+		JOptionPane.showMessageDialog(
+				mainWindow,
+				message,
+				NLS.str("msg.rename_disabled_title", langLocale),
+				JOptionPane.ERROR_MESSAGE);
 	}
 
 	private void loadWindowPos() {

--- a/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
@@ -131,6 +131,7 @@ public class RenameDialog extends JDialog {
 		fileOut.close();
 		File oldMap = File.createTempFile("deobf_bak_", ".txt");
 		Files.copy(deobfMapPath, oldMap.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		LOG.trace("Copying " + tmpFile.toPath() + " to " + deobfMapPath);
 		Files.copy(tmpFile.toPath(), deobfMapPath, StandardCopyOption.REPLACE_EXISTING);
 		Files.delete(oldMap.toPath());
 		Files.delete(tmpFile.toPath());
@@ -143,6 +144,7 @@ public class RenameDialog extends JDialog {
 	}
 
 	private List<String> updateDeobfMap(List<String> deobfMap, String alias) {
+		LOG.trace("updateDeobfMap(): alias = " + alias);
 		String id = alias.split("=")[0];
 		int i = 0;
 		while (i < deobfMap.size()) {
@@ -153,6 +155,7 @@ public class RenameDialog extends JDialog {
 				i++;
 			}
 		}
+		LOG.trace("updateDeobfMap(): Placing alias = " + alias);
 		deobfMap.add(alias);
 		return deobfMap;
 	}
@@ -170,6 +173,7 @@ public class RenameDialog extends JDialog {
 			return;
 		}
 		if (!refreshDeobfMapFile(renameText, root)) {
+			LOG.error("rename(): refreshDeobfMapFile() failed!");
 			dispose();
 			return;
 		}

--- a/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
@@ -190,7 +190,6 @@ public class RenameDialog extends JDialog {
 			deobfMap = readDeobfMap(deobfMapPath);
 		} catch (IOException e) {
 			LOG.error("rename(): readDeobfMap() failed");
-			dispose();
 			return false;
 		}
 		updateDeobfMap(deobfMap, getNodeAlias(renameText));
@@ -198,14 +197,6 @@ public class RenameDialog extends JDialog {
 			writeDeobfMapFile(deobfMapPath, deobfMap);
 		} catch (IOException e) {
 			LOG.error("rename(): writeDeobfMap() failed");
-			dispose();
-			return false;
-		}
-		try {
-			writeDeobfMapFile(deobfMapPath, deobfMap);
-		} catch (IOException e) {
-			LOG.error("rename(): updateDeobfMap() failed");
-			dispose();
 			return false;
 		}
 		return true;

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -138,6 +138,8 @@ msg.project_error_title=Fehler
 msg.project_error=Projekt konnte nicht geladen werden
 msg.rename_disabled_title=Umbenennen deaktiviert
 msg.rename_disabled=Einige der Umbenennungseinstellungen sind deaktiviert, bitte beachten Sie dies.
+msg.rename_disabled_force_rewrite_enabled=Deaktivieren Sie zum Umbenennen die Option "Deobfuscationskartendatei umschreiben erzwingen".
+msg.rename_disabled_deobfuscation_disabled=Bitte aktivieren Sie die Umbenennung von Deobfuscation.
 msg.cmd_select_class_error=Klasse\n%s auswählen nicht möglich\nSie existiert nicht.
 
 popup.undo=Rückgängig

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -138,6 +138,8 @@ msg.project_error_title=Error
 msg.project_error=Project could not be loaded
 msg.rename_disabled_title=Rename disabled
 msg.rename_disabled=Some of rename settings are disabled, please take this into consideration
+msg.rename_disabled_force_rewrite_enabled=Please disable "Force rewrite deobfuscation map file" option to rename.
+msg.rename_disabled_deobfuscation_disabled=Please enable deobfuscation to rename.
 msg.cmd_select_class_error=Failed to select the class\n%s\nThe class does not exist.
 
 popup.undo=Undo

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -138,6 +138,8 @@ msg.index_not_initialized=Índice no inicializado, ¡la bósqueda se desactivar�
 #msg.project_error=
 #msg.rename_disabled_title=
 #msg.rename_disabled=
+#msg.rename_disabled_force_rewrite_enabled=
+#msg.rename_disabled_deobfuscation_disabled=
 #msg.cmd_select_class_error=
 
 popup.undo=Deshacer

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -138,6 +138,8 @@ msg.project_error_title=错误
 msg.project_error=项目无法加载
 msg.rename_disabled_title=重命名已禁用
 msg.rename_disabled=某些重命名设置已禁用，请将此考虑在内
+msg.rename_disabled_force_rewrite_enabled=请禁用“强制覆盖反重构映射文件”选项以重命名。
+msg.rename_disabled_deobfuscation_disabled=请启用反混淆以重命名。
 msg.cmd_select_class_error=无法选择类\n%s\n该类不存在。
 
 popup.undo=撤销


### PR DESCRIPTION
:exclamation: Please review the [guidelines for contributing](https://github.com/skylot/jadx/blob/master/CONTRIBUTING.md#Pull-Request-Process)
Done.

### Description
    
The rename functionality relies on deobfuscation for now - so let the user know
this and ask the user to enable deobfuscation to get rename working.

The "Force rewrite deobfuscation map file" option effectively disables
renaming, because renaming relies on deobfuscation map modification for now,
but Force rewrite rewrites the map on each file reload, destroying changes.
So. let the user know this issue instead of silent failure.

TODO: Split rename map and deobfuscation map (for example, load the rename map
file after deobfuscation map file to override auto-generated aliases).

