### PR TITLE
Allow unsigned local lib builds ...gradle task: publishToMavenLocal (fixes #1438)

### DIFF
--- a/buildSrc/src/main/groovy/jadx-library.gradle
+++ b/buildSrc/src/main/groovy/jadx-library.gradle
@@ -66,6 +66,7 @@ publishing {
 }
 
 signing {
+	required { gradle.taskGraph.hasTask("publish") }
 	sign publishing.publications.mavenJava
 }
 


### PR DESCRIPTION
Accoding to Issue: #1438 I created this pull request since the solution is easy.

Currently the gradle task publishToMavenLocal can not be executed:
```
Execution failed for task ':jadx-core:signMavenJavaPublication'.
 Cannot perform signing task ':jadx-core:signMavenJavaPublication' because it has no configured signatory
```
-> gradle tries to sign all publishing tasks. But one might not have proper signing keys configured and one should not need signing for local builds.

Thus, I propose skipping signing for local builds according to:
https://docs.gradle.org/current/userguide/signing_plugin.html#sec:conditional_signing

Using:
```
signing {
    required { gradle.taskGraph.hasTask("publish") }
    sign publishing.publications.mavenJava
}
```
and thus only sign builds that should be published to the internet will be signed...publishing to local stays unsigned


Implementing this will also fix builds on jitpack.io ...see:
https://jitpack.io/#root-intruder/jadx

while skylot/jadx fails with aforementioned error:
https://jitpack.io/#skylot/jadx