### PR TITLE
fix: properly traverse methods with synchronize blocks that have no clear exit

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/regions/RegionMaker.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/regions/RegionMaker.java
@@ -594,6 +594,8 @@ public class RegionMaker {
 				List<BlockNode> list = BlockUtils.buildSimplePath(exitBlock);
 				if (list.isEmpty() || !list.get(list.size() - 1).getSuccessors().isEmpty()) {
 					stack.addExit(exitBlock);
+					// we can still try using this as an exit block to make sure it's visited.
+					exit = exitBlock;
 				}
 			}
 		}

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestSynchronizedInEndlessLoop.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestSynchronizedInEndlessLoop.java
@@ -2,7 +2,6 @@ package jadx.tests.integration.loops;
 
 import org.junit.jupiter.api.Test;
 
-import jadx.NotYetImplemented;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.tests.api.IntegrationTest;
 
@@ -34,7 +33,6 @@ public class TestSynchronizedInEndlessLoop extends IntegrationTest {
 	}
 
 	@Test
-	@NotYetImplemented
 	public void test() {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();

--- a/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized5.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/synchronize/TestSynchronized5.java
@@ -1,0 +1,20 @@
+package jadx.tests.integration.synchronize;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.SmaliTest;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestSynchronized5 extends SmaliTest {
+	@Test
+	public void test() {
+		ClassNode cls = getClassNodeFromSmali();
+		String code = cls.getCode().toString();
+
+		assertThat(code, containsString("1 != 0"));
+		assertThat(code, containsString("System.gc();"));
+	}
+}

--- a/jadx-core/src/test/smali/synchronize/TestSynchronized5.smali
+++ b/jadx-core/src/test/smali/synchronize/TestSynchronized5.smali
@@ -1,0 +1,62 @@
+.class public Lsynchronize/TestSynchronized5;
+.super Ljava/lang/Object;
+
+.method public final get()V
+    .registers 6
+
+    monitor-enter p0
+
+    :try_start_1
+
+    const/4 v0, 0
+
+    if-eqz v0, :cond_1
+
+    monitor-exit p0
+
+    return-void
+
+    :cond_1
+
+    monitor-exit p0
+    :try_end_1
+    .catchall {:try_start_1 .. :try_end_1} :catchall_1
+
+    monitor-enter p0
+
+    :try_start_2
+
+    const/4 v1, 1
+
+    if-eqz v1, :cond_2
+
+    invoke-static {}, Ljava/lang/System;->gc()V
+
+    :cond_2
+
+    monitor-exit p0
+    :try_end_2
+    .catchall {:try_start_2 .. :try_end_2} :catchall_2
+
+    return-void
+
+    :catchall_2
+    move-exception v0
+
+    :try_start_3
+    monitor-exit p0
+    :try_end_3
+    .catchall {:try_start_3 .. :try_end_3} :catchall_2
+
+    throw v0
+
+    :catchall_1
+    move-exception v0
+
+    :try_start_4
+    monitor-exit p0
+    :try_end_4
+    .catchall {:try_start_4 .. :try_end_4} :catchall_1
+
+    throw v0
+.end method


### PR DESCRIPTION
This issue appears to come from a difference in understanding of what a synchronized block exit is between `traverseMonitorExitsCross` and the later multi-exit handling in `processMonitorEnter`. 

In this test case, there are two paths out of the first synchronized block: One through a return-void, and one that is more complex and continues into the method. The return-void path is simple enough that it can be pulled into the synchronized block so this *can* be decompiled correctly. However, `traverseMonitorExitsCross` still attempts to find a common cross point between both exits, which fails. 

At that point, no single exit is known (the exit local variable in `processMonitorEnter` is null). In that method, this is not an issue: The fallback handling below recognizes that the return-void path is too simple to be added to the stack as an exit, so the stack looks good. However, the `exit` local variable is never set, thus `null` is returned. This leads to the `traverse` loop that initiated the processing of the block in the first place terminating. The code after the synchronized block is never processed, which leads to "missing block" errors:

```
20:47:08 WARN  - Code restructure failed: missing block: B:7:0x0007, code lost:
    monitor-enter(r5);
 in method: synchronize.TestSynchronized5.get():void, file: /tmp/jadx-14744901629462858150.dex
20:47:08 WARN  - Code restructure failed: missing block: B:9:0x0009, code lost:
    if (1 == 0) goto L_0x000e;
 in method: synchronize.TestSynchronized5.get():void, file: /tmp/jadx-14744901629462858150.dex
20:47:08 WARN  - Code restructure failed: missing block: B:11:?, code lost:
    java.lang.System.gc();
 in method: synchronize.TestSynchronized5.get():void, file: /tmp/jadx-14744901629462858150.dex
20:47:08 WARN  - Code restructure failed: missing block: B:12:0x000e, code lost:
    monitor-exit(r5);
 in method: synchronize.TestSynchronized5.get():void, file: /tmp/jadx-14744901629462858150.dex
20:47:08 WARN  - Code restructure failed: missing block: B:13:0x000f, code lost:
    return;
 in method: synchronize.TestSynchronized5.get():void, file: /tmp/jadx-14744901629462858150.dex
-----------------------------------------------------------
package synchronize;

public class TestSynchronized5 {
    /* JADX WARNING: Code restructure failed: missing block: B:11:?, code lost:
        java.lang.System.gc();
     */
    /* JADX WARNING: Code restructure failed: missing block: B:12:0x000e, code lost:
        monitor-exit(r5);
     */
    /* JADX WARNING: Code restructure failed: missing block: B:13:0x000f, code lost:
        return;
     */
    /* JADX WARNING: Code restructure failed: missing block: B:7:0x0007, code lost:
        monitor-enter(r5);
     */
    /* JADX WARNING: Code restructure failed: missing block: B:9:0x0009, code lost:
        if (1 == 0) goto L_0x000e;
     */
    public final void get() {
        synchronized (this) {
            if (0 != 0) {
            }
        }
    }
}
-----------------------------------------------------------

Method with problems: synchronize.TestSynchronized5.get():void
 Code restructure failed: missing block: B:7:0x0007, code lost:
    monitor-enter(r5);

Code restructure failed: missing block: B:9:0x0009, code lost:
    if (1 == 0) goto L_0x000e;

Code restructure failed: missing block: B:11:?, code lost:
    java.lang.System.gc();

Code restructure failed: missing block: B:12:0x000e, code lost:
    monitor-exit(r5);

Code restructure failed: missing block: B:13:0x000f, code lost:
    return;

 INLINE_NOT_NEEDED
org.opentest4j.AssertionFailedError: Method with problems: synchronize.TestSynchronized5.get():void
 Code restructure failed: missing block: B:7:0x0007, code lost:
    monitor-enter(r5);

Code restructure failed: missing block: B:9:0x0009, code lost:
    if (1 == 0) goto L_0x000e;

Code restructure failed: missing block: B:11:?, code lost:
    java.lang.System.gc();

Code restructure failed: missing block: B:12:0x000e, code lost:
    monitor-exit(r5);

Code restructure failed: missing block: B:13:0x000f, code lost:
    return;
```

This fix is very simple: if no single exit is known from `traverseMonitorExitsCross`, `processMonitorEnter` now returns *one of* the non-trivial candidate exits. For the test case, this leads to correct behavior. It is possible that there may be cases where there are even more exit blocks, with more than one of them meeting the "non-trivial" criterium (`buildSimplePath(exit).last.successors.isNotEmpty`), in which case only one of them would be returned. There is no check for this case, since I believe that this might still decompile correctly in some cases and should lead to downstream errors in the other cases (thoughts?).

This change also appears to have fixed TestSynchronizedInEndlessLoop, though I did not look at that test case in detail.