### PR TITLE
Renaming causes various concurrency issues

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/utils/search/CodeIndex.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/search/CodeIndex.java
@@ -23,7 +23,7 @@ public class CodeIndex {
 		values.add(value);
 	}
 
-	public void removeForCls(JavaClass cls) {
+	public synchronized void removeForCls(JavaClass cls) {
 		values.removeIf(v -> v.getJavaNode().getTopParentClass().equals(cls));
 	}
 


### PR DESCRIPTION
fix: prevent NullPointerException and ConcurrentModificationException when renaming something

Unfortunately even after this fix renaming still doesn't work for me (tried to rename a method of an Interface). With this fix no error is shown, just the renaming does not happen.