### PR TITLE
fix(gui): codearea popup menu always disabled in macos (#1052)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/JNodeMenuAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/JNodeMenuAction.java
@@ -36,13 +36,11 @@ public abstract class JNodeMenuAction<T> extends AbstractAction implements Popup
 
 	@Nullable
 	private T getNode() {
-		Point pos = codeArea.getMousePosition();
-		if (pos != null) {
-			Token token = codeArea.viewToToken(pos);
-			int offset = codeArea.adjustOffsetForToken(token);
-			return getNodeByOffset(offset);
-		}
-		return null;
+		Point pos = MouseInfo.getPointerInfo().getLocation();
+		SwingUtilities.convertPointFromScreen(pos, codeArea);
+		Token token = codeArea.viewToToken(pos);
+		int offset = codeArea.adjustOffsetForToken(token);
+		return getNodeByOffset(offset);
 	}
 
 	@Override


### PR DESCRIPTION
### Description
Can not select "Find Usage" and "Go to declaration" in context menu after I upgrade to macOS 11.1
I also tried many versions of java, but none of them works.
Then I look into the source code. Seems that [`codeArea.getMousePosition()`](https://github.com/skylot/jadx/blob/7f8d03d1927b95565938a4e2089f4cbed3417979/jadx-gui/src/main/java/jadx/gui/ui/codearea/JNodeMenuAction.java#L39) failed to retrieve the position.

Related issue: #1052
