### PR TITLE
fix: do not remove method start block when it is referenced from dead code

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocksmaker/BlockSplitter.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocksmaker/BlockSplitter.java
@@ -339,7 +339,7 @@ public class BlockSplitter extends AbstractVisitor {
 		Set<BlockNode> toRemove = new LinkedHashSet<>();
 		for (BlockNode block : mth.getBasicBlocks()) {
 			if (block.getPredecessors().isEmpty() && block != mth.getEnterBlock()) {
-				collectSuccessors(block, toRemove);
+				collectSuccessors(block, mth.getEnterBlock(), toRemove);
 			}
 		}
 		if (toRemove.isEmpty()) {
@@ -390,7 +390,7 @@ public class BlockSplitter extends AbstractVisitor {
 				&& !block.contains(AFlag.MTH_ENTER_BLOCK);
 	}
 
-	private static void collectSuccessors(BlockNode startBlock, Set<BlockNode> toRemove) {
+	private static void collectSuccessors(BlockNode startBlock, BlockNode methodEnterBlock, Set<BlockNode> toRemove) {
 		Deque<BlockNode> stack = new ArrayDeque<>();
 		stack.add(startBlock);
 		while (!stack.isEmpty()) {
@@ -398,7 +398,7 @@ public class BlockSplitter extends AbstractVisitor {
 			if (!toRemove.contains(block)) {
 				toRemove.add(block);
 				for (BlockNode successor : block.getSuccessors()) {
-					if (toRemove.containsAll(successor.getPredecessors())) {
+					if (successor != methodEnterBlock && toRemove.containsAll(successor.getPredecessors())) {
 						stack.push(successor);
 					}
 				}

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestDeadBlockReferencesStart.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestDeadBlockReferencesStart.java
@@ -1,0 +1,16 @@
+package jadx.tests.integration.others;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.SmaliTest;
+
+import static jadx.tests.api.utils.JadxMatchers.countString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestDeadBlockReferencesStart extends SmaliTest {
+	@Test
+	public void test() {
+		String code = getClassNodeFromSmali().getCode().getCodeStr();
+		assertThat(code, countString(0, "throw"));
+	}
+}

--- a/jadx-core/src/test/smali/others/TestDeadBlockReferencesStart.smali
+++ b/jadx-core/src/test/smali/others/TestDeadBlockReferencesStart.smali
@@ -1,0 +1,11 @@
+.class Lothers/TestDeadBlockReferencesStart;
+.super Ljava/lang/Object;
+
+.method public test()V
+    .registers 6
+
+     :start
+     return-void
+
+     goto :start
+.end method


### PR DESCRIPTION
The old code would ignore the entry block for the first pass of dead code removal but would still remove that block if it was referenced by another dead block, because the entry block has no predecessors.

This patch solves the immediate problem, but I'm not convinced by this approach to dead code elimination. I'm not sure it works reliably for complicated dead code structures. Maybe a tracing GC algorithm would be better? Tracing all the blocks that *are* reachable from the entry node instead of trying to determine which blocks are not. This should be possible in O(n).