### PR TITLE
chore: use relative file paths in .jadx project file (#1312)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
@@ -31,22 +31,13 @@ import jadx.gui.settings.data.ProjectData;
 import jadx.gui.settings.data.TabViewState;
 import jadx.gui.ui.MainWindow;
 import jadx.gui.ui.codearea.EditorViewState;
-import jadx.gui.utils.PathTypeAdapter;
+import jadx.gui.utils.RelativePathTypeAdapter;
 
 public class JadxProject {
 	private static final Logger LOG = LoggerFactory.getLogger(JadxProject.class);
 
 	private static final int CURRENT_PROJECT_VERSION = 1;
 	public static final String PROJECT_EXTENSION = "jadx";
-
-	private static final Gson GSON = new GsonBuilder()
-			.registerTypeHierarchyAdapter(Path.class, PathTypeAdapter.singleton())
-			.registerTypeAdapter(ICodeComment.class, GsonUtils.interfaceReplace(JadxCodeComment.class))
-			.registerTypeAdapter(ICodeRename.class, GsonUtils.interfaceReplace(JadxCodeRename.class))
-			.registerTypeAdapter(IJavaNodeRef.class, GsonUtils.interfaceReplace(JadxNodeRef.class))
-			.registerTypeAdapter(IJavaCodeRef.class, GsonUtils.interfaceReplace(JadxCodeRef.class))
-			.setPrettyPrinting()
-			.create();
 
 	private transient MainWindow mainWindow;
 	private transient JadxSettings settings;
@@ -179,9 +170,10 @@ public class JadxProject {
 	}
 
 	public void save() {
-		if (getProjectPath() != null) {
-			try (Writer writer = Files.newBufferedWriter(getProjectPath(), StandardCharsets.UTF_8)) {
-				GSON.toJson(data, writer);
+		Path savePath = getProjectPath();
+		if (savePath != null) {
+			try (Writer writer = Files.newBufferedWriter(savePath, StandardCharsets.UTF_8)) {
+				buildGson(savePath.getParent()).toJson(data, writer);
 				saved = true;
 			} catch (Exception e) {
 				LOG.error("Error saving project", e);
@@ -192,7 +184,7 @@ public class JadxProject {
 	public static JadxProject from(Path path) {
 		try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
 			JadxProject project = new JadxProject();
-			project.data = GSON.fromJson(reader, ProjectData.class);
+			project.data = buildGson(path.getParent()).fromJson(reader, ProjectData.class);
 			project.saved = true;
 			project.setProjectPath(path);
 			project.upgrade();
@@ -201,6 +193,17 @@ public class JadxProject {
 			LOG.error("Error loading project", e);
 			return null;
 		}
+	}
+
+	private static Gson buildGson(Path basePath) {
+		return new GsonBuilder()
+				.registerTypeHierarchyAdapter(Path.class, new RelativePathTypeAdapter(basePath))
+				.registerTypeAdapter(ICodeComment.class, GsonUtils.interfaceReplace(JadxCodeComment.class))
+				.registerTypeAdapter(ICodeRename.class, GsonUtils.interfaceReplace(JadxCodeRename.class))
+				.registerTypeAdapter(IJavaNodeRef.class, GsonUtils.interfaceReplace(JadxNodeRef.class))
+				.registerTypeAdapter(IJavaCodeRef.class, GsonUtils.interfaceReplace(JadxCodeRef.class))
+				.setPrettyPrinting()
+				.create();
 	}
 
 	private void upgrade() {

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxProject.java
@@ -172,8 +172,9 @@ public class JadxProject {
 	public void save() {
 		Path savePath = getProjectPath();
 		if (savePath != null) {
+			Path basePath = savePath.toAbsolutePath().getParent();
 			try (Writer writer = Files.newBufferedWriter(savePath, StandardCharsets.UTF_8)) {
-				buildGson(savePath.getParent()).toJson(data, writer);
+				buildGson(basePath).toJson(data, writer);
 				saved = true;
 			} catch (Exception e) {
 				LOG.error("Error saving project", e);
@@ -182,9 +183,10 @@ public class JadxProject {
 	}
 
 	public static JadxProject from(Path path) {
+		Path basePath = path.toAbsolutePath().getParent();
 		try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
 			JadxProject project = new JadxProject();
-			project.data = buildGson(path.getParent()).fromJson(reader, ProjectData.class);
+			project.data = buildGson(basePath).fromJson(reader, ProjectData.class);
 			project.saved = true;
 			project.setProjectPath(path);
 			project.upgrade();

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -364,9 +364,8 @@ public class MainWindow extends JFrame {
 		if (this.project.getFilePaths().size() == 1) {
 			// If there is only one file loaded we suggest saving the jadx project file next to the loaded file
 			Path loadedFile = this.project.getFilePaths().get(0);
-			String fileName = loadedFile.getFileName().toString();
-			fileName += ".jadx";
-			fileChooser.setSelectedFile(loadedFile.getParent().resolve(fileName).toFile());
+			String fileName = loadedFile.getFileName() + "." + JadxProject.PROJECT_EXTENSION;
+			fileChooser.setSelectedFile(loadedFile.resolveSibling(fileName).toFile());
 		}
 		int ret = fileChooser.showSaveDialog(mainPanel);
 		if (ret == JFileChooser.APPROVE_OPTION) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -361,6 +361,13 @@ public class MainWindow extends JFrame {
 		if (currentDirectory != null) {
 			fileChooser.setCurrentDirectory(currentDirectory.toFile());
 		}
+		if (this.project.getFilePaths().size() == 1) {
+			// If there is only one file loaded we suggest saving the jadx project file next to the loaded file
+			Path loadedFile = this.project.getFilePaths().get(0);
+			String fileName = loadedFile.getFileName().toString();
+			fileName += ".jadx";
+			fileChooser.setSelectedFile(loadedFile.getParent().resolve(fileName).toFile());
+		}
 		int ret = fileChooser.showSaveDialog(mainPanel);
 		if (ret == JFileChooser.APPROVE_OPTION) {
 			settings.setLastSaveProjectPath(fileChooser.getCurrentDirectory().toPath());

--- a/jadx-gui/src/main/java/jadx/gui/utils/RelativePathTypeAdapter.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/RelativePathTypeAdapter.java
@@ -1,0 +1,43 @@
+package jadx.gui.utils;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+public class RelativePathTypeAdapter extends TypeAdapter<Path> {
+	private final Path basePath;
+
+	public RelativePathTypeAdapter(Path basePath) {
+		this.basePath = basePath;
+	}
+
+	@Override
+	public void write(JsonWriter out, Path value) throws IOException {
+		if (value == null) {
+			out.nullValue();
+		} else {
+			value = value.toAbsolutePath().normalize();
+			String relativePath = basePath.relativize(value).toString();
+			out.value(relativePath);
+		}
+	}
+
+	@Override
+	public Path read(JsonReader in) throws IOException {
+		if (in.peek() == JsonToken.NULL) {
+			in.nextNull();
+			return null;
+		}
+		Path p = Paths.get(in.nextString());
+		if (p.isAbsolute()) {
+			return p;
+		}
+		return basePath.resolve(p);
+	}
+
+}

--- a/jadx-gui/src/main/java/jadx/gui/utils/RelativePathTypeAdapter.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/RelativePathTypeAdapter.java
@@ -3,6 +3,7 @@ package jadx.gui.utils;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
@@ -13,7 +14,7 @@ public class RelativePathTypeAdapter extends TypeAdapter<Path> {
 	private final Path basePath;
 
 	public RelativePathTypeAdapter(Path basePath) {
-		this.basePath = basePath;
+		this.basePath = Objects.requireNonNull(basePath);
 	}
 
 	@Override


### PR DESCRIPTION
Additionally the save as dialog now suggests a file name for the jadx project file if only one file is loaded.