### PR TITLE
Improvements of Quark integration

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/QuarkDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/QuarkDialog.java
@@ -253,11 +253,9 @@ class QuarkDialog extends JDialog {
 				quarkProcess = Runtime.getRuntime().exec(cmdList.toArray(new String[0]));
 
 				try (BufferedReader buf = new BufferedReader(new InputStreamReader(quarkProcess.getInputStream()))) {
-					while (quarkProcess.isAlive()) {
-						String output = buf.readLine();
-						if (output != null) {
-							LOG.debug(output);
-						}
+					String output = null;
+					while ((output = buf.readLine()) != null) {
+						LOG.debug(output);
 					}
 				}
 			} catch (Exception e) {


### PR DESCRIPTION
This PR refers to [#1119](https://github.com/skylot/jadx/issues/1119).
### Describe the feature

Hi, sorry for taking so long to fix this.
We (me, @18z, @krnick) have implemented some features:
- **Quark installation in Jadx**:
    - A feature that allows users to install Quark-Engine in Jadx with `pip3` (also available on Windows)
- **Error/warning dialog**:
    - A feature that pops up the error/warning dialog when Quark was (or maybe will) not work correctly
- **Improvement of progress bar**:
    - Implement the progress bar of Quark to `mainWindow`

Changes in this PR:
- **Quark installation in Jadx**:
    - Add pip3 and Quark installed check
    - Add function to create virtualenv
    - Add quark install process
    - Add quark rules update process
- **Error/warning dialog**:
    - Add a feature that pops up an error dialog for each exception
    - Add a feature that pops up a warning dialog when the selected APK file too large
- **Improvement of progress bar**:
    - Change `QuarkTask` from `extend SwingWorker` to `implement IBackgroundTask`
    - Remove progress bar from Quark dialog