### PR TITLE
Compact TabComponent labels and TabToolTip

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/ContentPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/ContentPanel.java
@@ -4,6 +4,7 @@ import javax.swing.*;
 
 import org.jetbrains.annotations.Nullable;
 
+import jadx.gui.treemodel.JClass;
 import jadx.gui.treemodel.JNode;
 
 public abstract class ContentPanel extends JPanel {
@@ -38,6 +39,10 @@ public abstract class ContentPanel extends JPanel {
 	 */
 	@Nullable
 	public String getTabTooltip() {
-		return null;
+		JClass jClass = node.getRootClass();
+		if (jClass != null) {
+			return jClass.getFullName();
+		}
+		return node.getName();
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
@@ -95,7 +95,7 @@ public class TabComponent extends JPanel {
 
 		panel.add(label);
 		panel.add(closeBtn);
-		panel.setBorder(BorderFactory.createEmptyBorder(4, 0, 0, 0));
+		panel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 	}
 
 	private JPopupMenu createTabPopupMenu(final ContentPanel contentPanel) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
@@ -47,7 +47,13 @@ public class TabComponent extends JPanel {
 		panel.setOpaque(false);
 
 		JNode node = contentPanel.getNode();
-		label = new JLabel(node.makeLongStringHtml());
+		String tabTitle;
+		if (node.getRootClass() != null) {
+			tabTitle = node.getRootClass().getName();
+		} else {
+			tabTitle = node.makeLongStringHtml();
+		}
+		label = new JLabel(tabTitle);
 		label.setFont(getLabelFont());
 		String toolTip = contentPanel.getTabTooltip();
 		if (toolTip != null) {


### PR DESCRIPTION
### Description

This PR:
- Changes the TabComponent tabs label to only show RootClass name instead of full Class name. This makes navigation between tabs easy.
- Enables TabToolTip, so use can hover over label to see full Class name (as well as resource path). This helps distinguish tabs with duplicate labels.

Before:

https://user-images.githubusercontent.com/11215000/108618497-e3993980-7444-11eb-968d-b7cb4b710fe4.mp4

After:

https://user-images.githubusercontent.com/11215000/108618503-ea27b100-7444-11eb-8d53-a6e69066bfd7.mp4

- Removes the top padding from tab title.
Before:
![Screenshot from 2021-02-21 16-27-02](https://user-images.githubusercontent.com/11215000/108622942-169df600-7462-11eb-8695-7e6c6d8f4bfa.png)
After:
![Screenshot from 2021-02-21 16-26-43](https://user-images.githubusercontent.com/11215000/108622949-27e70280-7462-11eb-990a-cd78bbc289ac.png)

Closes #1120