### PR TITLE
fix(gui): use correct charset when writing mapping file

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
@@ -137,8 +137,8 @@ public class RenameDialog extends JDialog {
 		File tmpFile = File.createTempFile("deobf_tmp_", ".txt");
 		try (FileOutputStream fileOut = new FileOutputStream(tmpFile)) {
 			for (String entry : deobfMap) {
-				fileOut.write(entry.getBytes());
-				fileOut.write(System.lineSeparator().getBytes());
+				fileOut.write(entry.getBytes(StandardCharsets.UTF_8));
+				fileOut.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
 			}
 		}
 		File oldMap = File.createTempFile("deobf_bak_", ".txt");


### PR DESCRIPTION
:exclamation: Please review the [guidelines for contributing](https://github.com/skylot/jadx/blob/master/CONTRIBUTING.md#Pull-Request-Process)

### Description
On Windows, the default charset depends on system settings 🤕 
