### PR TITLE
Add log messages in initialization phase

### DIFF
--- a/jadx-cli/src/main/java/jadx/cli/LogHelper.java
+++ b/jadx-cli/src/main/java/jadx/cli/LogHelper.java
@@ -54,7 +54,7 @@ public class LogHelper {
 		Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 		rootLogger.setLevel(logLevel.getLevel());
 
-		if (logLevel != LogLevelEnum.QUIET) {
+		if (logLevel == LogLevelEnum.PROGRESS) {
 			// show progress for all levels except quiet
 			setLevelForClass(JadxCLI.class, Level.INFO);
 			setLevelForClass(JadxDecompiler.class, Level.INFO);

--- a/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
+++ b/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
@@ -128,6 +128,7 @@ public final class JadxDecompiler implements Closeable {
 				loadedInputs.add(loadResult);
 			}
 		}
+		LOG.debug("Loaded using {} inputs plugin", loadedInputs.size());
 	}
 
 	private void reset() {

--- a/jadx-plugins/jadx-plugins-api/src/main/java/jadx/api/plugins/JadxPluginManager.java
+++ b/jadx-plugins/jadx-plugins-api/src/main/java/jadx/api/plugins/JadxPluginManager.java
@@ -39,6 +39,7 @@ public class JadxPluginManager {
 		ServiceLoader<JadxPlugin> jadxPlugins = ServiceLoader.load(JadxPlugin.class);
 		for (JadxPlugin plugin : jadxPlugins) {
 			addPlugin(plugin);
+			LOG.debug("Loading plugin: {}", plugin.getPluginInfo().getPluginId());
 		}
 		resolve();
 	}


### PR DESCRIPTION
I've had to resort to some print debugging because of a bug that occurred only outside Intellij, I've added a few logs that I think could be useful to others as well.

One thing to note: I don't think I saw the loaded input files message even in debug mode, not sure if it's a bug with the verbose flag