### PR TITLE
fix: "rename to make printable" option 

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/NameMapper.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/NameMapper.java
@@ -160,6 +160,18 @@ public class NameMapper {
 		return result;
 	}
 
+	public static String removeNonPrintableCharacters(String name) {
+		int len = name.length();
+		StringBuilder sb = new StringBuilder(len);
+		for (int i = 0; i < len; i++) {
+			int codePoint = name.codePointAt(i);
+			if (isPrintableChar(codePoint)) {
+				sb.append((char) codePoint);
+			}
+		}
+		return sb.toString();
+	}
+
 	private NameMapper() {
 	}
 }

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/RenameVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/RenameVisitor.java
@@ -125,22 +125,27 @@ public class RenameVisitor extends AbstractVisitor {
 
 	@Nullable
 	private static String fixClsShortName(JadxArgs args, String clsName) {
-		char firstChar = clsName.charAt(0);
 		boolean renameValid = args.isRenameValid();
-		if (Character.isDigit(firstChar) && renameValid) {
-			return Consts.ANONYMOUS_CLASS_PREFIX + NameMapper.removeInvalidCharsMiddle(clsName);
-		}
-		if (firstChar == '$' && renameValid) {
-			return 'C' + NameMapper.removeInvalidCharsMiddle(clsName);
+		if (renameValid) {
+			char firstChar = clsName.charAt(0);
+			if (Character.isDigit(firstChar)) {
+				return Consts.ANONYMOUS_CLASS_PREFIX + NameMapper.removeInvalidCharsMiddle(clsName);
+			}
+			if (firstChar == '$') {
+				return 'C' + NameMapper.removeInvalidCharsMiddle(clsName);
+			}
 		}
 		String cleanClsName = args.isRenamePrintable()
-				? NameMapper.removeInvalidChars(clsName, "C")
+				? NameMapper.removeNonPrintableCharacters(clsName)
 				: clsName;
 		if (cleanClsName.isEmpty()) {
 			return null;
 		}
-		if (renameValid && !NameMapper.isValidIdentifier(cleanClsName)) {
-			return 'C' + cleanClsName;
+		if (renameValid) {
+			cleanClsName = NameMapper.removeInvalidChars(clsName, "C");
+			if (!NameMapper.isValidIdentifier(cleanClsName)) {
+				return 'C' + cleanClsName;
+			}
 		}
 		return cleanClsName;
 	}


### PR DESCRIPTION
I noticed that Jadx with only the "rename to make printable" option enabled was renaming fully printable class names like `1oN` (because they are not valid Java identifier but for that there is different option).