### PR TITLE
Force protobuf version to prevent Java-7 issue

### DIFF
--- a/jadx-core/build.gradle
+++ b/jadx-core/build.gradle
@@ -7,6 +7,10 @@ dependencies {
 
 	implementation 'com.google.code.gson:gson:2.8.8'
 	implementation 'com.android.tools.build:aapt2-proto:4.2.1-7147631'
+	constraints {
+		// Force protobuf version to prevent Java-7 issue
+		implementation 'com.google.protobuf:protobuf-java:3.11.4'
+	}
 
 	testImplementation 'org.apache.commons:commons-lang3:3.12.0'
 


### PR DESCRIPTION
### Description
[aapt2-proto](https://mvnrepository.com/artifact/com.android.tools.build/aapt2-proto/4.2.1-7147631) depends on protobuf-java `3.10.0` which is [broken](https://github.com/protocolbuffers/protobuf/issues/6718) in Java-7 (Android only). This PR fixes the issue by updating proto-buf to 3.11.4