### PR TITLE
fix: configured resource indexing size limit is now correctly considered

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/utils/search/ResourceIndex.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/search/ResourceIndex.java
@@ -202,12 +202,14 @@ public class ResourceIndex {
 				} else {
 					resNodes.add(resNode);
 				}
+			} else {
+				LOG.debug("Resource skipped because of size limit: {} res size {} bytes", resNode, size);
 			}
 		}
 	}
 
 	private void refreshSettings() {
-		int size = cache.getJadxSettings().getSrhResourceSkipSize() * 10240;
+		int size = cache.getJadxSettings().getSrhResourceSkipSize() * 1048576;
 		if (size != sizeLimit
 				|| !cache.getJadxSettings().getSrhResourceFileExt().equals(fileExts)) {
 			clear();
@@ -224,14 +226,10 @@ public class ResourceIndex {
 					extSet.add(ext);
 				}
 			}
-			try {
-				ZipFile zipFile = getZipFile(cache.getJRoot());
+			try (ZipFile zipFile = getZipFile(cache.getJRoot())) {
 				traverseTree(cache.getJRoot(), zipFile); // reindex
-				if (zipFile != null) {
-					zipFile.close();
-				}
 			} catch (Exception e) {
-				e.printStackTrace();
+				LOG.error("Failed to apply settings to resource index", e);
 			}
 		}
 	}


### PR DESCRIPTION
According to the preferences page the resource size index limit is specified in MB but in code it was size * 10KB instead.