### PR TITLE
Minor fixes XML decoding and APK signature description

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
@@ -109,7 +109,7 @@ public class ValuesParser extends ParserConstants {
 			case TYPE_INT_DEC:
 				return Integer.toString(data);
 			case TYPE_INT_HEX:
-				return Integer.toHexString(data);
+				return "0x" + Integer.toHexString(data);
 			case TYPE_INT_BOOLEAN:
 				return data == 0 ? "false" : "true";
 			case TYPE_FLOAT:

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -237,7 +237,7 @@ apkSignature.signatureFailed=Ungültige APK-Signatur v%d gefunden
 apkSignature.errors=Fehler
 apkSignature.warnings=Warnhinweise
 apkSignature.exception=APK-Verifizierung fehlgeschlagen
-apkSignature.unprotectedEntry=Dateien, die nicht durch eine Signatur geschützt sind. Unbefugte Änderungen an diesem JAR-Eintrag werden nicht erkannt.
+apkSignature.unprotectedEntry=Dateien, die nicht durch eine APK-Signatur v1 geschützt sind. Unbefugte Änderungen an diesen Einträgen werden nur von einer APK-Signatur v2 oder neuer erkannt.
 
 issues_panel.label=Probleme:
 issues_panel.errors=%d Fehler

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -237,7 +237,7 @@ apkSignature.signatureFailed=Invalid APK signature v%d found
 apkSignature.errors=Errors
 apkSignature.warnings=Warnings
 apkSignature.exception=APK verification failed
-apkSignature.unprotectedEntry=Files that are not protected by signature. Unauthorized modifications to this JAR entry will not be detected.
+apkSignature.unprotectedEntry=Files that are not protected by APK signature v1. Unauthorized modifications to these entries can only be detected by APK signature v2 and higher.
 
 issues_panel.label=Issues:
 issues_panel.errors=%d errors


### PR DESCRIPTION
I noticed to minor problems:

1. Hexadecimal integers e.g. in AndrdoirManifest.xml were correctly decoded as hex values but the `0x`prefix was missing.
2. The warning about unprotected entries in APK signature only applies to v1 signatures. EN + DE text updated accordingly. Not sure how to handle this for KR and CN languages.