### PR TITLE
Update Messages_zh_CN.properties

### DIFF
--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -72,7 +72,7 @@ search_dialog.options=搜索选项：
 search_dialog.ignorecase=忽略大小写
 search_dialog.next_page=下一页
 search_dialog.prev_page=上一页
-search_dialog.info_label=显示了 %3$d 个结果中的第 %1$d 至第 %3$d 个
+search_dialog.info_label=显示了 %3$d 个结果中的第 %1$d 至第 %2$d 个
 search_dialog.col_node=节点
 search_dialog.col_code=代码
 


### PR DESCRIPTION
modifying error of positional argument in Chinese search result text

### Description
The second positional argument is mistakenly set to the third one in Chinese text