### PR TITLE
Refactoring

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/ConditionGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ConditionGen.java
@@ -3,6 +3,7 @@ package jadx.core.codegen;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.Set;
 
 import jadx.api.ICodeWriter;
 import jadx.core.dex.attributes.AFlag;
@@ -13,6 +14,7 @@ import jadx.core.dex.instructions.args.ArgType;
 import jadx.core.dex.instructions.args.InsnArg;
 import jadx.core.dex.instructions.args.InsnWrapArg;
 import jadx.core.dex.instructions.args.LiteralArg;
+import jadx.core.dex.instructions.mods.TernaryInsn;
 import jadx.core.dex.nodes.InsnNode;
 import jadx.core.dex.regions.conditions.Compare;
 import jadx.core.dex.regions.conditions.IfCondition;

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/ArithNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/ArithNode.java
@@ -15,27 +15,27 @@ import jadx.core.utils.exceptions.JadxRuntimeException;
 public class ArithNode extends InsnNode {
 
 	public static ArithNode build(InsnData insn, ArithOp op, ArgType type) {
-		RegisterArg resArg = InsnArg.reg(insn, 0, fixResultType(op, type));
+		RegisterArg resArg = InsnArg.register(insn, 0, fixResultType(op, type));
 		ArgType argType = fixArgType(op, type);
 		switch (insn.getRegsCount()) {
 			case 2:
-				return new ArithNode(op, resArg, InsnArg.reg(insn, 0, argType), InsnArg.reg(insn, 1, argType));
+				return new ArithNode(op, resArg, InsnArg.register(insn, 0, argType), InsnArg.register(insn, 1, argType));
 			case 3:
-				return new ArithNode(op, resArg, InsnArg.reg(insn, 1, argType), InsnArg.reg(insn, 2, argType));
+				return new ArithNode(op, resArg, InsnArg.register(insn, 1, argType), InsnArg.register(insn, 2, argType));
 			default:
 				throw new JadxRuntimeException("Unexpected registers count in " + insn);
 		}
 	}
 
 	public static ArithNode buildLit(InsnData insn, ArithOp op, ArgType type) {
-		RegisterArg resArg = InsnArg.reg(insn, 0, fixResultType(op, type));
+		RegisterArg resArg = InsnArg.register(insn, 0, fixResultType(op, type));
 		ArgType argType = fixArgType(op, type);
-		LiteralArg litArg = InsnArg.lit(insn, argType);
+		LiteralArg litArg = InsnArg.literal(insn, argType);
 		switch (insn.getRegsCount()) {
 			case 1:
-				return new ArithNode(op, resArg, InsnArg.reg(insn, 0, argType), litArg);
+				return new ArithNode(op, resArg, InsnArg.register(insn, 0, argType), litArg);
 			case 2:
-				return new ArithNode(op, resArg, InsnArg.reg(insn, 1, argType), litArg);
+				return new ArithNode(op, resArg, InsnArg.register(insn, 1, argType), litArg);
 			default:
 				throw new JadxRuntimeException("Unexpected registers count in " + insn);
 		}

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/FillArrayData.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/FillArrayData.java
@@ -70,22 +70,22 @@ public final class FillArrayData extends InsnNode {
 		switch (elemSize) {
 			case 1:
 				for (byte b : (byte[]) array) {
-					list.add(InsnArg.lit(b, type));
+					list.add(InsnArg.literal(b, type));
 				}
 				break;
 			case 2:
 				for (short b : (short[]) array) {
-					list.add(InsnArg.lit(b, type));
+					list.add(InsnArg.literal(b, type));
 				}
 				break;
 			case 4:
 				for (int b : (int[]) array) {
-					list.add(InsnArg.lit(b, type));
+					list.add(InsnArg.literal(b, type));
 				}
 				break;
 			case 8:
 				for (long b : (long[]) array) {
-					list.add(InsnArg.lit(b, type));
+					list.add(InsnArg.literal(b, type));
 				}
 				break;
 			default:

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/IfNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/IfNode.java
@@ -25,11 +25,11 @@ public class IfNode extends GotoNode {
 		super(InsnType.IF, insn.getTarget(), 2);
 		this.op = op;
 		ArgType argType = narrowTypeByOp(op);
-		addArg(InsnArg.reg(insn, 0, argType));
+		addArg(InsnArg.register(insn, 0, argType));
 		if (insn.getRegsCount() == 1) {
-			addArg(InsnArg.lit(0, argType));
+			addArg(InsnArg.literal(0, argType));
 		} else {
-			addArg(InsnArg.reg(insn, 1, argType));
+			addArg(InsnArg.register(insn, 1, argType));
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
@@ -67,50 +67,50 @@ public class InsnDecoder {
 
 			// move-result will be process in invoke and filled-new-array instructions
 			case MOVE_RESULT:
-				return insn(InsnType.MOVE_RESULT, InsnArg.reg(insn, 0, ArgType.UNKNOWN));
+				return insn(InsnType.MOVE_RESULT, InsnArg.register(insn, 0, ArgType.UNKNOWN));
 
 			case CONST:
-				LiteralArg narrowLitArg = InsnArg.lit(insn, ArgType.NARROW);
-				return insn(InsnType.CONST, InsnArg.reg(insn, 0, narrowLitArg.getType()), narrowLitArg);
+				LiteralArg narrowLitArg = InsnArg.literal(insn, ArgType.NARROW);
+				return insn(InsnType.CONST, InsnArg.register(insn, 0, narrowLitArg.getType()), narrowLitArg);
 
 			case CONST_WIDE:
-				LiteralArg wideLitArg = InsnArg.lit(insn, ArgType.WIDE);
-				return insn(InsnType.CONST, InsnArg.reg(insn, 0, wideLitArg.getType()), wideLitArg);
+				LiteralArg wideLitArg = InsnArg.literal(insn, ArgType.WIDE);
+				return insn(InsnType.CONST, InsnArg.register(insn, 0, wideLitArg.getType()), wideLitArg);
 
 			case CONST_STRING:
 				InsnNode constStrInsn = new ConstStringNode(insn.getIndexAsString());
-				constStrInsn.setResult(InsnArg.reg(insn, 0, ArgType.STRING));
+				constStrInsn.setResult(InsnArg.register(insn, 0, ArgType.STRING));
 				return constStrInsn;
 
 			case CONST_CLASS: {
 				ArgType clsType = ArgType.parse(insn.getIndexAsType());
 				InsnNode constClsInsn = new ConstClassNode(clsType);
-				constClsInsn.setResult(InsnArg.reg(insn, 0, ArgType.generic(Consts.CLASS_CLASS, clsType)));
+				constClsInsn.setResult(InsnArg.register(insn, 0, ArgType.generic(Consts.CLASS_CLASS, clsType)));
 				return constClsInsn;
 			}
 
 			case MOVE:
 				return insn(InsnType.MOVE,
-						InsnArg.reg(insn, 0, ArgType.NARROW),
-						InsnArg.reg(insn, 1, ArgType.NARROW));
+						InsnArg.register(insn, 0, ArgType.NARROW),
+						InsnArg.register(insn, 1, ArgType.NARROW));
 
 			case MOVE_MULTI:
 				int len = insn.getRegsCount();
 				InsnNode mmv = new InsnNode(InsnType.MOVE_MULTI, len);
 				for (int i = 0; i < len; i++) {
-					mmv.addArg(InsnArg.reg(insn, i, ArgType.UNKNOWN));
+					mmv.addArg(InsnArg.register(insn, i, ArgType.UNKNOWN));
 				}
 				return mmv;
 
 			case MOVE_WIDE:
 				return insn(InsnType.MOVE,
-						InsnArg.reg(insn, 0, ArgType.WIDE),
-						InsnArg.reg(insn, 1, ArgType.WIDE));
+						InsnArg.register(insn, 0, ArgType.WIDE),
+						InsnArg.register(insn, 1, ArgType.WIDE));
 
 			case MOVE_OBJECT:
 				return insn(InsnType.MOVE,
-						InsnArg.reg(insn, 0, ArgType.UNKNOWN_OBJECT),
-						InsnArg.reg(insn, 1, ArgType.UNKNOWN_OBJECT));
+						InsnArg.register(insn, 0, ArgType.UNKNOWN_OBJECT),
+						InsnArg.register(insn, 1, ArgType.UNKNOWN_OBJECT));
 
 			case ADD_INT:
 				return arith(insn, ArithOp.ADD, ArgType.INT);
@@ -132,9 +132,9 @@ public class InsnDecoder {
 
 			case RSUB_INT:
 				return new ArithNode(ArithOp.SUB,
-						InsnArg.reg(insn, 0, ArgType.INT),
-						InsnArg.lit(insn, ArgType.INT),
-						InsnArg.reg(insn, 1, ArgType.INT));
+						InsnArg.register(insn, 0, ArgType.INT),
+						InsnArg.literal(insn, ArgType.INT),
+						InsnArg.register(insn, 1, ArgType.INT));
 
 			case SUB_LONG:
 				return arith(insn, ArithOp.SUB, ArgType.LONG);
@@ -330,10 +330,10 @@ public class InsnDecoder {
 				return new GotoNode(insn.getTarget());
 
 			case THROW:
-				return insn(InsnType.THROW, null, InsnArg.reg(insn, 0, ArgType.THROWABLE));
+				return insn(InsnType.THROW, null, InsnArg.register(insn, 0, ArgType.THROWABLE));
 
 			case MOVE_EXCEPTION:
-				return insn(InsnType.MOVE_EXCEPTION, InsnArg.reg(insn, 0, ArgType.UNKNOWN_OBJECT_NO_ARRAY));
+				return insn(InsnType.MOVE_EXCEPTION, InsnArg.register(insn, 0, ArgType.UNKNOWN_OBJECT_NO_ARRAY));
 
 			case RETURN_VOID:
 				return new InsnNode(InsnType.RETURN, 0);
@@ -341,51 +341,51 @@ public class InsnDecoder {
 			case RETURN:
 				return insn(InsnType.RETURN,
 						null,
-						InsnArg.reg(insn, 0, method.getReturnType()));
+						InsnArg.register(insn, 0, method.getReturnType()));
 
 			case INSTANCE_OF:
 				InsnNode instInsn = new IndexInsnNode(InsnType.INSTANCE_OF, ArgType.parse(insn.getIndexAsType()), 1);
-				instInsn.setResult(InsnArg.reg(insn, 0, ArgType.BOOLEAN));
-				instInsn.addArg(InsnArg.reg(insn, 1, ArgType.UNKNOWN_OBJECT));
+				instInsn.setResult(InsnArg.register(insn, 0, ArgType.BOOLEAN));
+				instInsn.addArg(InsnArg.register(insn, 1, ArgType.UNKNOWN_OBJECT));
 				return instInsn;
 
 			case CHECK_CAST:
 				ArgType castType = ArgType.parse(insn.getIndexAsType());
 				InsnNode checkCastInsn = new IndexInsnNode(InsnType.CHECK_CAST, castType, 1);
-				checkCastInsn.setResult(InsnArg.reg(insn, 0, castType));
-				checkCastInsn.addArg(InsnArg.reg(insn, insn.getRegsCount() == 2 ? 1 : 0, ArgType.UNKNOWN_OBJECT));
+				checkCastInsn.setResult(InsnArg.register(insn, 0, castType));
+				checkCastInsn.addArg(InsnArg.register(insn, insn.getRegsCount() == 2 ? 1 : 0, ArgType.UNKNOWN_OBJECT));
 				return checkCastInsn;
 
 			case IGET:
 				FieldInfo igetFld = FieldInfo.fromRef(root, insn.getIndexAsField());
 				InsnNode igetInsn = new IndexInsnNode(InsnType.IGET, igetFld, 1);
-				igetInsn.setResult(InsnArg.reg(insn, 0, tryResolveFieldType(igetFld)));
-				igetInsn.addArg(InsnArg.reg(insn, 1, igetFld.getDeclClass().getType()));
+				igetInsn.setResult(InsnArg.register(insn, 0, tryResolveFieldType(igetFld)));
+				igetInsn.addArg(InsnArg.register(insn, 1, igetFld.getDeclClass().getType()));
 				return igetInsn;
 
 			case IPUT:
 				FieldInfo iputFld = FieldInfo.fromRef(root, insn.getIndexAsField());
 				InsnNode iputInsn = new IndexInsnNode(InsnType.IPUT, iputFld, 2);
-				iputInsn.addArg(InsnArg.reg(insn, 0, tryResolveFieldType(iputFld)));
-				iputInsn.addArg(InsnArg.reg(insn, 1, iputFld.getDeclClass().getType()));
+				iputInsn.addArg(InsnArg.register(insn, 0, tryResolveFieldType(iputFld)));
+				iputInsn.addArg(InsnArg.register(insn, 1, iputFld.getDeclClass().getType()));
 				return iputInsn;
 
 			case SGET:
 				FieldInfo sgetFld = FieldInfo.fromRef(root, insn.getIndexAsField());
 				InsnNode sgetInsn = new IndexInsnNode(InsnType.SGET, sgetFld, 0);
-				sgetInsn.setResult(InsnArg.reg(insn, 0, tryResolveFieldType(sgetFld)));
+				sgetInsn.setResult(InsnArg.register(insn, 0, tryResolveFieldType(sgetFld)));
 				return sgetInsn;
 
 			case SPUT:
 				FieldInfo sputFld = FieldInfo.fromRef(root, insn.getIndexAsField());
 				InsnNode sputInsn = new IndexInsnNode(InsnType.SPUT, sputFld, 1);
-				sputInsn.addArg(InsnArg.reg(insn, 0, tryResolveFieldType(sputFld)));
+				sputInsn.addArg(InsnArg.register(insn, 0, tryResolveFieldType(sputFld)));
 				return sputInsn;
 
 			case ARRAY_LENGTH:
 				InsnNode arrLenInsn = new InsnNode(InsnType.ARRAY_LENGTH, 1);
-				arrLenInsn.setResult(InsnArg.reg(insn, 0, ArgType.INT));
-				arrLenInsn.addArg(InsnArg.reg(insn, 1, ArgType.array(ArgType.UNKNOWN)));
+				arrLenInsn.setResult(InsnArg.register(insn, 0, ArgType.INT));
+				arrLenInsn.addArg(InsnArg.register(insn, 1, ArgType.array(ArgType.UNKNOWN)));
 				return arrLenInsn;
 
 			case AGET:
@@ -455,14 +455,14 @@ public class InsnDecoder {
 			case NEW_INSTANCE:
 				ArgType clsType = ArgType.parse(insn.getIndexAsType());
 				IndexInsnNode newInstInsn = new IndexInsnNode(InsnType.NEW_INSTANCE, clsType, 0);
-				newInstInsn.setResult(InsnArg.reg(insn, 0, clsType));
+				newInstInsn.setResult(InsnArg.register(insn, 0, clsType));
 				return newInstInsn;
 
 			case NEW_ARRAY:
 				return makeNewArray(insn);
 
 			case FILL_ARRAY_DATA:
-				return new FillArrayInsn(InsnArg.reg(insn, 0, ArgType.UNKNOWN_ARRAY), insn.getTarget());
+				return new FillArrayInsn(InsnArg.register(insn, 0, ArgType.UNKNOWN_ARRAY), insn.getTarget());
 			case FILL_ARRAY_DATA_PAYLOAD:
 				return new FillArrayData(((IArrayPayload) Objects.requireNonNull(insn.getPayload())));
 
@@ -483,12 +483,12 @@ public class InsnDecoder {
 			case MONITOR_ENTER:
 				return insn(InsnType.MONITOR_ENTER,
 						null,
-						InsnArg.reg(insn, 0, ArgType.UNKNOWN_OBJECT));
+						InsnArg.register(insn, 0, ArgType.UNKNOWN_OBJECT));
 
 			case MONITOR_EXIT:
 				return insn(InsnType.MONITOR_EXIT,
 						null,
-						InsnArg.reg(insn, 0, ArgType.UNKNOWN_OBJECT));
+						InsnArg.register(insn, 0, ArgType.UNKNOWN_OBJECT));
 
 			default:
 				throw new DecodeException("Unknown instruction: '" + insn + '\'');
@@ -497,7 +497,7 @@ public class InsnDecoder {
 
 	@NotNull
 	private SwitchInsn makeSwitch(InsnData insn, boolean packed) {
-		SwitchInsn swInsn = new SwitchInsn(InsnArg.reg(insn, 0, ArgType.UNKNOWN), insn.getTarget(), packed);
+		SwitchInsn swInsn = new SwitchInsn(InsnArg.register(insn, 0, ArgType.UNKNOWN), insn.getTarget(), packed);
 		ICustomPayload payload = insn.getPayload();
 		if (payload != null) {
 			swInsn.attachSwitchData(new SwitchData((ISwitchPayload) payload), insn.getTarget());
@@ -521,7 +521,7 @@ public class InsnDecoder {
 		}
 		int regsCount = insn.getRegsCount();
 		NewArrayNode newArr = new NewArrayNode(arrType, regsCount - 1);
-		newArr.setResult(InsnArg.reg(insn, 0, arrType));
+		newArr.setResult(InsnArg.register(insn, 0, arrType));
 		for (int i = 1; i < regsCount; i++) {
 			newArr.addArg(InsnArg.typeImmutableReg(insn, i, ArgType.INT));
 		}
@@ -545,13 +545,13 @@ public class InsnDecoder {
 		if (isRange) {
 			int r = insn.getReg(0);
 			for (int i = 0; i < regsCount; i++) {
-				regs[i] = InsnArg.reg(r, elType, typeImmutable);
+				regs[i] = InsnArg.register(r, elType, typeImmutable);
 				r++;
 			}
 		} else {
 			for (int i = 0; i < regsCount; i++) {
 				int regNum = insn.getReg(i);
-				regs[i] = InsnArg.reg(regNum, elType, typeImmutable);
+				regs[i] = InsnArg.register(regNum, elType, typeImmutable);
 			}
 		}
 		InsnNode node = new FilledNewArrayNode(elType, regs.length);
@@ -564,16 +564,16 @@ public class InsnDecoder {
 
 	private InsnNode cmp(InsnData insn, InsnType itype, ArgType argType) {
 		InsnNode inode = new InsnNode(itype, 2);
-		inode.setResult(InsnArg.reg(insn, 0, ArgType.INT));
-		inode.addArg(InsnArg.reg(insn, 1, argType));
-		inode.addArg(InsnArg.reg(insn, 2, argType));
+		inode.setResult(InsnArg.register(insn, 0, ArgType.INT));
+		inode.addArg(InsnArg.register(insn, 1, argType));
+		inode.addArg(InsnArg.register(insn, 2, argType));
 		return inode;
 	}
 
 	private InsnNode cast(InsnData insn, ArgType from, ArgType to) {
 		InsnNode inode = new IndexInsnNode(InsnType.CAST, to, 1);
-		inode.setResult(InsnArg.reg(insn, 0, to));
-		inode.addArg(InsnArg.reg(insn, 1, from));
+		inode.setResult(InsnArg.register(insn, 0, to));
+		inode.addArg(InsnArg.register(insn, 1, from));
 		return inode;
 	}
 
@@ -614,7 +614,7 @@ public class InsnDecoder {
 		InsnNode inode = new InsnNode(InsnType.AGET, 2);
 		inode.setResult(InsnArg.typeImmutableIfKnownReg(insn, 0, resType));
 		inode.addArg(InsnArg.typeImmutableIfKnownReg(insn, 1, ArgType.array(arrElemType)));
-		inode.addArg(InsnArg.reg(insn, 2, ArgType.NARROW_INTEGRAL));
+		inode.addArg(InsnArg.register(insn, 2, ArgType.NARROW_INTEGRAL));
 		return inode;
 	}
 
@@ -625,7 +625,7 @@ public class InsnDecoder {
 	private InsnNode arrayPut(InsnData insn, ArgType arrElemType, ArgType argType) {
 		InsnNode inode = new InsnNode(InsnType.APUT, 3);
 		inode.addArg(InsnArg.typeImmutableIfKnownReg(insn, 1, ArgType.array(arrElemType)));
-		inode.addArg(InsnArg.reg(insn, 2, ArgType.NARROW_INTEGRAL));
+		inode.addArg(InsnArg.register(insn, 2, ArgType.NARROW_INTEGRAL));
 		inode.addArg(InsnArg.typeImmutableIfKnownReg(insn, 0, argType));
 		return inode;
 	}
@@ -640,15 +640,15 @@ public class InsnDecoder {
 
 	private InsnNode neg(InsnData insn, ArgType type) {
 		InsnNode inode = new InsnNode(InsnType.NEG, 1);
-		inode.setResult(InsnArg.reg(insn, 0, type));
-		inode.addArg(InsnArg.reg(insn, 1, type));
+		inode.setResult(InsnArg.register(insn, 0, type));
+		inode.addArg(InsnArg.register(insn, 1, type));
 		return inode;
 	}
 
 	private InsnNode not(InsnData insn, ArgType type) {
 		InsnNode inode = new InsnNode(InsnType.NOT, 1);
-		inode.setResult(InsnArg.reg(insn, 0, type));
-		inode.addArg(InsnArg.reg(insn, 1, type));
+		inode.setResult(InsnArg.register(insn, 0, type));
+		inode.addArg(InsnArg.register(insn, 1, type));
 		return inode;
 	}
 

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/InvokeNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/InvokeNode.java
@@ -34,7 +34,7 @@ public class InvokeNode extends BaseInvokeNode {
 		}
 		int resReg = insn.getResultReg();
 		if (resReg != -1) {
-			setResult(InsnArg.reg(resReg, mth.getReturnType()));
+			setResult(InsnArg.register(resReg, mth.getReturnType()));
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/PhiInsn.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/PhiInsn.java
@@ -24,7 +24,7 @@ public final class PhiInsn extends InsnNode {
 
 	public PhiInsn(int regNum, int predecessors) {
 		this(predecessors);
-		setResult(InsnArg.reg(regNum, ArgType.UNKNOWN));
+		setResult(InsnArg.register(regNum, ArgType.UNKNOWN));
 		add(AFlag.DONT_INLINE);
 		add(AFlag.DONT_GENERATE);
 	}
@@ -35,7 +35,7 @@ public final class PhiInsn extends InsnNode {
 	}
 
 	public RegisterArg bindArg(BlockNode pred) {
-		RegisterArg arg = InsnArg.reg(getResult().getRegNum(), getResult().getInitType());
+		RegisterArg arg = InsnArg.register(getResult().getRegNum(), getResult().getInitType());
 		bindArg(arg, pred);
 		return arg;
 	}

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/InsnArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/InsnArg.java
@@ -26,19 +26,19 @@ public abstract class InsnArg extends Typed {
 	@Nullable("Null for method arguments")
 	protected InsnNode parentInsn;
 
-	public static RegisterArg reg(int regNum, ArgType type) {
+	public static RegisterArg register(int regNum, ArgType type) {
 		return new RegisterArg(regNum, type);
 	}
 
-	public static RegisterArg reg(InsnData insn, int argNum, ArgType type) {
-		return reg(insn.getReg(argNum), type);
+	public static RegisterArg register(InsnData insn, int argNum, ArgType type) {
+		return register(insn.getReg(argNum), type);
 	}
 
 	public static RegisterArg typeImmutableIfKnownReg(InsnData insn, int argNum, ArgType type) {
 		if (type.isTypeKnown()) {
 			return typeImmutableReg(insn.getReg(argNum), type);
 		}
-		return reg(insn.getReg(argNum), type);
+		return register(insn.getReg(argNum), type);
 	}
 
 	public static RegisterArg typeImmutableReg(InsnData insn, int argNum, ArgType type) {
@@ -46,10 +46,10 @@ public abstract class InsnArg extends Typed {
 	}
 
 	public static RegisterArg typeImmutableReg(int regNum, ArgType type) {
-		return reg(regNum, type, true);
+		return register(regNum, type, true);
 	}
 
-	public static RegisterArg reg(int regNum, ArgType type, boolean typeImmutable) {
+	public static RegisterArg register(int regNum, ArgType type, boolean typeImmutable) {
 		RegisterArg reg = new RegisterArg(regNum, type);
 		if (typeImmutable) {
 			reg.add(AFlag.IMMUTABLE_TYPE);
@@ -57,33 +57,17 @@ public abstract class InsnArg extends Typed {
 		return reg;
 	}
 
-	public static LiteralArg lit(long literal, ArgType type) {
+	public static LiteralArg literal(long literal, ArgType type) {
 		return LiteralArg.makeWithFixedType(literal, type);
 	}
 
-	public static LiteralArg lit(InsnData insn, ArgType type) {
-		return lit(insn.getLiteral(), type);
+	public static LiteralArg literal(InsnData insn, ArgType type) {
+		return literal(insn.getLiteral(), type);
 	}
 
 	private static InsnWrapArg wrap(InsnNode insn) {
 		insn.add(AFlag.WRAPPED);
 		return new InsnWrapArg(insn);
-	}
-
-	public boolean isRegister() {
-		return false;
-	}
-
-	public boolean isLiteral() {
-		return false;
-	}
-
-	public boolean isInsnWrap() {
-		return false;
-	}
-
-	public boolean isNamed() {
-		return false;
 	}
 
 	@Nullable
@@ -217,7 +201,7 @@ public abstract class InsnArg extends Typed {
 			LiteralArg litArg = (LiteralArg) this;
 			return litArg.getLiteral() == 0 && Objects.equals(litArg.getType(), ArgType.BOOLEAN);
 		}
-		return false;
+		return isNamed();
 	}
 
 	public boolean isTrue() {
@@ -225,7 +209,7 @@ public abstract class InsnArg extends Typed {
 			LiteralArg litArg = (LiteralArg) this;
 			return litArg.getLiteral() == 1 && Objects.equals(litArg.getType(), ArgType.BOOLEAN);
 		}
-		return false;
+		return isNamed();
 	}
 
 	public boolean isThis() {
@@ -243,7 +227,7 @@ public abstract class InsnArg extends Typed {
 		if (wrappedInsn != null && wrappedInsn.getType() == InsnType.IGET) {
 			return wrappedInsn.getArg(0).isAnyThis();
 		}
-		return false;
+		return isNamed();
 	}
 
 	public InsnNode unwrap() {
@@ -261,7 +245,7 @@ public abstract class InsnArg extends Typed {
 		if (isConst() && other.isConst()) {
 			return this.equals(other);
 		}
-		return false;
+		return isNamed();
 	}
 
 	protected final <T extends InsnArg> T copyCommonParams(T copy) {

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/InsnWrapArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/InsnWrapArg.java
@@ -57,18 +57,18 @@ public final class InsnWrapArg extends InsnArg {
 			return true;
 		}
 		if (!(o instanceof InsnWrapArg)) {
-			return false;
+			return isNamed();
 		}
 		InsnWrapArg that = (InsnWrapArg) o;
 		InsnNode thisInsn = wrappedInsn;
 		InsnNode thatInsn = that.wrappedInsn;
 		if (!thisInsn.isSame(thatInsn)) {
-			return false;
+			return isNamed();
 		}
 		int count = thisInsn.getArgsCount();
 		for (int i = 0; i < count; i++) {
 			if (!thisInsn.getArg(i).equals(thatInsn.getArg(i))) {
-				return false;
+				return isNamed();
 			}
 		}
 		return true;

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/LiteralArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/LiteralArg.java
@@ -67,7 +67,7 @@ public final class LiteralArg extends InsnArg {
 			case LONG:
 				return true;
 			default:
-				return false;
+				return isNamed();
 		}
 	}
 
@@ -83,7 +83,7 @@ public final class LiteralArg extends InsnArg {
 			double val = Double.longBitsToDouble(literal);
 			return val < 0 && Double.isFinite(val);
 		}
-		return false;
+		return isNamed();
 	}
 
 	@Nullable
@@ -119,7 +119,7 @@ public final class LiteralArg extends InsnArg {
 			return true;
 		}
 		if (o == null || getClass() != o.getClass()) {
-			return false;
+			return isNamed();
 		}
 		LiteralArg that = (LiteralArg) o;
 		return literal == that.literal && getType().equals(that.getType());
@@ -128,7 +128,7 @@ public final class LiteralArg extends InsnArg {
 	@Override
 	public String toString() {
 		try {
-			String value = TypeGen.literalToString(literal, getType(), StringUtils.getInstance(), true, false);
+			String value = TypeGen.literalToString(literal, getType(), StringUtils.getInstance(), true, isNamed());
 			if (getType().equals(ArgType.BOOLEAN) && (value.equals("true") || value.equals("false"))) {
 				return value;
 			}

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/NamedArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/NamedArg.java
@@ -43,7 +43,7 @@ public final class NamedArg extends InsnArg implements Named {
 			return true;
 		}
 		if (!(o instanceof NamedArg)) {
-			return false;
+			return super.isNamed();
 		}
 		return name.equals(((NamedArg) o).name);
 	}

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/RegisterArg.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/RegisterArg.java
@@ -121,7 +121,7 @@ public class RegisterArg extends InsnArg implements Named {
 	public boolean isNameEquals(InsnArg arg) {
 		String n = getName();
 		if (n == null || !(arg instanceof Named)) {
-			return false;
+			return isNamed();
 		}
 		return n.equals(((Named) arg).getName());
 	}
@@ -171,7 +171,7 @@ public class RegisterArg extends InsnArg implements Named {
 			return true;
 		}
 		if (!arg.isRegister()) {
-			return false;
+			return isNamed();
 		}
 		RegisterArg reg = (RegisterArg) arg;
 		return regNum == reg.getRegNum()
@@ -180,7 +180,7 @@ public class RegisterArg extends InsnArg implements Named {
 
 	public boolean sameReg(InsnArg arg) {
 		if (!arg.isRegister()) {
-			return false;
+			return isNamed();
 		}
 		return regNum == ((RegisterArg) arg).getRegNum();
 	}
@@ -204,7 +204,7 @@ public class RegisterArg extends InsnArg implements Named {
 			return true;
 		}
 		if (!(obj instanceof RegisterArg)) {
-			return false;
+			return isNamed();
 		}
 		RegisterArg other = (RegisterArg) obj;
 		return regNum == other.regNum

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/args/Typed.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/args/Typed.java
@@ -17,4 +17,20 @@ public abstract class Typed extends AttrNode {
 	public boolean isTypeImmutable() {
 		return false;
 	}
+
+	public boolean isRegister() {
+		return false;
+	}
+
+	public boolean isLiteral() {
+		return false;
+	}
+
+	public boolean isInsnWrap() {
+		return false;
+	}
+
+	public boolean isNamed() {
+		return false;
+	}
 }

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/invokedynamic/CustomLambdaCall.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/invokedynamic/CustomLambdaCall.java
@@ -56,7 +56,7 @@ public class CustomLambdaCall {
 		InvokeCustomNode resNode = buildMethodCall(mth, insn, isRange, values, callMthHandle);
 		int resReg = insn.getResultReg();
 		if (resReg != -1) {
-			resNode.setResult(InsnArg.reg(resReg, mth.getReturnType()));
+			resNode.setResult(InsnArg.register(resReg, mth.getReturnType()));
 		}
 		return resNode;
 	}

--- a/jadx-core/src/main/java/jadx/core/dex/instructions/invokedynamic/CustomStringConcat.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/invokedynamic/CustomStringConcat.java
@@ -56,7 +56,7 @@ public class CustomStringConcat {
 			processRecipe(recipe, concat, values, insn);
 			int resReg = insn.getResultReg();
 			if (resReg != -1) {
-				concat.setResult(InsnArg.reg(resReg, ArgType.STRING));
+				concat.setResult(InsnArg.register(resReg, ArgType.STRING));
 			}
 			return concat;
 		} catch (Exception e) {
@@ -84,7 +84,7 @@ public class CustomStringConcat {
 					sb.setLength(0);
 				}
 				if (argTag) {
-					concat.addArg(InsnArg.reg(insn, argNum++, ArgType.UNKNOWN));
+					concat.addArg(InsnArg.register(insn, argNum++, ArgType.UNKNOWN));
 				} else {
 					InsnArg constArg = buildInsnArgFromEncodedValue(values.get(constNum++));
 					concat.addArg(constArg);
@@ -101,7 +101,7 @@ public class CustomStringConcat {
 	private static InsnArg buildInsnArgFromEncodedValue(EncodedValue encodedValue) {
 		Object value = EncodedValueUtils.convertToConstValue(encodedValue);
 		if (value == null) {
-			return InsnArg.lit(0, ArgType.UNKNOWN);
+			return InsnArg.literal(0, ArgType.UNKNOWN);
 		}
 		if (value instanceof LiteralArg) {
 			return ((LiteralArg) value);

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/InsnNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/InsnNode.java
@@ -169,19 +169,19 @@ public class InsnNode extends LineAttrNode {
 	}
 
 	protected void addReg(InsnData insn, int i, ArgType type) {
-		addArg(InsnArg.reg(insn, i, type));
+		addArg(InsnArg.register(insn, i, type));
 	}
 
 	protected void addReg(int regNum, ArgType type) {
-		addArg(InsnArg.reg(regNum, type));
+		addArg(InsnArg.register(regNum, type));
 	}
 
 	protected void addLit(long literal, ArgType type) {
-		addArg(InsnArg.lit(literal, type));
+		addArg(InsnArg.literal(literal, type));
 	}
 
 	protected void addLit(InsnData insn, ArgType type) {
-		addArg(InsnArg.lit(insn, type));
+		addArg(InsnArg.literal(insn, type));
 	}
 
 	public int getOffset() {

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/MethodNode.java
@@ -171,7 +171,7 @@ public class MethodNode extends NotificationAttrNode implements IMethodDetails, 
 			thisArg = null;
 		} else {
 			ArgType thisClsType = typeUtils.expandTypeVariables(this, parentClass.getType());
-			RegisterArg arg = InsnArg.reg(pos++, thisClsType);
+			RegisterArg arg = InsnArg.register(pos++, thisClsType);
 			arg.add(AFlag.THIS);
 			arg.add(AFlag.IMMUTABLE_TYPE);
 			thisArg = arg;
@@ -183,7 +183,7 @@ public class MethodNode extends NotificationAttrNode implements IMethodDetails, 
 		argsList = new ArrayList<>(args.size());
 		for (ArgType argType : args) {
 			ArgType expandedType = typeUtils.expandTypeVariables(this, argType);
-			RegisterArg regArg = InsnArg.reg(pos, expandedType);
+			RegisterArg regArg = InsnArg.register(pos, expandedType);
 			regArg.add(AFlag.METHOD_ARGUMENT);
 			regArg.add(AFlag.IMMUTABLE_TYPE);
 			argsList.add(regArg);

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ConstInlineVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ConstInlineVisitor.java
@@ -226,7 +226,7 @@ public class ConstInlineVisitor extends AbstractVisitor {
 			if (argType.isObject() && literal != 0) {
 				argType = ArgType.NARROW_NUMBERS;
 			}
-			LiteralArg litArg = InsnArg.lit(literal, argType);
+			LiteralArg litArg = InsnArg.literal(literal, argType);
 			litArg.copyAttributesFrom(constArg);
 			if (!useInsn.replaceArg(arg, litArg)) {
 				return false;

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/InlineMethods.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/InlineMethods.java
@@ -136,7 +136,7 @@ public class InlineMethods extends AbstractVisitor {
 	}
 
 	private RegisterArg makeFakeArg(MethodNode mth, ArgType varType, String name) {
-		RegisterArg fakeArg = RegisterArg.reg(0, varType);
+		RegisterArg fakeArg = RegisterArg.register(0, varType);
 		SSAVar ssaVar = mth.makeNewSVar(fakeArg);
 		InitCodeVariables.initCodeVar(ssaVar);
 		fakeArg.setName(name);

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ReSugarCode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ReSugarCode.java
@@ -172,7 +172,7 @@ public class ReSugarCode extends AbstractVisitor {
 			if (index != prevIndex) {
 				// use zero for missing keys
 				for (long i = prevIndex + 1; i < index; i++) {
-					filledArr.addArg(InsnArg.lit(0, elemType));
+					filledArr.addArg(InsnArg.literal(0, elemType));
 				}
 			}
 			InsnNode put = entry.getValue();

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
@@ -488,7 +488,7 @@ public class SimplifyVisitor extends AbstractVisitor {
 	/* String concat without assign to variable will cause compilation error */
 	private static void checkResult(MethodNode mth, InsnNode concatInsn) {
 		if (concatInsn.getResult() == null) {
-			RegisterArg resArg = InsnArg.reg(0, ArgType.STRING);
+			RegisterArg resArg = InsnArg.register(0, ArgType.STRING);
 			SSAVar ssaVar = mth.makeNewSVar(resArg);
 			InitCodeVariables.initCodeVar(ssaVar);
 			ssaVar.setType(ArgType.STRING);

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockExceptionHandler.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockExceptionHandler.java
@@ -468,7 +468,7 @@ public class BlockExceptionHandler {
 		InsnNode me = BlockUtils.getLastInsn(block);
 		if (me != null && me.getType() == InsnType.MOVE_EXCEPTION) {
 			// set correct type for 'move-exception' operation
-			RegisterArg resArg = InsnArg.reg(me.getResult().getRegNum(), argType);
+			RegisterArg resArg = InsnArg.register(me.getResult().getRegNum(), argType);
 			resArg.copyAttributesFrom(me);
 			me.setResult(resArg);
 			me.add(AFlag.DONT_INLINE);

--- a/jadx-core/src/main/java/jadx/core/utils/EncodedValueUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/EncodedValueUtils.java
@@ -22,23 +22,23 @@ public class EncodedValueUtils {
 		Object value = encodedValue.getValue();
 		switch (encodedValue.getType()) {
 			case ENCODED_NULL:
-				return InsnArg.lit(0, ArgType.OBJECT);
+				return InsnArg.literal(0, ArgType.OBJECT);
 			case ENCODED_BOOLEAN:
 				return Boolean.TRUE.equals(value) ? LiteralArg.litTrue() : LiteralArg.litFalse();
 			case ENCODED_BYTE:
-				return InsnArg.lit((Byte) value, ArgType.BYTE);
+				return InsnArg.literal((Byte) value, ArgType.BYTE);
 			case ENCODED_SHORT:
-				return InsnArg.lit((Short) value, ArgType.SHORT);
+				return InsnArg.literal((Short) value, ArgType.SHORT);
 			case ENCODED_CHAR:
-				return InsnArg.lit((Character) value, ArgType.CHAR);
+				return InsnArg.literal((Character) value, ArgType.CHAR);
 			case ENCODED_INT:
-				return InsnArg.lit((Integer) value, ArgType.INT);
+				return InsnArg.literal((Integer) value, ArgType.INT);
 			case ENCODED_LONG:
-				return InsnArg.lit((Long) value, ArgType.LONG);
+				return InsnArg.literal((Long) value, ArgType.LONG);
 			case ENCODED_FLOAT:
-				return InsnArg.lit(Float.floatToIntBits((Float) value), ArgType.FLOAT);
+				return InsnArg.literal(Float.floatToIntBits((Float) value), ArgType.FLOAT);
 			case ENCODED_DOUBLE:
-				return InsnArg.lit(Double.doubleToLongBits((Double) value), ArgType.DOUBLE);
+				return InsnArg.literal(Double.doubleToLongBits((Double) value), ArgType.DOUBLE);
 			case ENCODED_STRING:
 				// noinspection RedundantCast
 				return (String) value;

--- a/jadx-core/src/test/java/jadx/tests/functional/TestIfCondition.java
+++ b/jadx-core/src/test/java/jadx/tests/functional/TestIfCondition.java
@@ -36,7 +36,7 @@ public class TestIfCondition {
 	}
 
 	private static InsnArg mockArg() {
-		return InsnArg.reg(0, ArgType.INT);
+		return InsnArg.register(0, ArgType.INT);
 	}
 
 	@Test

--- a/jadx-gui/src/main/java/jadx/gui/device/debugger/DbgUtils.java
+++ b/jadx-gui/src/main/java/jadx/gui/device/debugger/DbgUtils.java
@@ -130,6 +130,7 @@ public class DbgUtils {
 		int actionPos = 0; // last found action's index
 		String actionTag = "<action android:name=\"android.intent.action.MAIN\"";
 		int actionTagLen = 0; // beginning offset. suggested length set after first iteration
+
 		while (actionPos > -1) {
 			pos = content.indexOf(actionTag, actionPos + actionTagLen);
 			actionPos = pos;

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeArea.java
@@ -243,7 +243,7 @@ public abstract class AbstractCodeArea extends RSyntaxTextArea {
 	/**
 	 * Implement in this method the code that loads and sets the content to be displayed
 	 */
-	public abstract void load();
+	//public abstract void load();
 
 	/**
 	 * Implement in this method the code that reloads node from cache and sets the new content to be

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -75,7 +75,6 @@ public final class CodeArea extends AbstractCodeArea {
 		}
 	}
 
-	@Override
 	public void load() {
 		if (getText().isEmpty()) {
 			setText(node.getContent());

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
@@ -114,7 +114,7 @@ public class CodePanel extends JPanel {
 	}
 
 	public void load() {
-		codeArea.load();
+		//codeArea.load();
 		initLineNumbers();
 	}
 
@@ -137,6 +137,7 @@ public class CodePanel extends JPanel {
 			// nothing to show => hide lines view
 			mode = LineNumbersMode.DISABLE;
 		}
+
 		switch (mode) {
 			case DISABLE:
 				codeScrollPane.setRowHeaderView(null);

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CommentAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CommentAction.java
@@ -103,17 +103,8 @@ public class CommentAction extends AbstractAction implements DefaultPopupMenuLis
 			Object ann = topCls.getAnnotationAt(new CodePosition(line));
 			if (ann == null) {
 				// check if line with comment above node definition
-				try {
-					JavaNode defNode = linesInfo.getJavaNodeBelowLine(line);
-					if (defNode != null) {
-						String lineStr = codeArea.getLineText(line).trim();
-						if (lineStr.startsWith("//")) {
-							return new JadxCodeComment(JadxNodeRef.forJavaNode(defNode), "");
-						}
-					}
-				} catch (Exception e) {
-					LOG.error("Failed to check comment line: " + line, e);
-				}
+				JadxCodeComment defNode = getJadxCodeComment(line, linesInfo);
+				if (defNode != null) return defNode;
 				return null;
 			}
 
@@ -128,6 +119,22 @@ public class CommentAction extends AbstractAction implements DefaultPopupMenuLis
 			}
 		} catch (Exception e) {
 			LOG.error("Failed to add comment at line: " + line, e);
+		}
+		return null;
+	}
+
+	@Nullable
+	private JadxCodeComment getJadxCodeComment(int line, CodeLinesInfo linesInfo) {
+		try {
+			JavaNode defNode = linesInfo.getJavaNodeBelowLine(line);
+			if (defNode != null) {
+				String lineStr = codeArea.getLineText(line).trim();
+				if (lineStr.startsWith("//")) {
+					return new JadxCodeComment(JadxNodeRef.forJavaNode(defNode), "");
+				}
+			}
+		} catch (Exception e) {
+			LOG.error("Failed to check comment line: " + line, e);
 		}
 		return null;
 	}

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -28,6 +28,7 @@ import jadx.gui.treemodel.JNode;
 import jadx.gui.utils.NLS;
 import jadx.gui.utils.UiUtils;
 
+import static jadx.gui.ui.codearea.RenameAction.codeArea;
 import static javax.swing.KeyStroke.getKeyStroke;
 
 public final class FridaAction extends JNodeMenuAction<JNode> {
@@ -90,13 +91,7 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 		String shortClassName = javaMethod.getDeclaringClass().getName();
 
 		String functionUntilImplementation;
-		if (isOverloaded(javaMethod.getMethodNode())) {
-			List<ArgType> methodArgs = methodInfo.getArgumentsTypes();
-			String overloadStr = methodArgs.stream().map(this::parseArgType).collect(Collectors.joining(", "));
-			functionUntilImplementation = String.format("%s.%s.overload(%s).implementation", shortClassName, methodName, overloadStr);
-		} else {
-			functionUntilImplementation = String.format("%s.%s.implementation", shortClassName, methodName);
-		}
+		functionUntilImplementation = getString(javaMethod, methodInfo, methodName, shortClassName);
 
 		String functionParametersString =
 				Objects.requireNonNull(javaMethod.getTopParentClass().getCodeInfo()).getAnnotations().entrySet().stream()
@@ -122,6 +117,18 @@ public final class FridaAction extends JNodeMenuAction<JNode> {
 			finalFridaCode = functionParameterAndBody;
 		}
 		return finalFridaCode;
+	}
+
+	private String getString(JavaMethod javaMethod, MethodInfo methodInfo, String methodName, String shortClassName) {
+		String functionUntilImplementation;
+		if (isOverloaded(javaMethod.getMethodNode())) {
+			List<ArgType> methodArgs = methodInfo.getArgumentsTypes();
+			String overloadStr = methodArgs.stream().map(this::parseArgType).collect(Collectors.joining(", "));
+			functionUntilImplementation = String.format("%s.%s.overload(%s).implementation", shortClassName, methodName, overloadStr);
+		} else {
+			functionUntilImplementation = String.format("%s.%s.implementation", shortClassName, methodName);
+		}
+		return functionUntilImplementation;
 	}
 
 	private String generateClassSnippet(JClass jc) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/JNodeMenuAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/JNodeMenuAction.java
@@ -12,16 +12,17 @@ import org.jetbrains.annotations.Nullable;
 
 import jadx.gui.utils.UiUtils;
 
+import static jadx.gui.ui.codearea.RenameAction.codeArea;
+
 public abstract class JNodeMenuAction<T> extends AbstractAction implements PopupMenuListener {
 	private static final long serialVersionUID = -2600154727884853550L;
 
-	protected final transient CodeArea codeArea;
 	@Nullable
 	protected transient T node;
 
 	public JNodeMenuAction(String name, CodeArea codeArea) {
 		super(name);
-		this.codeArea = codeArea;
+		codeArea = codeArea; //Can be moved to
 	}
 
 	@Override

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/RenameAction.java
@@ -21,6 +21,7 @@ import static javax.swing.KeyStroke.getKeyStroke;
 public final class RenameAction extends JNodeMenuAction<JNode> {
 	private static final long serialVersionUID = -4680872086148463289L;
 
+	public static transient CodeArea codeArea;
 	private static final Logger LOG = LoggerFactory.getLogger(RenameAction.class);
 
 	public RenameAction(CodeArea codeArea) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/SearchBar.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/SearchBar.java
@@ -16,6 +16,7 @@ import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rtextarea.SearchContext;
 import org.fife.ui.rtextarea.SearchEngine;
 import org.fife.ui.rtextarea.SearchResult;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +44,9 @@ class SearchBar extends JToolBar {
 	private RSyntaxTextArea rTextArea;
 
 	private final JTextField searchField;
-	private final JToggleButton markAllCB;
-	private final JToggleButton regexCB;
-	private final JToggleButton wholeWordCB;
+	private JToggleButton markAllCB;
+	private JToggleButton regexCB;
+	private JToggleButton wholeWordCB;
 	private final JToggleButton matchCaseCB;
 	private boolean notFound;
 
@@ -78,6 +79,15 @@ class SearchBar extends JToolBar {
 
 		ActionListener forwardListener = e -> search(1);
 
+		matchCaseCB = getjToggleButton(forwardListener);
+
+		setFloatable(false);
+		setVisible(false);
+	}
+
+	@NotNull
+	private JToggleButton getjToggleButton(ActionListener forwardListener) {
+		final JToggleButton matchCaseCB;
 		matchCaseCB = new JToggleButton();
 		matchCaseCB.setIcon(ICON_MATCH);
 		matchCaseCB.setSelectedIcon(ICON_MATCH_SELECTED);
@@ -125,9 +135,7 @@ class SearchBar extends JToolBar {
 		closeButton.addActionListener(e -> toggle());
 		closeButton.setBorderPainted(false);
 		add(closeButton);
-
-		setFloatable(false);
-		setVisible(false);
+		return matchCaseCB;
 	}
 
 	public void toggle() {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/SmaliArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/SmaliArea.java
@@ -86,7 +86,6 @@ public final class SmaliArea extends AbstractCodeArea {
 		switchModel();
 	}
 
-	@Override
 	public void load() {
 		if (getText().isEmpty() || curVersion != shouldUseSmaliPrinterV2()) {
 			curVersion = shouldUseSmaliPrinterV2();


### PR DESCRIPTION
:exclamation: Please review the [guidelines for contributing](https://github.com/skylot/jadx/blob/master/CONTRIBUTING.md#Pull-Request-Process)

### Description
Extract Method:
Class: CommentAction
Package: jadx.gui.ui.codearea
Line: 106
Method Extracted to new method named getJadxCodeComment() at line 127.

Class: FridaAction
Package: jadx.gui.ui.codearea
Line: 93
Method Extracted to new method named getString() at line 121.

Rename Method:
Class: InsnArg
Package: jadx.core.dex.instructions.args
Line: 52
Method reg(), name changed according to its functionality. New name is register().

Class: InsnArg
Package: jadx.core.dex.instructions.args
Line: 93
Method lit(), name changed according to its functionality. New name is literal().

Move field:
Class JNodeMenuAction, variable codeArea which was declared at line 18,  is used only 2 times in that class. But it was used 4 times in class RenameAction.
So, moved that variable declaration to RenameAction. 

Pull-up method:
In package jadx.core.dex.instructions.args, class Typed is parent of InsnArg. Which have declaration of methods, isRegister(), isLiteral(), isInsnWrap() and isNamed(). 
These methods are further used in other child classes. I pulled up these methods to super class Typed and performed, pull-up method.

Push-down method:
Class AbtractCodeArea was extended by class SmaliArea and CodeArea, but one method named load() was rejected by SmaliArea so, I applied the concept of push-down refactoring method. I removed method load() from AbstractCodeArea and removed annotation of @override from subclass.

