### PR TITLE
QuarkReport: data validation added and other minor improvements

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportData.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportData.java
@@ -26,14 +26,15 @@ public class QuarkReportData {
 
 		@Override
 		public String toString() {
-			return "Crime{" +
-					"crime='" + crime + '\'' +
-					", confidence='" + confidence + '\'' +
-					", permissions=" + permissions +
-					", native_api=" + native_api +
-					", combination=" + combination +
-					", register=" + register +
-					'}';
+			final StringBuffer sb = new StringBuffer("Crime{");
+			sb.append("crime='").append(crime).append('\'');
+			sb.append(", confidence='").append(confidence).append('\'');
+			sb.append(", permissions=").append(permissions);
+			sb.append(", native_api=").append(native_api);
+			sb.append(", combination=").append(combination);
+			sb.append(", register=").append(register);
+			sb.append('}');
+			return sb.toString();
 		}
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportData.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportData.java
@@ -10,6 +10,7 @@ import jadx.core.utils.Utils;
 
 @SuppressWarnings("MemberName")
 public class QuarkReportData {
+
 	public static class Crime {
 		public String crime;
 		public String confidence;
@@ -18,6 +19,22 @@ public class QuarkReportData {
 		List<Method> native_api;
 		List<JsonElement> combination;
 		List<Map<String, InvokePlace>> register;
+
+		public int parseConfidence() {
+			return Integer.parseInt(confidence.replace("%", ""));
+		}
+
+		@Override
+		public String toString() {
+			return "Crime{" +
+					"crime='" + crime + '\'' +
+					", confidence='" + confidence + '\'' +
+					", permissions=" + permissions +
+					", native_api=" + native_api +
+					", combination=" + combination +
+					", register=" + register +
+					'}';
+		}
 	}
 
 	public static class Method {
@@ -46,4 +63,22 @@ public class QuarkReportData {
 	String threat_level;
 	int total_score;
 	List<Crime> crimes;
+
+	public void validate() {
+		if (crimes == null) {
+			throw new RuntimeException("Invalid data: \"crimes\" list missing");
+		}
+		for (Crime crime : crimes) {
+			if (crime.confidence == null) {
+				throw new RuntimeException("Confidence value missing: " + crime);
+			}
+			try {
+				crime.parseConfidence();
+			} catch (Exception e) {
+				throw new RuntimeException("Invalid crime entry: " + crime);
+			}
+		}
+
+	}
+
 }

--- a/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportNode.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportNode.java
@@ -1,5 +1,6 @@
 package jadx.gui.plugins.quark;
 
+import java.io.BufferedReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -33,12 +34,12 @@ public class QuarkReportNode extends JNode {
 
 	private static final ImageIcon ICON = UiUtils.openSvgIcon("ui/quark");
 
-	private final Path apkFile;
+	private final Path reportFile;
 
 	private ICodeInfo errorContent;
 
-	public QuarkReportNode(Path apkFile) {
-		this.apkFile = apkFile;
+	public QuarkReportNode(Path reportFile) {
+		this.reportFile = reportFile;
 	}
 
 	@Override
@@ -59,7 +60,11 @@ public class QuarkReportNode extends JNode {
 	@Override
 	public ContentPanel getContentPanel(TabbedPane tabbedPane) {
 		try {
-			QuarkReportData data = GSON.fromJson(Files.newBufferedReader(apkFile), QuarkReportData.class);
+			QuarkReportData data;
+			try (BufferedReader reader = Files.newBufferedReader(reportFile)) {
+				data = GSON.fromJson(reader, QuarkReportData.class);
+			}
+			data.validate();
 			return new QuarkReportPanel(tabbedPane, this, data);
 		} catch (Exception e) {
 			LOG.error("Quark report parse error", e);

--- a/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkReportPanel.java
@@ -70,7 +70,7 @@ public class QuarkReportPanel extends ContentPanel {
 	}
 
 	private void prepareData() {
-		data.crimes.sort(Comparator.comparingInt(c -> -Integer.parseInt(c.confidence.replace("%", ""))));
+		data.crimes.sort(Comparator.comparingInt(c -> -c.parseConfidence()));
 	}
 
 	private void initUI() {
@@ -290,7 +290,7 @@ public class QuarkReportPanel extends ContentPanel {
 			}
 			return new MethodTreeNode(javaMethod);
 		} catch (Exception e) {
-			LOG.error("Failed to parse method descriptor string", e);
+			LOG.error("Failed to parse method descriptor string: {}", descr, e);
 			return new TextTreeNode(descr);
 		}
 	}


### PR DESCRIPTION
Issues like #1548 are difficult to debug as they are cause by the data returned by Quark. 

I added data validation regarding the returned confidence value. In case this value is not as expected the whole record is printed, which allows a better understanding what went wrong in Quark.