### PR TITLE
add frida action to copy methods/classes as frida snippets

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -94,10 +94,12 @@ public final class CodeArea extends AbstractCodeArea {
 		GoToDeclarationAction goToDeclaration = new GoToDeclarationAction(this);
 		RenameAction rename = new RenameAction(this);
 		CommentAction comment = new CommentAction(this);
+		FridaAction frida = new FridaAction(this);
 
 		JPopupMenu popup = getPopupMenu();
 		popup.addSeparator();
 		popup.add(findUsage);
+		popup.add(frida);
 		popup.add(goToDeclaration);
 		popup.add(comment);
 		popup.add(new CommentSearchAction(this));

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -1,0 +1,191 @@
+package jadx.gui.ui.codearea;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.swing.*;
+
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jadx.api.data.annotations.VarDeclareRef;
+import jadx.core.dex.info.MethodInfo;
+import jadx.core.dex.instructions.args.ArgType;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.core.dex.nodes.MethodNode;
+import jadx.gui.treemodel.JClass;
+import jadx.gui.treemodel.JMethod;
+import jadx.gui.treemodel.JNode;
+import jadx.gui.utils.NLS;
+
+import static javax.swing.KeyStroke.getKeyStroke;
+
+public final class FridaAction extends JNodeMenuAction<JNode> {
+	private static final Logger LOG = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+	private static final long serialVersionUID = 4692546569977976384L;
+	private Map<String, Boolean> isInitial = new HashMap<>();
+	private String methodName;
+
+	public FridaAction(CodeArea codeArea) {
+
+		super(NLS.str("popup.frida") + " (f)", codeArea);
+		LOG.info("triggered meee");
+		KeyStroke key = getKeyStroke(KeyEvent.VK_F, 0);
+		codeArea.getInputMap().put(key, "trigger frida");
+		codeArea.getActionMap().put("trigger frida", new AbstractAction() {
+			@Override
+
+			public void actionPerformed(ActionEvent e) {
+				node = getNodeByOffset(codeArea.getWordStart(codeArea.getCaretPosition()));
+				copyFridaCode();
+			}
+		});
+	}
+
+	private void copyFridaCode() {
+
+		if (node != null) {
+			if (node instanceof JMethod) {
+				JMethod n = (JMethod) node;
+				MethodNode methodNode = n.getJavaMethod().getMethodNode();
+				MethodInfo mi = methodNode.getMethodInfo();
+				methodName = mi.getName();
+				if (methodName.equals("<init>") || methodName.equals("onCreate")) {
+					methodName = "$init";
+				}
+				String fullClassName = methodNode.getParentClass().getFullName();
+				String className = methodNode.getParentClass().getShortName();
+				LOG.debug("node is jmethod");
+				ClassNode tmp = methodNode.getParentClass();
+				while (true) {
+					if (!tmp.isTopClass()) {
+						fullClassName = fullClassName.substring(0, fullClassName.lastIndexOf(".")) + "$"
+								+ fullClassName.substring(fullClassName.lastIndexOf(".") + 1, fullClassName.length());
+					} else {
+						break;
+					}
+					tmp = tmp.getParentClass();
+				}
+				JMethod jMth = (JMethod) node;
+				int mthLine = jMth.getLine();
+				List<String> argNames = jMth.getRootClass().getCodeInfo().getAnnotations().entrySet().stream()
+						.filter(e -> e.getKey().getLine() == mthLine && e.getValue() instanceof VarDeclareRef)
+						.sorted(Comparator.comparingInt(e -> e.getKey().getPos()))
+						.map(e -> ((VarDeclareRef) e.getValue()).getName())
+						.collect(Collectors.toList());
+
+				StringBuilder functionParameters = new StringBuilder();
+				for (String argName : argNames) {
+					functionParameters.append(argName + ", ");
+				}
+				if (functionParameters.toString().length() > 2) {
+					functionParameters.setLength(functionParameters.length() - 2);
+				}
+
+				List<MethodNode> methods = methodNode.getParentClass().getMethods();
+				List<MethodNode> filteredmethod = methods.stream().filter(m -> m.getName().equals(methodName)).collect(Collectors.toList());
+				StringBuilder sb = new StringBuilder();
+				String overloadStr = "";
+				if (filteredmethod.size() > 1) {
+					List<ArgType> methodArgs = mi.getArgumentsTypes();
+					for (ArgType argType : methodArgs) {
+						sb.append("'" + parseArgType(argType) + "', ");
+					}
+					if (sb.length() > 2) {
+						sb.setLength(sb.length() - 2);
+					}
+					overloadStr = sb.toString();
+
+				}
+				String functionUntilImplementation = "";
+				if (!overloadStr.equals("")) {
+					functionUntilImplementation = String.format("%s.%s.overload(%s).implementation", className, methodName, overloadStr);
+				} else {
+					functionUntilImplementation = String.format("%s.%s.implementation", className, methodName);
+				}
+				String functionParameterAndBody = "";
+				if (!functionParameters.equals("")) {
+					functionParameterAndBody = String.format(
+							"%s = function(%s){\n\tconsole.log('%s is called')\n\tlet ret = this.%s(%s)\n\tconsole.log('%s ret value is ' + ret)\n\treturn ret\n}",
+							functionUntilImplementation, functionParameters, methodName, methodName, functionParameters, methodName);
+				} else {
+					functionParameterAndBody = String.format(
+							"%s = function(){\n\tconsole.log('%s is called')\n\tlet ret = this.%s()\n\tconsole.log('%s ret value is ' + ret)\n\treturn ret\n}",
+							functionUntilImplementation, methodName, methodName, methodName);
+				}
+				String finalFridaCode = "";
+				if (isInitial.getOrDefault(fullClassName, true)) {
+					finalFridaCode = String.format("let %s = Java.use(\"%s\")\n%s", className, fullClassName, functionParameterAndBody);
+					isInitial.put(fullClassName, false);
+				} else {
+					finalFridaCode = functionParameterAndBody;
+				}
+				LOG.debug("frida code : " + finalFridaCode);
+				Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+				StringSelection selection = new StringSelection(finalFridaCode);
+				clipboard.setContents(selection, selection);
+
+			} else if (node instanceof JClass) {
+				LOG.debug("node is jclass");
+				JClass jc = (JClass) node;
+				String fullClassName = jc.getCls().getClassNode().getClassInfo().getFullName();
+				String className = jc.getCls().getClassNode().getClassInfo().getShortName();
+				ClassNode tmp = jc.getCls().getClassNode();
+				while (true) {
+					if (!tmp.isTopClass()) {
+						fullClassName = fullClassName.substring(0, fullClassName.lastIndexOf(".")) + "$"
+								+ fullClassName.substring(fullClassName.lastIndexOf(".") + 1, fullClassName.length());
+					} else {
+						break;
+					}
+					tmp = tmp.getParentClass();
+				}
+				String finalFridaCode = String.format("let %s = Java.use(\"%s\")", className, fullClassName);
+				Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+				StringSelection selection = new StringSelection(finalFridaCode);
+				clipboard.setContents(selection, selection);
+				LOG.debug("frida code : " + finalFridaCode);
+				isInitial.put(fullClassName, false);
+			} else {
+				LOG.debug("node is something else");
+			}
+
+		}
+	}
+
+	private String parseArgType(ArgType x) {
+		StringBuilder parsedArgType = new StringBuilder();
+		if (x.isArray()) {
+			parsedArgType.append(x.getPrimitiveType().getShortName());
+			parsedArgType.append(x.getArrayElement().getPrimitiveType().getShortName());
+			if (!x.getArrayElement().isPrimitive()) {
+				parsedArgType.append(x.getArrayElement().toString() + ";");
+			}
+
+		} else {
+			parsedArgType.append(x.toString());
+		}
+		return parsedArgType.toString();
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		node = codeArea.getNodeUnderCaret();
+		copyFridaCode();
+	}
+
+	@Nullable
+	@Override
+	public JNode getNodeByOffset(int offset) {
+		return codeArea.getJNodeAtOffset(offset);
+	}
+}

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -113,10 +113,12 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 					functionUntilImplementation = String.format("%s.%s.implementation", className, methodName);
 				}
 				String functionParameterAndBody = "";
-				if (!functionParameters.equals("")) {
+				String functionParametersString = functionParameters.toString();
+				if (!functionParametersString.equals("")) {
 					functionParameterAndBody = String.format(
 							"%s = function(%s){\n\tconsole.log('%s is called')\n\tlet ret = this.%s(%s)\n\tconsole.log('%s ret value is ' + ret)\n\treturn ret\n}",
-							functionUntilImplementation, functionParameters, methodName, methodName, functionParameters, methodName);
+							functionUntilImplementation, functionParametersString, methodName, methodName, functionParametersString,
+							methodName);
 				} else {
 					functionParameterAndBody = String.format(
 							"%s = function(){\n\tconsole.log('%s is called')\n\tlet ret = this.%s()\n\tconsole.log('%s ret value is ' + ret)\n\treturn ret\n}",

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -193,6 +193,7 @@ popup.copy=Kopieren
 popup.paste=Einfügen
 popup.delete=Löschen
 popup.select_all=Alle auswählen
+popup.frida=Als Frida-Snippet kopieren
 popup.find_usage=Verwendung suchen
 popup.go_to_declaration=Zur Erklärung gehen
 popup.exclude=Ausschließen

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -193,6 +193,7 @@ popup.copy=Copy
 popup.paste=Paste
 popup.delete=Delete
 popup.select_all=Select All
+popup.frida=Copy as frida snippet
 popup.find_usage=Find Usage
 popup.go_to_declaration=Go to declaration
 popup.exclude=Exclude

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -193,6 +193,7 @@ popup.copy=Copiar
 popup.paste=Pegar
 popup.delete=Borrar
 popup.select_all=Seleccionar todo
+popup.frida=Copiar como fragmento de frida 
 #popup.find_usage=
 #popup.go_to_declaration=
 #popup.exclude=

--- a/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
@@ -193,6 +193,7 @@ popup.copy=붙여넣기
 popup.paste=복사
 popup.delete=삭제
 popup.select_all=모두 선택
+popup.frida=frida 스니펫으로 복사 
 popup.find_usage=사용 찾기
 popup.go_to_declaration=선언문으로 이동
 popup.exclude=제외

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -193,6 +193,7 @@ popup.copy=复制
 popup.paste=粘贴
 popup.delete=删除
 popup.select_all=全选
+popup.frida=复制为 frida 片段 
 popup.find_usage=查找用例
 popup.go_to_declaration=跳到声明
 popup.exclude=排除此包

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
@@ -193,6 +193,7 @@ popup.copy=複製
 popup.paste=貼上
 popup.delete=刪除
 popup.select_all=全選
+popup.frida=复制为 frida 片段 
 popup.find_usage=尋找使用情況
 popup.go_to_declaration=前往宣告
 popup.exclude=排除


### PR DESCRIPTION
PR for #1355.
Adds `Copy as frida snippet` option to code area popup.
- Adds correct overload signature to function snippets.
- Adds arguments (with names) as function parameter.
- Tracks which class definition already given to user. ( no duplicate definitions )
- Inserts kinda dummy information logging to function body.
- Inserts $ to inner class names so frida will be happy.