### PR TITLE
fix: IndexOutOfBoundsException in JumpManager (#1576)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/utils/JumpManager.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/JumpManager.java
@@ -82,5 +82,6 @@ public class JumpManager {
 
 	public void reset() {
 		list.clear();
+		currentPos = 0;
 	}
 }


### PR DESCRIPTION
Upon opening a new file in Jadx `JumpManager` `list` is reset but not `currentPos`. This can end up in an `IndexOutOfBoundsException` if you use the back function as shown in #1576.