### PR TITLE
Fix restoration of windows saved state

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -1,9 +1,6 @@
 package jadx.gui.settings;
 
 import java.awt.Font;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.Rectangle;
 import java.awt.Window;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -220,32 +217,10 @@ public class JadxSettings extends JadxCLIArgs {
 			return false;
 		}
 		if (window instanceof MainWindow) {
-			int extendedState = getMainWindowExtendedState();
-			if (extendedState != JFrame.NORMAL) {
-				((JFrame) window).setExtendedState(extendedState);
-				return true;
-			}
+			((JFrame) window).setExtendedState(getMainWindowExtendedState());
 		}
-
-		if (!isContainedInAnyScreen(pos)) {
-			return false;
-		}
-
 		window.setBounds(pos.getBounds());
 		return true;
-	}
-
-	private static boolean isContainedInAnyScreen(WindowLocation pos) {
-		Rectangle bounds = pos.getBounds();
-		if (bounds.getX() > 0 && bounds.getY() > 0) {
-			for (GraphicsDevice gd : GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
-				if (gd.getDefaultConfiguration().getBounds().contains(bounds)) {
-					return true;
-				}
-			}
-		}
-		LOG.debug("Window saved position was ignored: {}", pos);
-		return false;
 	}
 
 	public boolean isShowHeapUsageBar() {

--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -1,6 +1,9 @@
 package jadx.gui.settings;
 
 import java.awt.Font;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.awt.Window;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -216,11 +219,26 @@ public class JadxSettings extends JadxCLIArgs {
 		if (pos == null || pos.getBounds() == null) {
 			return false;
 		}
+		if (!isAccessibleInAnyScreen(pos)) {
+			return false;
+		}
+		window.setBounds(pos.getBounds());
 		if (window instanceof MainWindow) {
 			((JFrame) window).setExtendedState(getMainWindowExtendedState());
 		}
-		window.setBounds(pos.getBounds());
 		return true;
+	}
+
+	private static boolean isAccessibleInAnyScreen(WindowLocation pos) {
+		Rectangle windowBounds = pos.getBounds();
+		for (GraphicsDevice gd : GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices()) {
+			Rectangle screenBounds = gd.getDefaultConfiguration().getBounds();
+			if (screenBounds.intersects(windowBounds)) {
+				return true;
+			}
+		}
+		LOG.debug("Window saved position was ignored: {}", pos);
+		return false;
 	}
 
 	public boolean isShowHeapUsageBar() {


### PR DESCRIPTION
Suggested code changes alter current behavior of window saved state restoration to address the following issues:
  - window saved bounds not being restored when they extend past screen bounds in any direction;
  - divider location of main window's split pane is restored incorrectly when main window state is restored to maximized.