### PR TITLE
Fixes ns value

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -317,11 +317,10 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		if (ANDROID_NS_URL.equals(attrUrl)) {
 			attrName = ANDROID_NS_VALUE;
 			nsMap.put(ANDROID_NS_URL, attrName);
-		}
-		else {
+		} else {
 			for (int i = 1;; i++) {
 				attrName = "ns" + i;
-				if (!nsMap.containsValue(attrName) && !nsMapGenerated.contains(attrName)) {
+				if (!nsMapGenerated.contains(attrName) && !nsMap.containsValue(attrName)) {
 					nsMapGenerated.add(attrName);
 					// do not add generated value to nsMap
 					// because attrUrl might be used in a neighbor element, but never defined

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -313,17 +313,24 @@ public class BinaryXMLParser extends CommonBinaryParser {
 	}
 
 	private String generateNameForNS(String attrUrl) {
-		for (int i = 1;; i++) {
-			String attrName = "ns" + i;
-			if (!nsMap.containsValue(attrName) && !nsMapGenerated.contains(attrName)) {
-				nsMapGenerated.add(attrName);
-				// do not add generated value to nsMap
-				// because attrUrl might be used in a neighbor element, but never defined
-				writer.add("xmlns:").add(attrName)
-						.add("=\"").add(attrUrl).add("\" ");
-				return attrName;
+		String attrName;
+		if (ANDROID_NS_URL.equals(attrUrl)) {
+			attrName = ANDROID_NS_VALUE;
+			nsMap.put(ANDROID_NS_URL, attrName);
+		}
+		else {
+			for (int i = 1;; i++) {
+				attrName = "ns" + i;
+				if (!nsMap.containsValue(attrName) && !nsMapGenerated.contains(attrName)) {
+					nsMapGenerated.add(attrName);
+					// do not add generated value to nsMap
+					// because attrUrl might be used in a neighbor element, but never defined
+					break;
+				}
 			}
 		}
+		writer.add("xmlns:").add(attrName).add("=\"").add(attrUrl).add("\" ");
+		return attrName;
 	}
 
 	private String getAttributeName(int id) {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
@@ -9,6 +9,7 @@ public class ParserConstants {
 	}
 
 	protected static final String ANDROID_NS_URL = "http://schemas.android.com/apk/res/android";
+	protected static final String ANDROID_NS_VALUE = "android";
 
 	/**
 	 * Chunk types


### PR DESCRIPTION
Hey, I've noticed the following thing in Google Chrome app
```xml
    <uses-permission xmlns:ns17="http://schemas.android.com/apk/res/android" ns17:name="android.permission.CAMERA"/>
    <uses-permission xmlns:ns18="http://schemas.android.com/apk/res/android" ns18:name="android.permission.CHANGE_NETWORK_STATE"/>
    <uses-permission xmlns:ns19="http://schemas.android.com/apk/res/android" ns19:name="android.permission.DOWNLOAD_WITHOUT_NOTIFICATION"/>
    <uses-permission xmlns:ns20="http://schemas.android.com/apk/res/android" ns20:name="android.permission.FOREGROUND_SERVICE"/>
    <uses-permission xmlns:ns21="http://schemas.android.com/apk/res/android" ns21:name="android.permission.GET_ACCOUNTS"/>
    <uses-permission xmlns:ns22="http://schemas.android.com/apk/res/android" ns22:name="android.permission.INTERNET"/>
    <uses-permission xmlns:ns23="http://schemas.android.com/apk/res/android" ns23:name="android.permission.MANAGE_ACCOUNTS"/>
    <uses-permission xmlns:ns24="http://schemas.android.com/apk/res/android" ns24:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
    <uses-permission xmlns:ns25="http://schemas.android.com/apk/res/android" ns25:name="android.permission.NFC"/>
    <uses-permission xmlns:ns26="http://schemas.android.com/apk/res/android" ns26:name="android.permission.READ_EXTERNAL_STORAGE"/>
    <uses-permission xmlns:ns27="http://schemas.android.com/apk/res/android" ns27:name="android.permission.READ_SYNC_SETTINGS"/>
    <uses-permission xmlns:ns28="http://schemas.android.com/apk/res/android" ns28:name="android.permission.READ_SYNC_STATS"/>
    <uses-permission xmlns:ns29="http://schemas.android.com/apk/res/android" ns29:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
    <uses-permission xmlns:ns30="http://schemas.android.com/apk/res/android" ns30:name="android.permission.RECORD_AUDIO"/>
    <uses-permission xmlns:ns31="http://schemas.android.com/apk/res/android" ns31:name="android.permission.USE_CREDENTIALS"/>
```
but some reason the Android namespace declaration is missing in the header, so it's always generating it again and again. I added a check to prevent this