### PR TITLE
fix (gui): launch4j maximum heap

### DIFF
--- a/jadx-gui/build.gradle
+++ b/jadx-gui/build.gradle
@@ -66,6 +66,7 @@ launch4j {
 	jreMinVersion = '1.8.0'
 	jvmOptions = ['-Dawt.useSystemAAFontSettings=lcd', '-Dswing.aatext=true', '-XX:+UseG1GC']
 	jreRuntimeBits = "64"
+	bundledJre64Bit = true
 	initialHeapPercent = 5
 	maxHeapSize = 4096
 	maxHeapPercent = 70


### PR DESCRIPTION
As described at the end of #949 launch4j exe startup wrapper does not apply maximum heap configuration correctly. This PR fixes the problem.