### PR TITLE
XML decoding speed enhancement

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
@@ -334,6 +334,15 @@ public class RootNode {
 		return resolveClass(clsInfo);
 	}
 
+	/**
+	 * Searches for ClassNode by its full name (original or alias name)
+	 *
+	 * Warning: This method has a runtime of O(n) (n = number of classes).
+	 * If you need to call it more than once consider {@link #buildFullAliasClassCache()} instead
+	 *
+	 * @param fullName
+	 * @return
+	 */
 	@Nullable
 	public ClassNode searchClassByFullAlias(String fullName) {
 		for (ClassNode cls : classes) {
@@ -344,6 +353,24 @@ public class RootNode {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public Map<String, ClassNode> buildFullAliasClassCache() {
+		Map<String, ClassNode> classNameCache = new HashMap<>(classes.size());
+		for (ClassNode cls : classes) {
+			ClassInfo classInfo = cls.getClassInfo();
+			String fullName = classInfo.getFullName();
+			String alias = classInfo.getAliasFullName();
+			classNameCache.put(fullName, cls);
+			if (alias != null && !fullName.equals(alias)) {
+				classNameCache.put(alias, cls);
+			}
+		}
+		return classNameCache;
 	}
 
 	public List<ClassNode> searchClassByShortName(String shortName) {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -471,6 +471,9 @@ public class BinaryXMLParser extends CommonBinaryParser {
 	}
 
 	private void attachClassNode(ICodeWriter writer, String attrName, String clsName) {
+		if (!writer.isMetadataSupported()) {
+			return;
+		}
 		if (clsName == null || !attrName.equals("name")) {
 			return;
 		}

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -56,6 +56,8 @@ public class BinaryXMLParser extends CommonBinaryParser {
 	private final RootNode rootNode;
 	private String appPackageName;
 
+	private Map<String, ClassNode> classNameCache;
+
 	public BinaryXMLParser(RootNode rootNode) {
 		this.rootNode = rootNode;
 		try {
@@ -78,7 +80,9 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		firstElement = true;
 		decode();
 		nsMap = null;
-		return writer.finish();
+		ICodeInfo codeInfo = writer.finish();
+		this.classNameCache = null; // reset class name cache
+		return codeInfo;
 	}
 
 	private boolean isBinaryXml() throws IOException {
@@ -476,7 +480,10 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		} else {
 			clsFullName = clsName;
 		}
-		ClassNode classNode = rootNode.searchClassByFullAlias(clsFullName);
+		if (classNameCache == null) {
+			classNameCache = rootNode.buildFullAliasClassCache();
+		}
+		ClassNode classNode = classNameCache.get(clsFullName);
 		if (classNode != null) {
 			writer.attachAnnotation(classNode);
 		}


### PR DESCRIPTION
On a large APK I had the problem that AndroidManifest.xml generation took ~1 minute or more because the method to search for class references loops over all classes every time a potential reference is found in the XML. 

Instead I added a cache (on-demand initialization) so that we only have to loop one time over all classes now. To reflect changes the cache is deleted after each parse call. 

Cache handling is not thread safe as in my tests it seems like resource decoding is not done multi-threaded.