### PR TITLE
fix: processing threads spinner initialization (#1331)

### DIFF
--- a/jadx-core/src/main/java/jadx/api/JadxArgs.java
+++ b/jadx-core/src/main/java/jadx/api/JadxArgs.java
@@ -138,7 +138,7 @@ public class JadxArgs {
 	}
 
 	public void setThreadsCount(int threadsCount) {
-		this.threadsCount = threadsCount;
+		this.threadsCount = Math.max(1, threadsCount); // make sure threadsCount >= 1
 	}
 
 	public boolean isCfgOutput() {

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
@@ -433,9 +433,10 @@ public class JadxSettingsWindow extends JDialog {
 			needReload();
 		});
 
-		int threadsCountMax = Math.max(2, Runtime.getRuntime().availableProcessors() * 2); // fix for #1331
-		SpinnerNumberModel spinnerModel = new SpinnerNumberModel(
-				settings.getThreadsCount(), 1, threadsCountMax, 1);
+		// fix for #1331
+		int threadsCountValue = settings.getThreadsCount();
+		int threadsCountMax = Math.max(2, Math.max(threadsCountValue, Runtime.getRuntime().availableProcessors() * 2));
+		SpinnerNumberModel spinnerModel = new SpinnerNumberModel(threadsCountValue, 1, threadsCountMax, 1);
 		JSpinner threadsCount = new JSpinner(spinnerModel);
 		threadsCount.addChangeListener(e -> {
 			settings.setThreadsCount((Integer) threadsCount.getValue());

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettingsWindow.java
@@ -433,8 +433,9 @@ public class JadxSettingsWindow extends JDialog {
 			needReload();
 		});
 
+		int threadsCountMax = Math.max(2, Runtime.getRuntime().availableProcessors() * 2); // fix for #1331
 		SpinnerNumberModel spinnerModel = new SpinnerNumberModel(
-				settings.getThreadsCount(), 1, Runtime.getRuntime().availableProcessors() * 2, 1);
+				settings.getThreadsCount(), 1, threadsCountMax, 1);
 		JSpinner threadsCount = new JSpinner(spinnerModel);
 		threadsCount.addChangeListener(e -> {
 			settings.setThreadsCount((Integer) threadsCount.getValue());


### PR DESCRIPTION
Preferences: processing threads spinner initialization fixed so that it allows to select 1 or 2 threads even if Java is unable to determine the maximum number of available processors.