### PR TITLE
Update the report parsing in Quark integration

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportData.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportData.java
@@ -3,6 +3,7 @@ package jadx.gui.plugins.quark;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.SerializedName;
 
 import jadx.core.utils.Utils;
@@ -15,7 +16,7 @@ public class QuarkReportData {
 		public List<String> permissions;
 
 		List<Method> native_api;
-		List<String[]> combination;
+		List<JsonElement> combination;
 		List<Map<String, InvokePlace>> register;
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportPanel.java
@@ -32,6 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.Strings;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 
 import jadx.api.JavaClass;
 import jadx.api.JavaMethod;
@@ -246,13 +248,15 @@ public class QuarkReportPanel extends ContentPanel {
 				}
 				add(node);
 			}
-			List<String[]> combination = crime.combination;
-			if (Utils.notEmpty(combination)) {
+			List<JsonElement> combination = crime.combination;
+			if (Utils.notEmpty(combination) && combination.get(0) instanceof JsonArray) {
 				TextTreeNode node = new TextTreeNode("Combination");
 				int size = combination.size();
 				for (int i = 0; i < size; i++) {
 					TextTreeNode set = new TextTreeNode("Set " + i);
-					for (String mth : combination.get(i)) {
+					JsonArray array = (JsonArray) combination.get(i);
+					for (JsonElement ele : array) {
+						String mth = ele.getAsString();
 						set.add(resolveMethod(mth));
 					}
 					node.add(set);


### PR DESCRIPTION
### Description
Please refer to #1289

This PR aims to:
1. make the parsing logic compatible with both versions of Quark reports.
2. show the additional information defined in the old format if possible.

Tested with Quark-Engine v21.8.1, v21.10.2, and v21.11.*.