### PR TITLE
Fix/frida raw class names

### DIFF
--- a/jadx-core/src/main/java/jadx/api/JavaField.java
+++ b/jadx-core/src/main/java/jadx/api/JavaField.java
@@ -28,6 +28,10 @@ public final class JavaField implements JavaNode {
 		return parent.getFullName() + '.' + getName();
 	}
 
+	public String getRawName() {
+		return field.getName();
+	}
+
 	@Override
 	public JavaClass getDeclaringClass() {
 		return parent;

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
@@ -412,13 +412,12 @@ public class MethodNode extends NotificationAttrNode implements IMethodDetails, 
 		return Utils.collectionMap(exceptionsAttr.getList(), ArgType::object);
 	}
 
-
 	public List<MethodNode> getOverloads() {
 		List<MethodNode> methods = parentClass.getMethods();
 		MethodInfo thisMthInfo = this.mthInfo;
 		return methods.stream()
-				.filter(m -> m.getName().equals(thisMthInfo.getName()) && !Objects.equals(thisMthInfo.getShortId(), m.getMethodInfo().getShortId())
-				)
+				.filter(m -> m.getName().equals(thisMthInfo.getName())
+						&& !Objects.equals(thisMthInfo.getShortId(), m.getMethodInfo().getShortId()))
 				.collect(Collectors.toList());
 	}
 

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
@@ -412,15 +412,6 @@ public class MethodNode extends NotificationAttrNode implements IMethodDetails, 
 		return Utils.collectionMap(exceptionsAttr.getList(), ArgType::object);
 	}
 
-	public List<MethodNode> getOverloads() {
-		List<MethodNode> methods = parentClass.getMethods();
-		MethodInfo thisMthInfo = this.mthInfo;
-		return methods.stream()
-				.filter(m -> m.getName().equals(thisMthInfo.getName())
-						&& !Objects.equals(thisMthInfo.getShortId(), m.getMethodInfo().getShortId()))
-				.collect(Collectors.toList());
-	}
-
 	/**
 	 * Return true if exists method with same name and arguments count
 	 */

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -409,6 +410,16 @@ public class MethodNode extends NotificationAttrNode implements IMethodDetails, 
 			return Collections.emptyList();
 		}
 		return Utils.collectionMap(exceptionsAttr.getList(), ArgType::object);
+	}
+
+
+	public List<MethodNode> getOverloads() {
+		List<MethodNode> methods = parentClass.getMethods();
+		MethodInfo thisMthInfo = this.mthInfo;
+		return methods.stream()
+				.filter(m -> m.getName().equals(thisMthInfo.getName()) && !Objects.equals(thisMthInfo.getShortId(), m.getMethodInfo().getShortId())
+				)
+				.collect(Collectors.toList());
 	}
 
 	/**

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -105,6 +105,7 @@ public final class CodeArea extends AbstractCodeArea {
 		popup.add(new CommentSearchAction(this));
 		popup.add(rename);
 		popup.addPopupMenuListener(findUsage);
+		popup.addPopupMenuListener(frida);
 		popup.addPopupMenuListener(goToDeclaration);
 		popup.addPopupMenuListener(comment);
 		popup.addPopupMenuListener(rename);

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 
+import jadx.core.dex.nodes.ClassNode;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,7 +82,7 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 		String shortClassName = javaMethod.getDeclaringClass().getName();
 
 		String functionUntilImplementation;
-		if (!javaMethod.getMethodNode().getOverloads().isEmpty()) {
+		if (isOverloaded(javaMethod.getMethodNode())) {
 			List<ArgType> methodArgs = methodInfo.getArgumentsTypes();
 			String overloadStr = methodArgs.stream().map(this::parseArgType).collect(Collectors.joining(", "));
 			functionUntilImplementation = String.format("%s.%s.overload(%s).implementation", shortClassName, methodName, overloadStr);
@@ -139,6 +140,14 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 		String finalFridaCode = String.format("%s\n%s = %s.%s.value", classSnippet, fieldName, jc.getName(), rawFieldName);
 		LOG.debug("frida code : " + finalFridaCode);
 		return finalFridaCode;
+	}
+
+	public Boolean isOverloaded(MethodNode methodNode) {
+		ClassNode parentClass = methodNode.getParentClass();
+		List<MethodNode> methods = parentClass.getMethods();
+		return methods.stream()
+				.anyMatch(m -> m.getName().equals(methodNode.getName())
+						&& !Objects.equals(methodNode.getMethodInfo().getShortId(), m.getMethodInfo().getShortId()));
 	}
 
 	private String parseArgType(ArgType x) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -10,19 +10,19 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 
-import jadx.api.JavaClass;
-import jadx.api.JavaField;
-import jadx.api.JavaMethod;
-import jadx.gui.treemodel.JField;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jadx.api.JavaClass;
+import jadx.api.JavaField;
+import jadx.api.JavaMethod;
 import jadx.api.data.annotations.VarDeclareRef;
 import jadx.core.dex.info.MethodInfo;
 import jadx.core.dex.instructions.args.ArgType;
 import jadx.core.dex.nodes.MethodNode;
 import jadx.gui.treemodel.JClass;
+import jadx.gui.treemodel.JField;
 import jadx.gui.treemodel.JMethod;
 import jadx.gui.treemodel.JNode;
 import jadx.gui.utils.NLS;
@@ -70,7 +70,6 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 
 	}
 
-
 	private String generateMethodSnippet(JMethod jMth) {
 		JavaMethod javaMethod = jMth.getJavaMethod();
 		MethodInfo methodInfo = javaMethod.getMethodNode().getMethodInfo();
@@ -90,12 +89,12 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 			functionUntilImplementation = String.format("%s.%s.implementation", shortClassName, methodName);
 		}
 
-		String functionParametersString = Objects.requireNonNull(javaMethod.getTopParentClass().getCodeInfo()).getAnnotations().entrySet().stream()
-				.filter(e -> e.getKey().getLine() == jMth.getLine() && e.getValue() instanceof VarDeclareRef)
-				.sorted(Comparator.comparingInt(e -> e.getKey().getPos()))
-				.map(e -> ((VarDeclareRef) e.getValue()).getName())
-				.collect(Collectors.joining(", "));
-
+		String functionParametersString =
+				Objects.requireNonNull(javaMethod.getTopParentClass().getCodeInfo()).getAnnotations().entrySet().stream()
+						.filter(e -> e.getKey().getLine() == jMth.getLine() && e.getValue() instanceof VarDeclareRef)
+						.sorted(Comparator.comparingInt(e -> e.getKey().getPos()))
+						.map(e -> ((VarDeclareRef) e.getValue()).getName())
+						.collect(Collectors.joining(", "));
 
 		String functionParameterAndBody = String.format(
 				"%s = function(%s){\n\tconsole.log('%s is called')\n\tlet ret = this.%s(%s)\n\tconsole.log('%s ret value is ' + ret)\n\treturn ret\n}",
@@ -126,7 +125,6 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 		JavaField javaField = jf.getJavaField();
 		String rawFieldName = javaField.getRawName();
 		String fieldName = javaField.getName();
-
 
 		List<MethodNode> methodNodes = javaField.getFieldNode().getParentClass().getMethods();
 		for (MethodNode methodNode : methodNodes) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -35,7 +35,6 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 	public FridaAction(CodeArea codeArea) {
 
 		super(NLS.str("popup.frida") + " (f)", codeArea);
-		LOG.info("triggered meee");
 		KeyStroke key = getKeyStroke(KeyEvent.VK_F, 0);
 		codeArea.getInputMap().put(key, "trigger frida");
 		codeArea.getActionMap().put("trigger frida", new AbstractAction() {
@@ -64,7 +63,7 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 				LOG.debug("node is jmethod");
 				JMethod jMth = (JMethod) node;
 				int mthLine = jMth.getLine();
-				List<String> argNames = Objects.requireNonNull(jMth.getRootClass().getCodeInfo()).getAnnotations().entrySet().stream()
+				List<String> argNames = Objects.requireNonNull(methodNode.getTopParentClass().getCode()).getAnnotations().entrySet().stream()
 						.filter(e -> e.getKey().getLine() == mthLine && e.getValue() instanceof VarDeclareRef)
 						.sorted(Comparator.comparingInt(e -> e.getKey().getPos()))
 						.map(e -> ((VarDeclareRef) e.getValue()).getName())

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -30,7 +30,7 @@ import jadx.gui.utils.NLS;
 import static javax.swing.KeyStroke.getKeyStroke;
 
 public final class FridaAction extends JNodeMenuAction<JNode> {
-	private static final Logger LOG = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+	private static final Logger LOG = LoggerFactory.getLogger(FridaAction.class);
 	private static final long serialVersionUID = 4692546569977976384L;
 	private final Map<String, Boolean> isInitial = new HashMap<>();
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 
-import jadx.core.dex.nodes.ClassNode;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +20,7 @@ import jadx.api.JavaMethod;
 import jadx.api.data.annotations.VarDeclareRef;
 import jadx.core.dex.info.MethodInfo;
 import jadx.core.dex.instructions.args.ArgType;
+import jadx.core.dex.nodes.ClassNode;
 import jadx.core.dex.nodes.MethodNode;
 import jadx.gui.treemodel.JClass;
 import jadx.gui.treemodel.JField;

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -85,7 +85,7 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 			functionUntilImplementation = String.format("%s.%s.implementation", className, methodName);
 		}
 
-		String functionParametersString = Objects.requireNonNull(methodNode.getTopParentClass().getCode()).getAnnotations().entrySet().stream()
+		String functionParametersString = Objects.requireNonNull(jMth.getJavaMethod().getTopParentClass().getCodeInfo()).getAnnotations().entrySet().stream()
 				.filter(e -> e.getKey().getLine() == jMth.getLine() && e.getValue() instanceof VarDeclareRef)
 				.sorted(Comparator.comparingInt(e -> e.getKey().getPos()))
 				.map(e -> ((VarDeclareRef) e.getValue()).getName())

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -98,7 +98,7 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 						.collect(Collectors.joining(", "));
 
 		String functionParameterAndBody = String.format(
-				"%s = function(%s){\n\tconsole.log('%s is called')\n\tlet ret = this.%s(%s)\n\tconsole.log('%s ret value is ' + ret)\n\treturn ret\n}",
+				"%s = function(%s){\n\tconsole.log('%s is called');\n\tlet ret = this.%s(%s);\n\tconsole.log('%s ret value is ' + ret);\n\treturn ret;\n}",
 				functionUntilImplementation, functionParametersString, methodName, methodName, functionParametersString, methodName);
 
 		String finalFridaCode;
@@ -116,7 +116,7 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 		JavaClass javaClass = jc.getCls();
 		String rawClassName = javaClass.getRawName();
 		String shortClassName = javaClass.getName();
-		String finalFridaCode = String.format("let %s = Java.use(\"%s\")", shortClassName, rawClassName);
+		String finalFridaCode = String.format("let %s = Java.use(\"%s\");", shortClassName, rawClassName);
 		LOG.debug("frida code : " + finalFridaCode);
 		isInitial.put(rawClassName, false);
 		return finalFridaCode;
@@ -137,7 +137,7 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 
 		JClass jc = jf.getRootClass();
 		String classSnippet = generateClassSnippet(jc);
-		String finalFridaCode = String.format("%s\n%s = %s.%s.value", classSnippet, fieldName, jc.getName(), rawFieldName);
+		String finalFridaCode = String.format("%s\n%s = %s.%s.value;", classSnippet, fieldName, jc.getName(), rawFieldName);
 		LOG.debug("frida code : " + finalFridaCode);
 		return finalFridaCode;
 	}


### PR DESCRIPTION
As described in #1365 I changed the Frida snippet to use the raw name of the class instead of the renamed name.
I also cleaned the code a bit, and added the ability to generate a snippet for accessing fields.

BTW, I noticed a very strange behavior when trying to get the top parent of an inlined class.
I noticed that when I do `javaMethod.getTopParentClass()` I get the parent of the class after it was inlined.
However when I tried to `methodNode().getTopParentClass()` for the same method I got the inner class.
Is this the intended behavior? If not I will open an issue with an example.