### PR TITLE
fix: "Always Select Opened File/Class" was not syncing upon activation

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -249,8 +249,8 @@ public class JadxSettings extends JadxCLIArgs {
 		return alwaysSelectOpened;
 	}
 
-	public void setAlwaysSelectOpened(boolean showHeapUsageBar) {
-		this.alwaysSelectOpened = showHeapUsageBar;
+	public void setAlwaysSelectOpened(boolean alwaysSelectOpened) {
+		this.alwaysSelectOpened = alwaysSelectOpened;
 		partialSync(settings -> settings.alwaysSelectOpened = alwaysSelectOpened);
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -868,6 +868,9 @@ public class MainWindow extends JFrame {
 		alwaysSelectOpened.setState(settings.isAlwaysSelectOpened());
 		alwaysSelectOpened.addActionListener(event -> {
 			settings.setAlwaysSelectOpened(!settings.isAlwaysSelectOpened());
+			if (settings.isAlwaysSelectOpened()) {
+				this.syncWithEditor();
+			}
 		});
 
 		Action syncAction = new AbstractAction(NLS.str("menu.sync"), ICON_SYNC) {


### PR DESCRIPTION
When activating the option "Always Select Opened File/Class" while having tabs with classes open, nothing happened where you would expect the currently selected class to be selected in class tree view.