### PR TITLE
feat: Add option to include/exclude dependencies when saving

### DIFF
--- a/jadx-core/src/main/java/jadx/api/JadxArgs.java
+++ b/jadx-core/src/main/java/jadx/api/JadxArgs.java
@@ -49,6 +49,7 @@ public class JadxArgs {
 
 	private boolean skipResources = false;
 	private boolean skipSources = false;
+	private boolean includeDependencies = false;
 
 	/**
 	 * Predicate that allows to filter the classes to be process based on their full name
@@ -259,6 +260,14 @@ public class JadxArgs {
 
 	public void setSkipSources(boolean skipSources) {
 		this.skipSources = skipSources;
+	}
+
+	public void setIncludeDependencies(boolean includeDependencies) {
+		this.includeDependencies = includeDependencies;
+	}
+
+	public boolean isIncludeDependencies() {
+		return includeDependencies;
 	}
 
 	public Predicate<String> getClassFilter() {
@@ -513,6 +522,7 @@ public class JadxArgs {
 				+ ", useImports=" + useImports
 				+ ", skipResources=" + skipResources
 				+ ", skipSources=" + skipSources
+				+ ", includeDependencies=" + includeDependencies
 				+ ", deobfuscationOn=" + deobfuscationOn
 				+ ", deobfuscationMapFile=" + deobfuscationMapFile
 				+ ", deobfuscationMapFileMode=" + deobfuscationMapFileMode

--- a/jadx-core/src/main/java/jadx/api/JadxArgs.java
+++ b/jadx-core/src/main/java/jadx/api/JadxArgs.java
@@ -49,12 +49,16 @@ public class JadxArgs {
 
 	private boolean skipResources = false;
 	private boolean skipSources = false;
-	private boolean includeDependencies = false;
 
 	/**
 	 * Predicate that allows to filter the classes to be process based on their full name
 	 */
 	private Predicate<String> classFilter = null;
+
+	/**
+	 * Save dependencies for classes accepted by {@code classFilter}
+	 */
+	private boolean includeDependencies = false;
 
 	private boolean deobfuscationOn = false;
 	private boolean useSourceNameAsClassAlias = false;

--- a/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
+++ b/jadx-core/src/main/java/jadx/api/JadxDecompiler.java
@@ -331,10 +331,14 @@ public final class JadxDecompiler implements Closeable {
 		List<JavaClass> classes = getClasses();
 		List<JavaClass> processQueue = new ArrayList<>(classes.size());
 		for (JavaClass cls : classes) {
-			if (cls.getClassNode().contains(AFlag.DONT_GENERATE)) {
+			ClassNode clsNode = cls.getClassNode();
+			if (clsNode.contains(AFlag.DONT_GENERATE)) {
 				continue;
 			}
-			if (classFilter != null && !classFilter.test(cls.getFullName())) {
+			if (classFilter != null && !classFilter.test(clsNode.getClassInfo().getFullName())) {
+				if (!args.isIncludeDependencies()) {
+					clsNode.add(AFlag.DONT_GENERATE);
+				}
 				continue;
 			}
 			processQueue.add(cls);

--- a/jadx-core/src/main/java/jadx/core/ProcessClass.java
+++ b/jadx-core/src/main/java/jadx/core/ProcessClass.java
@@ -99,6 +99,10 @@ public class ProcessClass {
 			return generateCode(topParentClass);
 		}
 		try {
+			if (cls.contains(AFlag.DONT_GENERATE)) {
+				process(cls, false);
+				return ICodeInfo.EMPTY;
+			}
 			for (ClassNode depCls : cls.getDependencies()) {
 				process(depCls, false);
 			}

--- a/jadx-core/src/main/java/jadx/core/utils/DecompilerScheduler.java
+++ b/jadx-core/src/main/java/jadx/core/utils/DecompilerScheduler.java
@@ -65,7 +65,7 @@ public class DecompilerScheduler implements IDecompileScheduler {
 				continue;
 			}
 			int depsSize = cls.getTotalDepsCount();
-			if (depsSize == 0) {
+			if (depsSize == 0 || !decompiler.getArgs().isIncludeDependencies()) {
 				// add classes without dependencies in merged batch
 				mergedBatch.add(cls);
 				if (mergedBatch.size() >= MERGED_BATCH_SIZE) {

--- a/jadx-core/src/main/java/jadx/core/utils/DecompilerScheduler.java
+++ b/jadx-core/src/main/java/jadx/core/utils/DecompilerScheduler.java
@@ -65,7 +65,7 @@ public class DecompilerScheduler implements IDecompileScheduler {
 				continue;
 			}
 			int depsSize = cls.getTotalDepsCount();
-			if (depsSize == 0 || !decompiler.getArgs().isIncludeDependencies()) {
+			if (depsSize == 0) {
 				// add classes without dependencies in merged batch
 				mergedBatch.add(cls);
 				if (mergedBatch.size() >= MERGED_BATCH_SIZE) {


### PR DESCRIPTION
By default, when a class filter is applied, only the matching files will be saved.
Alternatively, "setIncludeDependencies(true)" can be used to also have them saved.

Fix #1466