### PR TITLE
Prevent duplicated Override-annotations + minor optimization

### DIFF
--- a/jadx-core/src/main/java/jadx/core/Consts.java
+++ b/jadx-core/src/main/java/jadx/core/Consts.java
@@ -22,6 +22,8 @@ public class Consts {
 	public static final String DALVIK_THROWS = "Ldalvik/annotation/Throws;";
 	public static final String DALVIK_ANNOTATION_DEFAULT = "Ldalvik/annotation/AnnotationDefault;";
 
+	public static final String OVERRIDE_ANNOTATION = "Ljava/lang/Override;";
+
 	public static final String DEFAULT_PACKAGE_NAME = "defpackage";
 	public static final String ANONYMOUS_CLASS_PREFIX = "AnonymousClass";
 

--- a/jadx-core/src/main/java/jadx/core/codegen/AnnotationGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/AnnotationGen.java
@@ -69,7 +69,7 @@ public class AnnotationGen {
 		}
 		for (IAnnotation a : aList.getAll()) {
 			String aCls = a.getAnnotationClass();
-			if (!aCls.startsWith(Consts.DALVIK_ANNOTATION_PKG)) {
+			if (!aCls.startsWith(Consts.DALVIK_ANNOTATION_PKG) && !aCls.equals(Consts.OVERRIDE_ANNOTATION)) {
 				code.startLine();
 				formatAnnotation(code, a);
 			}

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/OverrideMethodVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/OverrideMethodVisitor.java
@@ -56,7 +56,7 @@ public class OverrideMethodVisitor extends AbstractVisitor {
 	}
 
 	private void processMth(ClassNode cls, List<ArgType> superTypes, MethodNode mth) {
-		if (mth.isConstructor() || mth.getAccessFlags().isStatic()) {
+		if (mth.isConstructor() || mth.getAccessFlags().isStatic() || mth.getAccessFlags().isPrivate()) {
 			return;
 		}
 		MethodOverrideAttr attr = processOverrideMethods(cls, mth, superTypes);

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestExplicitOverride.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestExplicitOverride.java
@@ -1,0 +1,16 @@
+package jadx.tests.integration.others;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.SmaliTest;
+
+import static jadx.tests.api.utils.JadxMatchers.countString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TestExplicitOverride extends SmaliTest {
+	@Test
+	public void test() {
+		String code = getClassNodeFromSmali().getCode().getCodeStr();
+		assertThat(code, countString(1, "@Override"));
+	}
+}

--- a/jadx-core/src/test/smali/others/TestExplicitOverride.smali
+++ b/jadx-core/src/test/smali/others/TestExplicitOverride.smali
@@ -1,0 +1,34 @@
+###### Class others.TestExplicitOverride (others.TestExplicitOverride)
+.class public Lothers/TestExplicitOverride;
+.super Ljava/lang/Exception;
+.source "TestExplicitOverride.java"
+
+
+# direct methods
+.method public constructor <init>()V
+    .registers 1
+
+    .prologue
+    .line 3
+    invoke-direct {p0}, Ljava/lang/Exception;-><init>()V
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public getMessage()Ljava/lang/String;
+    .registers 2
+
+    .annotation runtime Ljava/lang/Override;
+    .end annotation
+
+    .prologue
+    .line 7
+    invoke-super {p0}, Ljava/lang/Exception;->getMessage()Ljava/lang/String;
+
+    move-result-object v0
+
+    return-object v0
+.end method
+


### PR DESCRIPTION
### Description
The first commit prevents duplicated override annotations for explicit override annotations. The second is a minor optimization: skip override detection for private methods.

This pull request is a fix for #1188