### PR TITLE
Save jobf when decompiling to Java through the cli

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/DeobfPresets.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/DeobfPresets.java
@@ -134,7 +134,7 @@ public class DeobfPresets {
 			list.add(String.format("m %s = %s", mthEntry.getKey(), mthEntry.getValue()));
 		}
 		Collections.sort(list);
-		if (list.size() == 0) {
+		if (list.isEmpty()) {
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("Deobfuscation map is empty, not saving it");
 			}

--- a/jadx-core/src/main/java/jadx/core/deobf/DeobfPresets.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/DeobfPresets.java
@@ -134,6 +134,12 @@ public class DeobfPresets {
 			list.add(String.format("m %s = %s", mthEntry.getKey(), mthEntry.getValue()));
 		}
 		Collections.sort(list);
+		if (list.size() == 0) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Deobfuscation map is empty, not saving it");
+			}
+			return;
+		}
 		Files.write(deobfMapFile, list, MAP_FILE_CHARSET,
 				StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 		if (LOG.isDebugEnabled()) {

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/rename/RenameVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/rename/RenameVisitor.java
@@ -46,7 +46,7 @@ public class RenameVisitor extends AbstractVisitor {
 		checkClasses(deobfuscator, root, args);
 		UserRenames.applyForNodes(root);
 
-		if (args.isDeobfuscationOn()) {
+		if (args.isDeobfuscationOn() || !args.isJsonOutput()) {
 			deobfuscator.savePresets();
 			deobfuscator.clear();
 		}


### PR DESCRIPTION
As I suggested in #1274, the commit will output a jobf file when decompiling to Java.

I'm not sure if it should be on by default because there doesn't seem to be a way to disable it except of passing `/dev/null` as the deobfuscation name but I guess this is the same problem with the deobfuscation feature. What do you think?