### PR TITLE
fix: preserve original method details in inlined invocation

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/InlineMethods.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/InlineMethods.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jadx.core.dex.attributes.AFlag;
+import jadx.core.dex.attributes.AType;
 import jadx.core.dex.attributes.nodes.MethodInlineAttr;
 import jadx.core.dex.info.MethodInfo;
 import jadx.core.dex.instructions.InsnType;
@@ -16,6 +17,7 @@ import jadx.core.dex.instructions.args.InsnArg;
 import jadx.core.dex.instructions.args.RegisterArg;
 import jadx.core.dex.instructions.args.SSAVar;
 import jadx.core.dex.nodes.BlockNode;
+import jadx.core.dex.nodes.IMethodDetails;
 import jadx.core.dex.nodes.InsnNode;
 import jadx.core.dex.nodes.MethodNode;
 import jadx.core.dex.visitors.typeinference.TypeInferenceVisitor;
@@ -103,8 +105,13 @@ public class InlineMethods extends AbstractVisitor {
 				}
 			}
 		}
+		IMethodDetails methodDetailsAttr = inlCopy.get(AType.METHOD_DETAILS);
 		if (!BlockUtils.replaceInsn(mth, block, insn, inlCopy)) {
 			mth.addWarnComment("Failed to inline method: " + callMth);
+		}
+		// replaceInsn replaces the attributes as well, make sure to preserve METHOD_DETAILS
+		if (methodDetailsAttr != null) {
+			inlCopy.addAttr(methodDetailsAttr);
 		}
 	}
 

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestCastInOverloadedAccessor.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestCastInOverloadedAccessor.java
@@ -1,0 +1,41 @@
+package jadx.tests.integration.invoke;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.SmaliTest;
+
+import static jadx.tests.api.utils.JadxMatchers.containsOne;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestCastInOverloadedAccessor extends SmaliTest {
+	static class X {
+		void test() {
+			new Runnable() {
+				@Override
+				public void run() {
+					outerMethod("");
+					outerMethod("", "");
+				}
+			};
+		}
+
+		private void outerMethod(String s) {
+		}
+
+		private void outerMethod(String s, String t) {
+		}
+
+		private void outerMethod(int a) {
+		}
+
+		private void outerMethod(int a, int b) {
+		}
+	}
+
+	@Test
+	public void test() {
+		String code = getClassNode(X.class).getCode().getCodeStr();
+		assertThat(code, containsOne("outerMethod(\"\")"));
+		assertThat(code, containsOne("outerMethod(\"\", \"\")"));
+	}
+}


### PR DESCRIPTION
`replaceInsn` copies the attributes from the replaced instruction to the new instruction. This included the `METHOD_DETAILS` attribute. For synthetic accessor methods used for accessing private methods of outer classes, this gives an invoke node that calls the outer method but has a `METHOD_DETAILS` attribute for the synthetic accessor method.

Because of this dissonance, overload processing further downstream would use the method details for the synthetic accessor to process overloads of the normal outer class method. The synthetic accessor includes an additional leading argument: the `Outer.this` argument. In overload processing, this argument would be resolved when it shouldn't be, leading to a cast to the outer class type being inserted for the first argument (i.e. the casts appear one position to the right in the argument list of where they should be).

In the test case added in this PR, this bug would manifest as the decompilation `outerMethod((X.this) "");` and `outerMethod((X.this) "", (String) "");` respectively.

With this fix, the `METHOD_DETAILS` are preserved during inlining. This ensures that the invariant that the method detail attribute matches the actual method called by the invoke is maintained.