### PR TITLE
Add shortcuts to TabbedPanel & enhence JumpPosition

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/StringUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/StringUtils.java
@@ -7,6 +7,8 @@ import jadx.core.deobf.NameMapper;
 
 public class StringUtils {
 	private static final StringUtils DEFAULT_INSTANCE = new StringUtils(new JadxArgs());
+	private static final String WHITES = " \t\r\n\f\b";
+	private static final String WORD_SEPARATORS = WHITES + "(\")<,>{}=+-*/|[]\\:;'.`~!#^&";
 
 	public static StringUtils getInstance() {
 		return DEFAULT_INSTANCE;
@@ -252,5 +254,14 @@ public class StringUtils {
 			idx += subStrLen;
 		}
 		return count;
+	}
+
+	public static boolean isWhite(char chr) {
+		return WHITES.indexOf(chr) != -1;
+	}
+
+	public static boolean isWordSeparator(char chr) {
+		return WORD_SEPARATORS.indexOf(chr) != -1;
+
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -62,6 +62,7 @@ public class JadxSettings extends JadxCLIArgs {
 
 	private Map<String, WindowLocation> windowPos = new HashMap<>();
 	private int mainWindowExtendedState = JFrame.NORMAL;
+	private boolean codeAreaLineWrap = false;
 	/**
 	 * UI setting: the width of the tree showing the classes, resources, ...
 	 */
@@ -389,6 +390,14 @@ public class JadxSettings extends JadxCLIArgs {
 	public void setMainWindowExtendedState(int mainWindowExtendedState) {
 		this.mainWindowExtendedState = mainWindowExtendedState;
 		partialSync(settings -> settings.mainWindowExtendedState = mainWindowExtendedState);
+	}
+
+	public void setCodeAreaLineWrap(boolean lineWrap) {
+		this.codeAreaLineWrap = lineWrap;
+	}
+
+	public boolean isCodeAreaLineWrap() {
+		return this.codeAreaLineWrap;
 	}
 
 	private void upgradeSettings(int fromVersion) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/HtmlPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/HtmlPanel.java
@@ -30,6 +30,10 @@ public final class HtmlPanel extends ContentPanel {
 		textArea.setFont(settings.getFont());
 	}
 
+	public JEditorPane getHtmlArea() {
+		return textArea;
+	}
+
 	private static final class JHtmlPane extends JEditorPane {
 		private static final long serialVersionUID = 6886040384052136157L;
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/RenameDialog.java
@@ -49,10 +49,7 @@ import jadx.gui.treemodel.JNode;
 import jadx.gui.treemodel.JPackage;
 import jadx.gui.ui.codearea.ClassCodeContentPanel;
 import jadx.gui.ui.codearea.CodePanel;
-import jadx.gui.utils.CacheObject;
-import jadx.gui.utils.JNodeCache;
-import jadx.gui.utils.NLS;
-import jadx.gui.utils.TextStandardActions;
+import jadx.gui.utils.*;
 
 public class RenameDialog extends JDialog {
 	private static final long serialVersionUID = -3269715644416902410L;
@@ -319,6 +316,7 @@ public class RenameDialog extends JDialog {
 		setLocationRelativeTo(null);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 		setModalityType(ModalityType.APPLICATION_MODAL);
+		UiUtils.addEscapeShortCutToDispose(this);
 	}
 
 	@Override

--- a/jadx-gui/src/main/java/jadx/gui/ui/TabbedPane.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/TabbedPane.java
@@ -1,13 +1,11 @@
 package jadx.gui.ui;
 
-import java.awt.Component;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 
-import javax.swing.JTabbedPane;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 import javax.swing.text.BadLocationException;
 
 import org.jetbrains.annotations.Nullable;
@@ -16,13 +14,12 @@ import org.slf4j.LoggerFactory;
 
 import jadx.api.ResourceFile;
 import jadx.api.ResourceType;
+import jadx.core.utils.StringUtils;
+import jadx.core.utils.exceptions.JadxRuntimeException;
 import jadx.gui.treemodel.ApkSignature;
 import jadx.gui.treemodel.JNode;
 import jadx.gui.treemodel.JResource;
-import jadx.gui.ui.codearea.AbstractCodeArea;
-import jadx.gui.ui.codearea.AbstractCodeContentPanel;
-import jadx.gui.ui.codearea.ClassCodeContentPanel;
-import jadx.gui.ui.codearea.CodeContentPanel;
+import jadx.gui.ui.codearea.*;
 import jadx.gui.utils.JumpManager;
 import jadx.gui.utils.JumpPosition;
 
@@ -34,6 +31,9 @@ public class TabbedPane extends JTabbedPane {
 	private final transient MainWindow mainWindow;
 	private final transient Map<JNode, ContentPanel> openTabs = new LinkedHashMap<>();
 	private final transient JumpManager jumps = new JumpManager();
+
+	private transient ContentPanel curTab;
+	private transient ContentPanel lastTab;
 
 	TabbedPane(MainWindow window) {
 		this.mainWindow = window;
@@ -55,6 +55,93 @@ public class TabbedPane extends JTabbedPane {
 			}
 			setSelectedIndex(index);
 		});
+		interceptTabKey();
+		enableSwitchingTabs();
+	}
+
+	private void interceptTabKey() {
+		KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(new KeyEventDispatcher() {
+			private static final int ctrlDown = KeyEvent.CTRL_DOWN_MASK;
+			private long ctrlInterval = 0;
+
+			@Override
+			public boolean dispatchKeyEvent(KeyEvent e) {
+				long cur = System.currentTimeMillis();
+				if (!FocusManager.isActive()) {
+					return false; // don't do nothing when tab is not on focus.
+				}
+				int code = e.getKeyCode();
+				boolean consume = code == KeyEvent.VK_TAB; // consume Tab key event anyway
+				boolean isReleased = e.getID() == KeyEvent.KEY_RELEASED;
+				if (isReleased) {
+					if (code == KeyEvent.VK_CONTROL) {
+						ctrlInterval = cur;
+					} else if (code == KeyEvent.VK_TAB) {
+						boolean doSwitch = false;
+						if ((e.getModifiersEx() & ctrlDown) != 0) {
+							doSwitch = lastTab != null && getTabCount() > 1;
+						} else {
+							// the gap of the release of ctrl and tab is very close, nearly the same time,
+							// but ctrl released first.
+							ctrlInterval = cur - ctrlInterval;
+							if (ctrlInterval <= 90) {
+								doSwitch = lastTab != null && getTabCount() > 1;
+							}
+						}
+						if (doSwitch) {
+							setSelectedComponent(lastTab);
+						}
+					}
+				} else if (consume && (e.getModifiersEx() & ctrlDown) == 0) {
+					// switch between source and smali
+					if (curTab instanceof ClassCodeContentPanel) {
+						((ClassCodeContentPanel) curTab).switchPanel();
+					}
+				}
+				return consume;
+			}
+		});
+	}
+
+	private void enableSwitchingTabs() {
+		addChangeListener(e -> {
+			ContentPanel tab = getSelectedCodePanel();
+			if (tab == null) { // all closed
+				curTab = null;
+				lastTab = null;
+				return;
+			}
+			FocusManager.focusOnCodePanel(tab);
+			if (tab == curTab) { // a tab was closed by not the current one.
+				if (lastTab != null && indexOfComponent(lastTab) == -1) { // lastTab was closed
+					setLastTabAdjacentToCurTab();
+				}
+				return;
+			}
+			if (tab == lastTab) {
+				if (indexOfComponent(curTab) == -1) { // curTab was closed and lastTab is the current one.
+					curTab = lastTab;
+					setLastTabAdjacentToCurTab();
+					return;
+				}
+				// it's switching between lastTab and curTab.
+			}
+			lastTab = curTab;
+			curTab = tab;
+		});
+	}
+
+	private void setLastTabAdjacentToCurTab() {
+		if (getTabCount() < 2) {
+			lastTab = null;
+			return;
+		}
+		int idx = indexOfComponent(curTab);
+		if (idx == 0) {
+			lastTab = (ContentPanel) getComponentAt(idx + 1);
+		} else {
+			lastTab = (ContentPanel) getComponentAt(idx - 1);
+		}
 	}
 
 	public MainWindow getMainWindow() {
@@ -69,16 +156,36 @@ public class TabbedPane extends JTabbedPane {
 		SwingUtilities.invokeLater(() -> {
 			setSelectedComponent(contentPanel);
 			AbstractCodeArea codeArea = contentPanel.getCodeArea();
-			int line = pos.getLine();
-			if (line < 0) {
-				try {
-					line = 1 + codeArea.getLineOfOffset(-line);
-				} catch (BadLocationException e) {
-					LOG.error("Can't get line for: {}", pos, e);
-					line = pos.getNode().getLine();
+			if (pos.isPrecise()) {
+				codeArea.scrollToPos(pos.getPos());
+			} else {
+				int line = pos.getLine();
+				if (line < 0) {
+					try {
+						line = 1 + codeArea.getLineOfOffset(-line);
+					} catch (BadLocationException e) {
+						LOG.error("Can't get line for: {}", pos, e);
+						line = pos.getNode().getLine();
+					}
+				}
+				if (pos.getPos() <= 0) {
+					codeArea.scrollToLine(line);
+				} else {
+					int lineNum = Math.max(0, line - 1);
+					try {
+						int offs = codeArea.getLineStartOffset(lineNum);
+						while (StringUtils.isWhite(codeArea.getText(offs, 1).charAt(0))) {
+							offs += 1;
+						}
+						offs += pos.getPos();
+						pos.setPrecise(offs);
+						codeArea.scrollToPos(offs);
+					} catch (BadLocationException e) {
+						e.printStackTrace();
+						codeArea.scrollToLine(line);
+					}
 				}
 			}
-			codeArea.scrollToLine(line);
 			codeArea.requestFocus();
 		});
 	}
@@ -149,6 +256,7 @@ public class TabbedPane extends JTabbedPane {
 			if (panel == null) {
 				return null;
 			}
+			FocusManager.listen(panel);
 			addContentPanel(panel);
 			setTabComponentAt(indexOfComponent(panel), makeTabComponent(panel));
 		}
@@ -219,5 +327,73 @@ public class TabbedPane extends JTabbedPane {
 		closeAllTabs();
 		openTabs.clear();
 		jumps.reset();
+		curTab = null;
+		lastTab = null;
+	}
+
+	private static class FocusManager implements FocusListener {
+		static boolean active = false;
+		static FocusManager listener = new FocusManager();
+
+		static boolean isActive() {
+			return active;
+		}
+
+		@Override
+		public void focusGained(FocusEvent e) {
+			active = true;
+		}
+
+		@Override
+		public void focusLost(FocusEvent e) {
+			active = false;
+		}
+
+		static void listen(ContentPanel pane) {
+			if (pane instanceof ClassCodeContentPanel) {
+				((ClassCodeContentPanel) pane).getCodeArea().addFocusListener(listener);
+				((ClassCodeContentPanel) pane).getSmaliCodeArea().addFocusListener(listener);
+				return;
+			}
+			if (pane instanceof AbstractCodeContentPanel) {
+				((AbstractCodeContentPanel) pane).getCodeArea().addFocusListener(listener);
+				return;
+			}
+			if (pane instanceof HtmlPanel) {
+				((HtmlPanel) pane).getHtmlArea().addFocusListener(listener);
+				return;
+			}
+			if (pane instanceof ImagePanel) {
+				pane.addFocusListener(listener);
+				return;
+			}
+			throw new JadxRuntimeException("Add the new ContentPanel to TabbedPane.FocusManager: " + pane);
+		}
+
+		static void focusOnCodePanel(ContentPanel pane) {
+			if (pane instanceof ClassCodeContentPanel) {
+				SwingUtilities.invokeLater(() -> {
+					((ClassCodeContentPanel) pane).getCurrentCodeArea().requestFocus();
+				});
+				return;
+			}
+			if (pane instanceof AbstractCodeContentPanel) {
+				SwingUtilities.invokeLater(() -> {
+					((AbstractCodeContentPanel) pane).getCodeArea().requestFocus();
+				});
+				return;
+			}
+			if (pane instanceof HtmlPanel) {
+				SwingUtilities.invokeLater(() -> {
+					((HtmlPanel) pane).getHtmlArea().requestFocusInWindow();
+				});
+				return;
+			}
+			if (pane instanceof ImagePanel) {
+				SwingUtilities.invokeLater(((ImagePanel) pane)::requestFocusInWindow);
+				return;
+			}
+			throw new JadxRuntimeException("Add the new ContentPanel to TabbedPane.FocusManager: " + pane);
+		}
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/ClassCodeContentPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/ClassCodeContentPanel.java
@@ -22,7 +22,7 @@ public final class ClassCodeContentPanel extends AbstractCodeContentPanel {
 
 	private final transient CodePanel javaCodePanel;
 	private final transient CodePanel smaliCodePanel;
-	// private final transient JTabbedPane areaTabbedPane;
+	private final transient JTabbedPane areaTabbedPane;
 
 	public ClassCodeContentPanel(TabbedPane panel, JNode jnode) {
 		super(panel, jnode);
@@ -33,7 +33,7 @@ public final class ClassCodeContentPanel extends AbstractCodeContentPanel {
 		setLayout(new BorderLayout());
 		setBorder(new EmptyBorder(0, 0, 0, 0));
 
-		JTabbedPane areaTabbedPane = new JTabbedPane(JTabbedPane.BOTTOM);
+		areaTabbedPane = new JTabbedPane(JTabbedPane.BOTTOM);
 		areaTabbedPane.setBorder(new EmptyBorder(0, 0, 0, 0));
 		areaTabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
 		areaTabbedPane.add(javaCodePanel, NLS.str("tabs.code"));
@@ -72,6 +72,19 @@ public final class ClassCodeContentPanel extends AbstractCodeContentPanel {
 
 	public CodePanel getJavaCodePanel() {
 		return javaCodePanel;
+	}
+
+	public void switchPanel() {
+		boolean toSmali = areaTabbedPane.getSelectedComponent() == javaCodePanel;
+		areaTabbedPane.setSelectedComponent(toSmali ? smaliCodePanel : javaCodePanel);
+	}
+
+	public AbstractCodeArea getCurrentCodeArea() {
+		return ((CodePanel) areaTabbedPane.getSelectedComponent()).getCodeArea();
+	}
+
+	public AbstractCodeArea getSmaliCodeArea() {
+		return smaliCodePanel.getCodeArea();
 	}
 
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -1,8 +1,7 @@
 package jadx.gui.ui.codearea;
 
-import java.awt.event.InputEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+import java.awt.*;
+import java.awt.event.*;
 
 import javax.swing.*;
 
@@ -50,17 +49,22 @@ public final class CodeArea extends AbstractCodeArea {
 			@SuppressWarnings("deprecation")
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				if (e.isControlDown()) {
-					int offs = viewToModel(e.getPoint());
-					JumpPosition jump = codeLinkGenerator.getJumpLinkAtOffset(CodeArea.this, offs);
-					if (jump != null) {
-						contentPanel.getTabbedPane().codeJump(jump);
-					}
+				if (e.getClickCount() % 2 == 0 || e.isControlDown()) {
+					navToDecl(e.getPoint(), codeLinkGenerator);
 				}
 			}
 		});
+
 		if (isJavaCode) {
 			addMouseMotionListener(new MouseHoverHighlighter(this, codeLinkGenerator));
+		}
+	}
+
+	private void navToDecl(Point point, CodeLinkGenerator codeLinkGenerator) {
+		int offs = viewToModel(point);
+		JumpPosition jump = codeLinkGenerator.getJumpLinkAtOffset(CodeArea.this, offs);
+		if (jump != null) {
+			contentPanel.getTabbedPane().codeJump(jump);
 		}
 	}
 
@@ -147,6 +151,14 @@ public final class CodeArea extends AbstractCodeArea {
 	private JNode convertJavaNode(JavaNode javaNode) {
 		JNodeCache nodeCache = getMainWindow().getCacheObject().getNodeCache();
 		return nodeCache.makeFrom(javaNode);
+	}
+
+	public JNode getNodeUnderCaret() {
+		int start = getWordStart(getCaretPosition());
+		if (start == -1) {
+			start = getCaretPosition();
+		}
+		return getJNodeAtOffset(start);
 	}
 
 	@Nullable

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FindUsageAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FindUsageAction.java
@@ -1,6 +1,9 @@
 package jadx.gui.ui.codearea;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.*;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -8,20 +11,35 @@ import jadx.gui.treemodel.JNode;
 import jadx.gui.ui.UsageDialog;
 import jadx.gui.utils.NLS;
 
+import static javax.swing.KeyStroke.getKeyStroke;
+
 public final class FindUsageAction extends JNodeMenuAction<JNode> {
 	private static final long serialVersionUID = 4692546569977976384L;
 
 	public FindUsageAction(CodeArea codeArea) {
-		super(NLS.str("popup.find_usage"), codeArea);
+		super(NLS.str("popup.find_usage") + " (x)", codeArea);
+		KeyStroke key = getKeyStroke(KeyEvent.VK_X, 0);
+		codeArea.getInputMap().put(key, "trigger usage");
+		codeArea.getActionMap().put("trigger usage", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				node = codeArea.getNodeUnderCaret();
+				showUsageDialog();
+			}
+		});
+	}
+
+	private void showUsageDialog() {
+		if (node != null) {
+			UsageDialog usageDialog = new UsageDialog(codeArea.getMainWindow(), node);
+			usageDialog.setVisible(true);
+			node = null;
+		}
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		if (node == null) {
-			return;
-		}
-		UsageDialog usageDialog = new UsageDialog(codeArea.getMainWindow(), node);
-		usageDialog.setVisible(true);
+		showUsageDialog();
 	}
 
 	@Nullable

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/GoToDeclarationAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/GoToDeclarationAction.java
@@ -1,24 +1,43 @@
 package jadx.gui.ui.codearea;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+
+import javax.swing.*;
 
 import org.jetbrains.annotations.Nullable;
 
 import jadx.gui.utils.JumpPosition;
 import jadx.gui.utils.NLS;
 
+import static javax.swing.KeyStroke.getKeyStroke;
+
 public final class GoToDeclarationAction extends JNodeMenuAction<JumpPosition> {
 	private static final long serialVersionUID = -1186470538894941301L;
 
 	public GoToDeclarationAction(CodeArea codeArea) {
-		super(NLS.str("popup.go_to_declaration"), codeArea);
+		super(NLS.str("popup.go_to_declaration") + " (d)", codeArea);
+		KeyStroke key = getKeyStroke(KeyEvent.VK_D, 0);
+		codeArea.getInputMap().put(key, "trigger goto decl");
+		codeArea.getActionMap().put("trigger goto decl", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				node = getNodeByOffset(codeArea.getWordStart(codeArea.getCaretPosition()));
+				doJump();
+			}
+		});
+	}
+
+	private void doJump() {
+		if (node != null) {
+			codeArea.getContentPanel().getTabbedPane().codeJump(node);
+			node = null;
+		}
 	}
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		if (node != null) {
-			codeArea.getContentPanel().getTabbedPane().codeJump(node);
-		}
+		doJump();
 	}
 
 	@Nullable

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
@@ -14,7 +14,7 @@ import jadx.gui.ui.RenameDialog;
 import jadx.gui.utils.NLS;
 import jadx.gui.utils.UiUtils;
 
-import static com.sun.glass.events.KeyEvent.VK_N;
+import static java.awt.event.KeyEvent.VK_N;
 import static javax.swing.KeyStroke.getKeyStroke;
 
 public final class RenameAction extends JNodeMenuAction<JNode> {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
@@ -2,6 +2,7 @@ package jadx.gui.ui.codearea;
 
 import java.awt.event.ActionEvent;
 
+import javax.swing.*;
 import javax.swing.event.PopupMenuEvent;
 
 import org.jetbrains.annotations.Nullable;
@@ -11,6 +12,10 @@ import org.slf4j.LoggerFactory;
 import jadx.gui.treemodel.JNode;
 import jadx.gui.ui.RenameDialog;
 import jadx.gui.utils.NLS;
+import jadx.gui.utils.UiUtils;
+
+import static com.sun.glass.events.KeyEvent.VK_N;
+import static javax.swing.KeyStroke.getKeyStroke;
 
 public final class RenameAction extends JNodeMenuAction<JNode> {
 	private static final long serialVersionUID = -4680872086148463289L;
@@ -18,7 +23,32 @@ public final class RenameAction extends JNodeMenuAction<JNode> {
 	private static final Logger LOG = LoggerFactory.getLogger(RenameAction.class);
 
 	public RenameAction(CodeArea codeArea) {
-		super(NLS.str("popup.rename"), codeArea);
+		super(NLS.str("popup.rename") + " (n)", codeArea);
+		KeyStroke key = getKeyStroke(VK_N, 0);
+		codeArea.getInputMap().put(key, "trigger rename");
+		codeArea.getActionMap().put("trigger rename", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				node = codeArea.getNodeUnderCaret();
+				showRenameDialog();
+			}
+		});
+	}
+
+	private void showRenameDialog() {
+		if (node == null) {
+			LOG.info("node == null!");
+			UiUtils.showMessageBox(codeArea.getMainWindow(), NLS.str("msg.rename_node_disabled"));
+			return;
+		}
+		if (!node.canRename()) {
+			UiUtils.showMessageBox(codeArea.getMainWindow(),
+					NLS.str("msg.rename_node_failed", node.getJavaNode().getFullName()));
+			LOG.info("node can't be renamed");
+			return;
+		}
+		RenameDialog.rename(codeArea.getMainWindow(), node);
+		node = null;
 	}
 
 	@Override
@@ -29,11 +59,7 @@ public final class RenameAction extends JNodeMenuAction<JNode> {
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		if (node == null) {
-			LOG.info("node == null!");
-			return;
-		}
-		RenameDialog.rename(codeArea.getMainWindow(), node);
+		showRenameDialog();
 	}
 
 	@Nullable

--- a/jadx-gui/src/main/java/jadx/gui/utils/JumpPosition.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/JumpPosition.java
@@ -5,10 +5,35 @@ import jadx.gui.treemodel.JNode;
 public class JumpPosition {
 	private final JNode node;
 	private final int line;
+	// the position of the node in java code,
+	// call codeArea.scrollToPos(pos) to set caret
+	private int pos;
+	// Precise means caret can be set right at the node in codeArea,
+	// not just the start of the line.
+	private boolean precise;
 
 	public JumpPosition(JNode node, int line) {
+		this(node, line, 0);
+	}
+
+	public JumpPosition(JNode node, int line, int pos) {
 		this.node = node;
 		this.line = line;
+		this.pos = pos;
+	}
+
+	public boolean isPrecise() {
+		return precise;
+	}
+
+	public JumpPosition setPrecise(int pos) {
+		this.pos = pos;
+		this.precise = true;
+		return this;
+	}
+
+	public int getPos() {
+		return pos;
 	}
 
 	public JNode getNode() {
@@ -28,7 +53,7 @@ public class JumpPosition {
 			return false;
 		}
 		JumpPosition position = (JumpPosition) obj;
-		return line == position.line && node.equals(position.node);
+		return line == position.line && node.equals(position.node) && pos == position.pos;
 	}
 
 	@Override

--- a/jadx-gui/src/main/java/jadx/gui/utils/UiUtils.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/UiUtils.java
@@ -1,21 +1,16 @@
 package jadx.gui.utils;
 
-import java.awt.Image;
-import java.awt.Toolkit;
-import java.awt.Window;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.Action;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JComponent;
-import javax.swing.KeyStroke;
+import javax.swing.*;
 
 import org.intellij.lang.annotations.MagicConstant;
 import org.slf4j.Logger;
@@ -205,5 +200,14 @@ public class UiUtils {
 	@MagicConstant(flagsFromClass = InputEvent.class)
 	public static int ctrlButton() {
 		return CTRL_BNT_KEY;
+	}
+
+	public static void showMessageBox(Component parent, String msg) {
+		JOptionPane.showMessageDialog(parent, msg);
+	}
+
+	public static void addEscapeShortCutToDispose(JDialog dialog) {
+		KeyStroke stroke = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+		dialog.getRootPane().registerKeyboardAction(e -> dialog.dispose(), stroke, JComponent.WHEN_IN_FOCUSED_WINDOW);
 	}
 }

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -145,7 +145,10 @@ msg.rename_disabled=Einige der Umbenennungseinstellungen sind deaktiviert, bitte
 msg.rename_disabled_force_rewrite_enabled=Deaktivieren Sie zum Umbenennen die Option "Deobfuscationskartendatei umschreiben erzwingen".
 msg.rename_disabled_deobfuscation_disabled=Bitte aktivieren Sie die Umbenennung von Deobfuscation.
 msg.cmd_select_class_error=Klasse\n%s auswählen nicht möglich\nSie existiert nicht.
+#msg.rename_node_disabled=
+#msg.rename_node_failed=
 
+#popup.line_wrap=
 popup.undo=Rückgängig
 popup.redo=Wiederholen
 popup.cut=Ausschneiden

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -145,7 +145,10 @@ msg.rename_disabled=Some of rename settings are disabled, next options will be c
 msg.rename_disabled_force_rewrite_enabled=Disable "Force rewrite deobfuscation map file" option.
 msg.rename_disabled_deobfuscation_disabled=Enable deobfuscation.
 msg.cmd_select_class_error=Failed to select the class\n%s\nThe class does not exist.
+msg.rename_node_disabled=Can't rename this node
+msg.rename_node_failed=Can't rename %s
 
+popup.line_wrap=Line Wrap
 popup.undo=Undo
 popup.redo=Redo
 popup.cut=Cut

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -145,7 +145,10 @@ msg.index_not_initialized=Índice no inicializado, ¡la bósqueda se desactivar�
 #msg.rename_disabled_force_rewrite_enabled=
 #msg.rename_disabled_deobfuscation_disabled=
 #msg.cmd_select_class_error=
+#msg.rename_node_disabled=
+#msg.rename_node_failed=
 
+#popup.line_wrap=
 popup.undo=Deshacer
 popup.redo=Rehacer
 popup.cut=Cortar

--- a/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
@@ -145,7 +145,10 @@ msg.rename_disabled=일부 이름 바꾸기 설정이 비활성화되고 다음 
 msg.rename_disabled_force_rewrite_enabled="난독 해제 맵 파일 강제 다시 쓰기"옵션을 비활성화합니다.
 msg.rename_disabled_deobfuscation_disabled=난독 해제 활성화
 msg.cmd_select_class_error=클래스를 선택하지 못했습니다.\n%s\n클래스가 없습니다.
+#msg.rename_node_disabled=
+#msg.rename_node_failed=
 
+#popup.line_wrap=
 popup.undo=실행 취소
 popup.redo=다시 실행
 popup.cut=자르기

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -145,7 +145,10 @@ msg.rename_disabled=某些重命名设置已禁用，请将此考虑在内
 msg.rename_disabled_force_rewrite_enabled=请禁用“强制覆盖反重构映射文件”选项以重命名。
 msg.rename_disabled_deobfuscation_disabled=请启用反混淆以重命名。
 msg.cmd_select_class_error=无法选择类\n%s\n该类不存在。
+#msg.rename_node_disabled=
+#msg.rename_node_failed=
 
+#popup.line_wrap=
 popup.undo=撤销
 popup.redo=重做
 popup.cut=剪切


### PR DESCRIPTION
#1085 

hello, I added some shortcuts for codeArea 

```

- n for rename
- x for usage search
- d / double clicks for goto declaration
- tab for switching between java and smali
- ctrl + tab for swtching between current tab and the previous one

```

and some improvements

1. a line-wrap toggle for codeArea, when code lines is too long it's handy.
2. record caret position in JumpPosition, so the caret can be set rigth at the node not just the start of the line, e.g. when 
click on a search result the caret goes to the matched place not the line head.

![add_shortcuts_present2](https://user-images.githubusercontent.com/66319139/105572819-6f5f6d80-5d94-11eb-94d4-7fbaf83cf65e.gif)


