### PR TITLE
Renames invalid res keys

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
@@ -292,7 +292,7 @@ public class ResTableParser extends CommonBinaryParser {
 		if (renamedKey != null) {
 			return renamedKey;
 		}
-		if (!origKeyName.isEmpty()) {
+		if (origKeyName.matches("[\\w\\d-_.]+")) {
 			return origKeyName;
 		}
 		FieldNode constField = root.getConstValues().getGlobalConstFields().get(resRef);

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,8 @@ import jadx.core.xmlgen.entry.ValuesParser;
 
 public class ResTableParser extends CommonBinaryParser {
 	private static final Logger LOG = LoggerFactory.getLogger(ResTableParser.class);
+
+	private static final Pattern VALID_RES_KEY_PATTERN = Pattern.compile("[\\w\\d-_.]+");
 
 	private static final class PackageChunk {
 		private final int id;
@@ -292,7 +295,7 @@ public class ResTableParser extends CommonBinaryParser {
 		if (renamedKey != null) {
 			return renamedKey;
 		}
-		if (origKeyName.matches("[\\w\\d-_.]+")) {
+		if (VALID_RES_KEY_PATTERN.matcher(origKeyName).matches()) {
 			return origKeyName;
 		}
 		FieldNode constField = root.getConstValues().getGlobalConstFields().get(resRef);


### PR DESCRIPTION
### Description
I've noticed an apk with invalid resource keys. E.g.:

```xml
    <application android:theme="@style/%!" android:label="@string/~{" android:icon="@mipmap/~" android:allowBackup="true" android:supportsRtl="true">
```

```xml
        <PreferenceScreen android:title="@string/!&" android:key="expset" android:summary="@string/~;"/>
```

the last example prevents the XML file from being parsed. 