### PR TITLE
Small improvements (tooltip, dex source file)

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
@@ -147,6 +147,7 @@ public class ClassGen {
 
 		annotationGen.addForClass(clsCode);
 		insertRenameInfo(clsCode, cls);
+		CodeGenUtils.addInputFileInfo(clsCode, cls);
 		clsCode.startLineWithNum(cls.getSourceLine()).add(af.makeString());
 		if (af.isInterface()) {
 			if (af.isAnnotation()) {

--- a/jadx-core/src/main/java/jadx/core/utils/CodeGenUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/CodeGenUtils.java
@@ -100,6 +100,15 @@ public class CodeGenUtils {
 		}
 	}
 
+	public static void addInputFileInfo(ICodeWriter code, ClassNode node) {
+		if (node.getClsData() != null) {
+			String inputFileName = node.getClsData().getInputFileName();
+			if (inputFileName != null) {
+				code.startLine("/* loaded from: ").add(inputFileName).add(" */");
+			}
+		}
+	}
+
 	public static CodeVar getCodeVar(RegisterArg arg) {
 		SSAVar svar = arg.getSVar();
 		if (svar != null) {

--- a/jadx-core/src/test/java/jadx/tests/integration/debuginfo/TestLineNumbers2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/debuginfo/TestLineNumbers2.java
@@ -39,7 +39,7 @@ public class TestLineNumbers2 extends IntegrationTest {
 
 		ClassNode cls = getClassNode(TestCls.class);
 		Map<Integer, Integer> lineMapping = cls.getCode().getLineMapping();
-		assertEquals("{5=17, 8=18, 11=22, 12=23, 13=24, 14=28, 16=25, 17=26, 18=28, 21=31, 22=32}",
+		assertEquals("{6=17, 9=18, 12=22, 13=23, 14=24, 15=28, 17=25, 18=26, 19=28, 22=31, 23=32}",
 				lineMapping.toString());
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
@@ -50,9 +50,9 @@ public class TestArrayForEachNegative extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
 
-		// Remove all comments - on Windows they can contain a colon because of the path C:\...
-		// added by CodeGenUtils.addInputFileInfo
-		code = code.replaceAll("/\\*[^/]*\\*/", "");
+		// Remove all comments - as the comment created by CodeGenUtils.addInputFileInfo
+		// always contains a colon
+		code = code.replaceAll("/\\*.*?\\*/", "");
 
 		assertThat(code, not(containsString(":")));
 	}

--- a/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/loops/TestArrayForEachNegative.java
@@ -50,6 +50,10 @@ public class TestArrayForEachNegative extends IntegrationTest {
 		ClassNode cls = getClassNode(TestCls.class);
 		String code = cls.getCode().toString();
 
+		// Remove all comments - on Windows they can contain a colon because of the path C:\...
+		// added by CodeGenUtils.addInputFileInfo
+		code = code.replaceAll("/\\*[^/]*\\*/", "");
+
 		assertThat(code, not(containsString(":")));
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JNode.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JNode.java
@@ -116,6 +116,10 @@ public abstract class JNode extends DefaultMutableTreeNode {
 		return javaNode.getDefPos();
 	}
 
+	public String getTooltip() {
+		return null;
+	}
+
 	@Override
 	public String toString() {
 		return makeString();

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JRoot.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JRoot.java
@@ -152,4 +152,21 @@ public class JRoot extends JNode {
 		}
 		return count + " files";
 	}
+
+	@Override
+	public String getTooltip() {
+		List<Path> paths = wrapper.getOpenPaths();
+		int count = paths.size();
+		if (count < 2) {
+			return null;
+		}
+		// Show list of loaded files (full path)
+		StringBuilder sb = new StringBuilder("<html>");
+		for (Path p : paths) {
+			sb.append(UiUtils.escapeHtml(p.toString()));
+			sb.append("<br>");
+		}
+		sb.append("</html>");
+		return sb.toString();
+	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -60,6 +60,7 @@ import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.JTree;
 import javax.swing.SwingUtilities;
+import javax.swing.ToolTipManager;
 import javax.swing.WindowConstants;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
@@ -1068,6 +1069,7 @@ public class MainWindow extends JFrame {
 		DefaultMutableTreeNode treeRootNode = new DefaultMutableTreeNode(NLS.str("msg.open_file"));
 		treeModel = new DefaultTreeModel(treeRootNode);
 		tree = new JTree(treeModel);
+		ToolTipManager.sharedInstance().registerComponent(tree);
 		tree.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
 		tree.addMouseListener(new MouseAdapter() {
 			@Override
@@ -1094,7 +1096,11 @@ public class MainWindow extends JFrame {
 					boolean isLeaf, int row, boolean focused) {
 				Component c = super.getTreeCellRendererComponent(tree, value, selected, expanded, isLeaf, row, focused);
 				if (value instanceof JNode) {
-					setIcon(((JNode) value).getIcon());
+					JNode jNode = (JNode) value;
+					setIcon(jNode.getIcon());
+					setToolTipText(jNode.getTooltip());
+				} else {
+					setToolTipText(null);
 				}
 				if (value instanceof JPackage) {
 					setEnabled(((JPackage) value).isEnabled());

--- a/jadx-gui/src/main/java/jadx/gui/utils/UiUtils.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/UiUtils.java
@@ -94,7 +94,7 @@ public class UiUtils {
 	}
 
 	public static String escapeHtml(String str) {
-		return str.replace("<", "&lt;");
+		return str.replace("<", "&lt;").replace(">", "&gt;");
 	}
 
 	public static String typeStr(ArgType type) {


### PR DESCRIPTION
1. If multiple files are loaded in Jadx their file paths are now shown as tooltip on the JRoot node
2. Decompiled classes get a comment from which dex files they have been loaded from. This is useful if the APK files contains dex files in non-standard locations (e.g. in assets or other places).

For 2. I also tried to include the APK source file name in the comment in case multiple files are loaded, but it seems that Jadx does not store this information at least I wasn't able to identify how to access this information.  I assume this would require some bigger changes to `DexFileLoader` to carry the original source file information through all the different loader methods to save it in the end in `DexClassData` .