### PR TITLE
Only show renaming option for JClass, JField and JMethod

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -88,7 +88,9 @@ import jadx.gui.settings.JadxSettings;
 import jadx.gui.settings.JadxSettingsWindow;
 import jadx.gui.treemodel.ApkSignature;
 import jadx.gui.treemodel.JClass;
+import jadx.gui.treemodel.JField;
 import jadx.gui.treemodel.JLoadableNode;
+import jadx.gui.treemodel.JMethod;
 import jadx.gui.treemodel.JNode;
 import jadx.gui.treemodel.JPackage;
 import jadx.gui.treemodel.JResource;
@@ -614,7 +616,7 @@ public class MainWindow extends JFrame {
 		if (obj instanceof JPackage) {
 			JPackagePopupMenu menu = new JPackagePopupMenu(this, (JPackage) obj);
 			menu.show(e.getComponent(), e.getX(), e.getY());
-		} else if (obj != null) {
+		} else if (obj instanceof JClass || obj instanceof JField || obj instanceof JMethod) {
 			JPopupMenu menu = new JPopupMenu();
 			JMenuItem jmi = new JMenuItem(NLS.str("popup.rename"));
 			jmi.addActionListener(action -> rename(obj));


### PR DESCRIPTION
### Description
My previous PR (#993) erroneously used a null-check for determining if the Rename option should be shown. As result, all nodes had the Rename option shown (but of course it does not work for nodes which are not class/method/field instances).
As this is just a quick fix for an issue in my last PR, I don't think it needs an issue attached (If it does, please tell me).

I'm sorry for pushing broken code to the project. In my future contributions I will try to pay more attention to possible regressions, lol.