### PR TITLE
fix variable usage & caret position after rename

### DIFF
--- a/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
+++ b/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
@@ -448,7 +448,7 @@ public final class JadxDecompiler implements Closeable {
 		}
 		if (obj instanceof VariableNode) {
 			VariableNode varNode = (VariableNode) obj;
-			return new JavaVariable(getJavaClassByNode(varNode.getClassNode()), varNode);
+			return new JavaVariable(getJavaClassByNode(varNode.getClassNode().getTopParentClass()), varNode);
 		}
 		throw new JadxRuntimeException("Unexpected node type: " + obj);
 	}

--- a/jadx-core/src/main/java/jadx/api/JavaVariable.java
+++ b/jadx-core/src/main/java/jadx/api/JavaVariable.java
@@ -55,6 +55,9 @@ public class JavaVariable implements JavaNode {
 
 	@Override
 	public boolean equals(Object obj) {
-		return node.equals(obj);
+		if (obj instanceof JavaVariable) {
+			return node.equals(((JavaVariable) obj).getVariableNode());
+		}
+		return false;
 	}
 }

--- a/jadx-core/src/main/java/jadx/core/codegen/InsnGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/InsnGen.java
@@ -92,7 +92,6 @@ public class InsnGen {
 			if (codeVar != null) {
 				VariableNode node = mth.getVariable(codeVar.getIndex());
 				if (node != null) {
-					node.useVar(code, codeVar);
 					code.attachAnnotation(node);
 				}
 			}
@@ -653,7 +652,6 @@ public class InsnGen {
 		if (insn.isSuper()) {
 			code.add("super");
 		} else if (insn.isThis()) {
-			code.attachAnnotation(mth.getParentClass());
 			code.add("this");
 		} else {
 			code.add("new ");

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
@@ -110,15 +110,6 @@ public class MethodNode extends NotificationAttrNode implements IMethodDetails, 
 		return null;
 	}
 
-	public VariableNode getVariable(int index, VarKind varType) {
-		for (VariableNode variable : variables) {
-			if (variable.getVarKind() == varType && variable.getIndex() == index) {
-				return variable;
-			}
-		}
-		return null;
-	}
-
 	public VariableNode declareVar(VisibleVar var, NameGen nameGen, VarKind varKind) {
 		if (var instanceof CodeVar) {
 			if (((CodeVar) var).isThis()) {
@@ -127,14 +118,11 @@ public class MethodNode extends NotificationAttrNode implements IMethodDetails, 
 		}
 		VariableNode varNode;
 		int index = var.getIndex();
-		if (index == -1) {
+		if (index > -1) {
+			varNode = getVariable(var.getIndex());
+		} else {
 			index = variables.size();
 			var.setIndex(index);
-			varNode = null;
-		} else {
-			varNode = getVariable(var.getIndex());
-		}
-		if (varNode == null) {
 			String name = mthInfo.getVariableName(VariableNode.makeVarIndex(index, varKind));
 			if (name != null) {
 				var.setName(name); // set name with user renamed previously.

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/VariableNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/VariableNode.java
@@ -1,9 +1,7 @@
 package jadx.core.dex.nodes;
 
-import jadx.core.codegen.CodeWriter;
 import jadx.core.dex.attributes.nodes.LineAttrNode;
 import jadx.core.dex.instructions.args.ArgType;
-import jadx.core.dex.instructions.args.CodeVar;
 import jadx.core.utils.exceptions.JadxRuntimeException;
 
 public class VariableNode extends LineAttrNode {
@@ -54,17 +52,6 @@ public class VariableNode extends LineAttrNode {
 
 	public int getIndex() {
 		return index;
-	}
-
-	public void addUsage(int line, int offset, int codeOffset) {
-	}
-
-	public void useVar(CodeWriter code, CodeVar codeVar) {
-		if (!codeVar.isThis()) { // TODO: add usage
-			// IdentifierVisitor.VariableNode node = codeVar.getVariableNode();
-			// node.addUsage(code.getLine(), code.getOffset(), code.bufLength());
-			// code.attachAnnotation(node);
-		}
 	}
 
 	public String getRenameKey() {


### PR DESCRIPTION
#1099 

fix variable usage and set the caret at the new position of the renamed node.


![var_usage_present](https://user-images.githubusercontent.com/66319139/106016570-8f778f80-60fa-11eb-94ac-378a04ecc592.gif)


