### PR TITLE
Small search dialog optimizations

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/CommonSearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/CommonSearchDialog.java
@@ -95,7 +95,9 @@ public abstract class CommonSearchDialog extends JDialog {
 	protected abstract void loadStart();
 
 	public void loadWindowPos() {
-		mainWindow.getSettings().loadWindowPos(this);
+		if (!mainWindow.getSettings().loadWindowPos(this)) {
+			setSize(800, 500);
+		}
 	}
 
 	public void prepare() {

--- a/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
@@ -95,10 +95,10 @@ public class SearchDialog extends CommonSearchDialog {
 		this.options = buildOptions(preset);
 		this.options.addAll(additionalOptions);
 
+		loadWindowPos();
 		initUI();
 		searchFieldSubscribe();
 		registerInitOnOpen();
-		loadWindowPos();
 		registerActiveTabListener();
 	}
 
@@ -246,8 +246,6 @@ public class SearchDialog extends CommonSearchDialog {
 		});
 
 		setTitle(NLS.str("menu.text_search"));
-		pack();
-		setSize(800, 500);
 		setLocationRelativeTo(null);
 		setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
 		setModalityType(ModalityType.MODELESS);

--- a/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/SearchDialog.java
@@ -1,9 +1,6 @@
 package jadx.gui.ui;
 
-import java.awt.BorderLayout;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
+import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.util.Collections;
@@ -38,10 +35,12 @@ import jadx.gui.treemodel.JNode;
 import jadx.gui.utils.NLS;
 import jadx.gui.utils.TextStandardActions;
 import jadx.gui.utils.layout.WrapLayout;
+import jadx.gui.utils.search.SearchSettings;
 import jadx.gui.utils.search.TextSearchIndex;
 
 public class SearchDialog extends CommonSearchDialog {
 	private static final long serialVersionUID = -5105405456969134105L;
+	private static final Color SEARCHFIELD_ERROR_COLOR = new Color(255, 150, 150);
 
 	private static final Logger LOG = LoggerFactory.getLogger(SearchDialog.class);
 
@@ -80,6 +79,8 @@ public class SearchDialog extends CommonSearchDialog {
 
 	private final transient SearchPreset searchPreset;
 	private final transient Set<SearchOptions> options;
+
+	private Color searchFieldDefaultBgColor;
 
 	private transient JTextField searchField;
 
@@ -183,6 +184,7 @@ public class SearchDialog extends CommonSearchDialog {
 
 	private void initUI() {
 		searchField = new JTextField();
+		searchFieldDefaultBgColor = searchField.getBackground();
 		searchField.setAlignmentX(LEFT_ALIGNMENT);
 		TextStandardActions.attach(searchField);
 
@@ -304,7 +306,16 @@ public class SearchDialog extends CommonSearchDialog {
 		}
 		LOG.debug("search event: {}", text);
 		showSearchState();
-		return index.buildSearch(text, options);
+		try {
+			Flowable<JNode> result = index.buildSearch(text, options);
+			if (searchField.getBackground() == SEARCHFIELD_ERROR_COLOR) {
+				searchField.setBackground(searchFieldDefaultBgColor);
+			}
+			return result;
+		} catch (SearchSettings.InvalidSearchTermException e) {
+			searchField.setBackground(SEARCHFIELD_ERROR_COLOR);
+			return Flowable.empty();
+		}
 	}
 
 	private void processSearchResults(java.util.List<JNode> results) {

--- a/jadx-gui/src/main/java/jadx/gui/utils/layout/WrapLayout.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/layout/WrapLayout.java
@@ -128,10 +128,10 @@ public class WrapLayout extends FlowLayout {
 
 				if (m.isVisible()) {
 					Dimension d = preferred ? m.getPreferredSize() : m.getMinimumSize();
+					int width = d.width;
 
 					// Can't add the component to current row. Start a new row.
-
-					if (rowWidth + d.width > maxWidth) {
+					if (rowWidth + width >= maxWidth) {
 						addRow(dim, rowWidth, rowHeight);
 						rowWidth = 0;
 						rowHeight = 0;
@@ -143,7 +143,7 @@ public class WrapLayout extends FlowLayout {
 						rowWidth += hgap;
 					}
 
-					rowWidth += d.width;
+					rowWidth += width;
 					rowHeight = Math.max(rowHeight, d.height);
 				}
 			}

--- a/jadx-gui/src/main/java/jadx/gui/utils/search/SearchSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/search/SearchSettings.java
@@ -52,14 +52,13 @@ public class SearchSettings {
 		return this.regexPattern;
 	}
 
-	public boolean preCompile() {
+	public boolean preCompile() throws InvalidSearchTermException {
 		if (useRegex) {
 			try {
 				int flags = ignoreCase ? Pattern.CASE_INSENSITIVE : 0;
 				this.regexPattern = Pattern.compile(searchString, flags);
 			} catch (Exception e) {
-				LOG.warn("Invalid Regex: {}", this.searchString, e);
-				return false;
+				throw new InvalidSearchTermException("Invalid Regex: " + this.searchString, e);
 			}
 		}
 		return true;
@@ -104,5 +103,12 @@ public class SearchSettings {
 
 	public void setActiveCls(JClass activeCls) {
 		this.activeCls = activeCls;
+	}
+
+	public static class InvalidSearchTermException extends Exception {
+
+		public InvalidSearchTermException(String message, Throwable cause) {
+			super(message, cause);
+		}
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/utils/search/TextSearchIndex.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/search/TextSearchIndex.java
@@ -109,7 +109,8 @@ public class TextSearchIndex {
 		this.codeIndex.removeForCls(cls);
 	}
 
-	public Flowable<JNode> buildSearch(String text, Set<SearchDialog.SearchOptions> options) {
+	public Flowable<JNode> buildSearch(String text, Set<SearchDialog.SearchOptions> options)
+			throws SearchSettings.InvalidSearchTermException {
 		boolean ignoreCase = options.contains(IGNORE_CASE);
 		boolean useRegex = options.contains(USE_REGEX);
 


### PR DESCRIPTION
When opening the search dialog for the first time the layout was a bit strange, it seems the WrapLayout was reserving space for placing the two search option boxes stacked vertically, but later redecided and placed them horizontally but keeping the vertical space. 
This was may be related to the fact that the target window size was restored after creating all components and additionally an fixed intermediate window size was set. Seems that this confused the Java layouting engines.

Additionally I modified the search dialog to show a red background color in case an invalid regex was entered.