### PR TITLE
fix a minor bug in while loop

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/ADBDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/ADBDialog.java
@@ -624,7 +624,8 @@ public class ADBDialog extends JDialog implements ADB.DeviceStateListener, ADB.J
 						}
 					}
 					resultDesc = rst.desc;
-				} while (false);
+					break;
+				} while (true);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
Recently, I found a mistake that I had made in all my code.
I had always thought that the `continue` (in code below) will go to the `do` statement and start a new round, but nope, according to the official Java documentation
> The continue statement ... skips to the end of the innermost loop's body and evaluates the boolean expression that controls the loop.

So turns out the `continue` goes to the `while (false)`  instead of  `do`. 
```java
do {
 if (loop())
  continue;
} while (false);
```

I am very sorry for wrote such code to Jadx.
