### PR TITLE
fix: elemSize=0 fill_array_data_payload insn obfuscation

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/instructions/FillArrayData.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/FillArrayData.java
@@ -39,6 +39,7 @@ public final class FillArrayData extends InsnNode {
 	private static ArgType getElementType(int elementWidthUnit) {
 		switch (elementWidthUnit) {
 			case 1:
+			case 0:
 				return ONE_BYTE_TYPE;
 			case 2:
 				return TWO_BYTES_TYPE;

--- a/jadx-plugins/jadx-dex-input/src/main/java/jadx/plugins/input/dex/insns/DexInsnFormat.java
+++ b/jadx-plugins/jadx-dex-input/src/main/java/jadx/plugins/input/dex/insns/DexInsnFormat.java
@@ -336,6 +336,10 @@ public abstract class DexInsnFormat {
 					data = array;
 					break;
 				}
+				case 0: {
+					data = new byte[0];
+					break;
+				}
 				default:
 					throw new DexException("Unexpected element size in FILL_ARRAY_DATA_PAYLOAD: " + elemSize);
 			}


### PR DESCRIPTION
### fix case
the case is at the end of method code item,Insert some fill_array_data_payload instructions with elemSize of 0 at the end of the method.

such as:

![image](https://user-images.githubusercontent.com/27995531/104675261-2407e800-5720-11eb-82df-90649939457b.png)

The left is before optimization, the right is after optimization

and the smali is:
![image](https://user-images.githubusercontent.com/27995531/104675280-308c4080-5720-11eb-9e90-598d9a135370.png)
