### PR TITLE
fix: do not show empty RenameDialog

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/JPackagePopupMenu.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/JPackagePopupMenu.java
@@ -79,7 +79,7 @@ class JPackagePopupMenu extends JPopupMenu {
 
 	private void rename(JPackage pkg) {
 		LOG.debug("Renaming package: fullName={}, name={}", pkg.getFullName(), pkg.getName());
-		new RenameDialog(mainWindow, pkg).setVisible(true);
+		RenameDialog.rename(mainWindow, pkg);
 	}
 
 	private List<String> splitPackage(String rawPackage) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -655,8 +655,7 @@ public class MainWindow extends JFrame {
 	}
 
 	private void rename(JNode node) {
-		RenameDialog renameDialog = new RenameDialog(this, node);
-		renameDialog.setVisible(true);
+		RenameDialog.rename(this, node);
 	}
 
 	private void treeRightClickAction(MouseEvent e) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
@@ -33,8 +33,7 @@ public final class RenameAction extends JNodeMenuAction<JNode> {
 			LOG.info("node == null!");
 			return;
 		}
-		RenameDialog renameDialog = new RenameDialog(codeArea.getMainWindow(), node);
-		renameDialog.setVisible(true);
+		RenameDialog.rename(codeArea.getMainWindow(), node);
 	}
 
 	@Nullable


### PR DESCRIPTION
If DeobfuscationForceSave settings is enabled the RenameDialog shows a dialog and asks the user to change this setting. 
If the user denies the change the rename dialog is still shown, but without title and any control. 