### PR TITLE
reverse XML attribute name decoding priority

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -335,19 +335,25 @@ public class BinaryXMLParser extends CommonBinaryParser {
 	}
 
 	private String getAttributeName(int id) {
+		// As the outcome of https://github.com/skylot/jadx/issues/1208
+		// Android seems to favor entries from AndroidResMap and only if
+		// there is no entry uses the values form the XML string pool
+		if (0 <= id && id < resourceIds.length) {
+			int resId = resourceIds[id];
+			String str = ValuesParser.getAndroidResMap().get(resId);
+			if (str != null) {
+				// cut type before /
+				int typeEnd = str.indexOf('/');
+				if (typeEnd != -1) {
+					return str.substring(typeEnd + 1);
+				}
+				return str;
+			}
+		}
+
 		String str = getString(id);
 		if (str == null || str.isEmpty()) {
-			int resId = resourceIds[id];
-			str = ValuesParser.getAndroidResMap().get(resId);
-			if (str == null) {
-				return "NOT_FOUND_0x" + Integer.toHexString(id);
-			}
-			// cut type before /
-			int typeEnd = str.indexOf('/');
-			if (typeEnd != -1) {
-				return str.substring(typeEnd + 1);
-			}
-			return str;
+			return "NOT_FOUND_0x" + Integer.toHexString(id);
 		}
 		return str;
 	}


### PR DESCRIPTION
Reversed XML attribute name decoding priority as discussed in #1208

I looked at different binary XML files and they look consistent, there it seems that reversing the XML attribute decoding priority does not have a negative effect.