### PR TITLE
Update appdata.xml

### DIFF
--- a/appdata.xml
+++ b/appdata.xml
@@ -7,24 +7,16 @@
     <summary>Dex to Java decompiler</summary>
     <description>
         <p>Command line and GUI tools for producing Java source code from Android Dex and Apk files</p>
-        <p>
-            <strong>Main features:</strong>
-            <ul>
-                <li>decompile Dalvik bytecode to java classes from APK, dex, aar, aab and zip files</li>
-                <li>decode AndroidManifest.xml and other resources from resources.arsc</li>
-                <li>deobfuscator included</li>
-            </ul>
-        </p>
-        <p>
-            <strong>jadx-gui features:</strong>
-            <ul>
-                <li>view decompiled code with highlighted syntax</li>
-                <li>jump to declaration</li>
-                <li>find usage</li>
-                <li>full text search</li>
-                <li>smali debugger, check https://github.com/skylot/jadx/wiki/Smali-debugger for setup and usage</li>
-            </ul>
-        </p>
+        <ul>
+            <li>decompile Dalvik bytecode to java classes from APK, dex, aar, aab and zip files</li>
+            <li>decode AndroidManifest.xml and other resources from resources.arsc</li>
+            <li>deobfuscator included</li>
+            <li>view decompiled code with highlighted syntax</li>
+            <li>jump to declaration</li>
+            <li>find usage</li>
+            <li>full text search</li>
+            <li>smali debugger</li>
+        </ul>
     </description>
     <screenshots>
         <screenshot type="default">


### PR DESCRIPTION
Don't count my PRs for this, I know exactly what I'm doing.
learned: appstream is a little picky princess

apparently she didn't like the taste of `<strong>` nodes

`<ul>`'s had to be moved outside of `<p>` or would just silently not render

Also removed the "Main features:" and "jadx-gui features:" texts before the lists and merged them, because "Main features:" is too short. You can't have short texts above lists, this is a very important reason to fail, world is going down otherwise.

```
builddir/files/share/appdata/com.github.skylot.jadx.appdata.xml: FAILED:
• style-invalid         : Content before <ul> is too short [18], at least 20 characters required
```

btw. for the future: you can check those appdata.xml files with `appstream-util validate <xml-file>`.
But you need to have luck that it does output all errors and not just say it is fine while rendering "(null)" in software stores.

whatever. You can see the current xml in action here:
https://flathub.org/apps/details/com.github.skylot.jadx

Should be fine now. If there are wishes from your side, tell me, I can test them on flathub before next release is made.
Also be careful if you want to edit the description in the future.

---

Fixes https://github.com/skylot/jadx/issues/1427#issuecomment-1083144197