### PR TITLE
Process exception handler when handler block is start of a new try block

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocksmaker/BlockSplitter.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocksmaker/BlockSplitter.java
@@ -113,12 +113,11 @@ public class BlockSplitter extends AbstractVisitor {
 					}
 				}
 			}
+			if (insn.contains(AType.EXC_HANDLER)) {
+				processExceptionHandler(mth, curBlock, insn);
+			}
 			if (insn.contains(AFlag.TRY_ENTER)) {
 				curBlock = insertSplitterBlock(mth, blocksMap, curBlock, insn, startNew);
-			} else if (insn.contains(AType.EXC_HANDLER)) {
-				processExceptionHandler(mth, curBlock, insn);
-				blocksMap.put(insn.getOffset(), curBlock);
-				curBlock.getInstructions().add(insn);
 			} else {
 				blocksMap.put(insn.getOffset(), curBlock);
 				curBlock.getInstructions().add(insn);

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryWithEmptyCatchTriple.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryWithEmptyCatchTriple.java
@@ -1,0 +1,21 @@
+package jadx.tests.integration.trycatch;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.SmaliTest;
+
+import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestTryWithEmptyCatchTriple extends SmaliTest {
+	@Test
+	public void test() {
+		ClassNode cls = getClassNodeFromSmaliWithPkg("trycatch", "TestTryWithEmptyCatchTriple");
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsOne("} catch (Error unused) {"));
+		assertThat(code, containsOne("} catch (Error unused2) {"));
+		assertThat(code, containsOne("} catch (Error unused3) {"));
+	}
+}

--- a/jadx-core/src/test/smali/trycatch/TestTryWithEmptyCatchTriple.smali
+++ b/jadx-core/src/test/smali/trycatch/TestTryWithEmptyCatchTriple.smali
@@ -1,0 +1,53 @@
+.class public Ltrycatch/TestTryWithEmptyCatchTriple;
+.super Ljava/lang/Object;
+
+.field static field:[I
+
+.method static test()V
+    .registers 3
+    const/4 v0, 0x1
+
+    :try_start_1
+    sget-object v1, Ltrycatch/TestTryWithEmptyCatchTriple;->field:[I
+
+    const/4 v2, 0x0
+
+    aput v0, v1, v2
+
+    :try_end_1
+    .catch Ljava/lang/Error; {:try_start_1 .. :try_end_1} :catch_1
+
+    :catch_1
+
+    sget-object v1, Ltrycatch/TestTryWithEmptyCatchTriple;->field:[I
+
+    array-length v1, v1
+
+    new-array v1, v1, [I
+
+    sput-object v1, Ltrycatch/TestTryWithEmptyCatchTriple;->field:[I
+
+    :try_start_2
+    sget-object v1, Ltrycatch/TestTryWithEmptyCatchTriple;->field:[I
+
+    const/4 v2, 0x0
+
+    aput v0, v1, v2
+    :try_end_2
+    .catch Ljava/lang/Error; {:try_start_2 .. :try_end_2} :catch_2
+
+    :catch_2
+    :try_start_3
+    sget-object v0, Ltrycatch/TestTryWithEmptyCatchTriple;->field:[I
+
+    const/4 v1, 0x0
+
+    const/4 v2, 0x2
+
+    aput v2, v0, v1
+    :try_end_3
+    .catch Ljava/lang/Error; {:try_start_3 .. :try_end_3} :catch_3
+
+    :catch_3
+    return-void
+.end method


### PR DESCRIPTION
Note: I have *not* created an issue for this even though you require this in your contribution guidelines, because I already developed a patch for my own use and did not want to duplicate any discussion across the issue and the PR. If necessary I can open a separate issue for this bug.

I found this bug when reverse engineering an app. The test case is obviously modified from the original source, but is still representative of the bug.

While the change makes sense to me – adding the synthetic exception handler block should still be done even when the handler instruction is also a TRY_ENTER, and looking at the graph the handler block is inserted at the correct position – I'd still like someone more familiar with the decompiler to look at the change :) All test cases run fine, but you never know.

With the patch, the code properly decompiles to three try-catch clauses with empty catch blocks. Without the patch, the error from the test case is as follows:

```
11:05:30 DEBUG - Loaded plugin: SmaliInput
11:05:30 DEBUG - Loaded plugin: JavaConvert
11:05:30 DEBUG - Loaded plugin: DexInput
11:05:30 DEBUG - Effective jadx args: JadxArgs{inputFiles=[src/test/smali/trycatch/TestTryWithEmptyCatchTriple.smali], outDir=test-out-tmp, outDirSrc=test-out-tmp/sources, outDirRes=test-out-tmp/resources, threadsCount=1, cfgOutput=false, rawCFGOutput=false, fallbackMode=false, showInconsistentCode=true, useImports=true, skipResources=true, skipSources=false, deobfuscationOn=false, deobfuscationForceSave=false, useSourceNameAsClassAlias=false, parseKotlinMetadata=false, deobfuscationMinLength=0, deobfuscationMaxLength=2147483647, escapeUnicode=false, replaceConsts=true, respectBytecodeAccModifiers=false, exportAsGradleProject=false, fsCaseSensitive=false, renameFlags=[CASE, VALID, PRINTABLE], outputFormat=JAVA, codeCache=InMemoryCodeCache}
11:05:30 INFO  - loading ...
11:05:31 DEBUG - Loading dex: /tmp/jadx-5776836765237836553.dex
11:05:31 DEBUG - Classes loaded: 1
11:05:31 DEBUG - Clst file loaded in 71ms, classes: 4750, methods: 11879
11:05:31 DEBUG - '.arsc' file not found
11:05:31 DEBUG - Dependency collection done in 16ms
11:05:31 WARN  - Missing exception handler attribute for start block: B:7:0x0012 in method: trycatch.TestTryWithEmptyCatchTriple.test():void, file: /tmp/jadx-5776836765237836553.dex
11:05:31 WARN  - Failed to process nested try/catch in method: trycatch.TestTryWithEmptyCatchTriple.test():void, file: /tmp/jadx-5776836765237836553.dex
-----------------------------------------------------------
package trycatch;

public class TestTryWithEmptyCatchTriple {
    static int[] field;

    /* JADX WARNING: Failed to process nested try/catch */
    /* JADX WARNING: Missing exception handler attribute for start block: B:7:0x0012 */
    static void test() {
        try {
            field[0] = 1;
        } catch (Error unused) {
        }
        field = new int[field.length];
        field[0] = 1;
        try {
            field[0] = 2;
        } catch (Error unused2) {
        }
    }
}
-----------------------------------------------------------

Method with problems: trycatch.TestTryWithEmptyCatchTriple.test():void
 Missing exception handler attribute for start block: B:7:0x0012
Failed to process nested try/catch
 INLINE_NOT_NEEDED
org.opentest4j.AssertionFailedError: Method with problems: trycatch.TestTryWithEmptyCatchTriple.test():void
 Missing exception handler attribute for start block: B:7:0x0012
Failed to process nested try/catch
 INLINE_NOT_NEEDED
	at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:39)
	at org.junit.jupiter.api.Assertions.fail(Assertions.java:117)
	at jadx.tests.api.IntegrationTest.checkCode(IntegrationTest.java:255)
	at java.base/java.util.Collections$SingletonList.forEach(Collections.java:4933)
	at jadx.tests.api.IntegrationTest.decompileAndCheck(IntegrationTest.java:210)
	at jadx.tests.api.IntegrationTest.getClassNodeFromFiles(IntegrationTest.java:160)
	at jadx.tests.api.SmaliTest.getClassNodeFromSmali(SmaliTest.java:26)
	at jadx.tests.api.SmaliTest.getClassNodeFromSmaliWithPkg(SmaliTest.java:45)
	at jadx.tests.integration.trycatch.TestTryWithEmptyCatchTriple.test(TestTryWithEmptyCatchTriple.java:14)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:210)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:206)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:131)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:65)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:143)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:129)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:127)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:126)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:84)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:99)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:79)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:75)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy5.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.stop(TestWorker.java:133)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.base/java.lang.Thread.run(Thread.java:832)

jadx.tests.integration.trycatch.TestTryWithEmptyCatchTriple > test() FAILED
    org.opentest4j.AssertionFailedError at TestTryWithEmptyCatchTriple.java:14
```