### PR TITLE
Allow for handling of incorrect android manifest namespace chunks

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -191,7 +191,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		int comment = is.readInt32();
 		int endPrefix = is.readInt32();
 		int endURI = is.readInt32();
-		is.skip(headerSize - 0x18);
+		is.skip(headerSize - 0x10);
 		namespaceDepth--;
 
 		String nsKey = getString(endURI);


### PR DESCRIPTION
This will allow for processing manifest files that have a larger namespace start or end chunk than what is normal.  I decided not to implement similar changes for other chunk types because I do not have data available to test.

This will fix issue #1232 