### PR TITLE
feat(gui): add parameters logging in Frida code snippet

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -92,15 +92,24 @@ public final class FridaAction extends JNodeAction {
 		} else {
 			functionUntilImplementation = String.format("%s[\"%s\"].implementation", shortClassName, methodName);
 		}
-		String functionParametersString = String.join(", ", collectMethodArgNames(javaMethod));
+
+		List<String> methodArgNames = collectMethodArgNames(javaMethod);
+
+		String functionParametersString = String.join(", ", methodArgNames);
+		String logParametersString =
+				methodArgNames.stream().map(e -> String.format("'%s: ' + %s", e, e)).collect(Collectors.joining(" + ', ' + "));
+		if (logParametersString.length() > 0) {
+			logParametersString = " + ', ' + " + logParametersString;
+		}
 		String functionParameterAndBody = String.format(
-				"%s = function(%s){\n"
-						+ "    console.log('%s is called');\n"
+				"%s = function (%s) {\n"
+						+ "    console.log('%s is called'%s);\n"
 						+ "    let ret = this.%s(%s);\n"
 						+ "    console.log('%s ret value is ' + ret);\n"
 						+ "    return ret;\n"
 						+ "};",
-				functionUntilImplementation, functionParametersString, methodName, methodName, functionParametersString, methodName);
+				functionUntilImplementation, functionParametersString, methodName, logParametersString, methodName,
+				functionParametersString, methodName);
 
 		return generateClassSnippet(jMth.getJParent()) + "\n" + functionParameterAndBody;
 	}


### PR DESCRIPTION
Add function parameters logging in Frida code snippet.
For Example, for the following Java method
```java
 public String testJadx(Object object, String string, Integer integer) {
     return "1";
 }
```
The following Frida code will be generated.
```javascript
let MainActivity = Java.use("com.testjadx.MainActivity");
MainActivity["testJadx"].overload('java.lang.Object', 'java.lang.String', 'java.lang.Integer').implementation = function (object, string, integer) {
    console.log('testJadx is called' + ', ' + 'object: ' + object + ', ' + 'string: ' + string + ', ' + 'integer: ' + integer);
    let ret = this.testJadx(object, string, integer);
    console.log('testJadx ret value is ' + ret);
    return ret;
};
```
When the method called in the following,
``` java
testJadx("obj", "str", 123);
```
Frida cli print the following output.
```
testJadx is called, object: obj, string: str, integer: 123
testJadx ret value is 1
```

#1497 