### PR TITLE
Fix method mappings being saved as field mappings

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
@@ -132,7 +132,7 @@ public class Deobfuscator {
 			for (MethodNode mth : cls.getMethods()) {
 				MethodInfo methodInfo = mth.getMethodInfo();
 				if (methodInfo.hasAlias()) {
-					deobfPresets.getFldPresetMap().put(methodInfo.getRawFullId(), methodInfo.getAlias());
+					deobfPresets.getMthPresetMap().put(methodInfo.getRawFullId(), methodInfo.getAlias());
 				}
 			}
 		}


### PR DESCRIPTION
Looks like a typo or copy/paste problem from: https://github.com/skylot/jadx/commit/0c9e3227d0337dae81a246884f31c2a54e754aa6 _(So, release 1.3.3+)_

Resolves #1432 