### PR TITLE
fix: NullPointerException in adb device viewer (#1585)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/device/protocol/ADB.java
+++ b/jadx-gui/src/main/java/jadx/gui/device/protocol/ADB.java
@@ -103,7 +103,7 @@ public class ADB {
 			}
 			return result;
 		} catch (SocketException e) {
-			LOG.error("Aborting readServiceProtocol: socket closed");
+			LOG.warn("Aborting readServiceProtocol: {}", e.toString());
 		} catch (IOException e) {
 			LOG.error("Failed to read readServiceProtocol", e);
 		}
@@ -207,7 +207,7 @@ public class ADB {
 					List<ADBDeviceInfo> deviceInfoList = new ArrayList<>(deviceLines.length);
 					for (String deviceLine : deviceLines) {
 						if (!deviceLine.trim().isEmpty()) {
-							deviceInfoList.add(ADBDeviceInfo.make(deviceLine, host, port));
+							deviceInfoList.add(new ADBDeviceInfo(deviceLine, host, port));
 						}
 					}
 					listener.onDeviceStatusChange(deviceInfoList);

--- a/jadx-gui/src/main/java/jadx/gui/device/protocol/ADBDeviceInfo.java
+++ b/jadx-gui/src/main/java/jadx/gui/device/protocol/ADBDeviceInfo.java
@@ -1,15 +1,86 @@
 package jadx.gui.device.protocol;
 
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jadx.core.utils.log.LogUtils;
+
 public class ADBDeviceInfo {
-	public String adbHost;
-	public int adbPort;
-	public String serial;
-	public String state;
-	public String model;
-	public String allInfo;
+	private static final Logger LOG = LoggerFactory.getLogger(ADBDeviceInfo.class);
+	private final String adbHost;
+	private final int adbPort;
+	private final String serial;
+	private final String state;
+	private final String model;
+	private final String allInfo;
+
+	/**
+	 * Store the device info property values like "device" "model" "product" or "transport_id"
+	 */
+	private final Map<String, String> propertiesMap = new TreeMap<>();
+
+	ADBDeviceInfo(String info, String host, int port) {
+		String[] infoFields = info.trim().split("\\s+");
+		allInfo = String.join(" ", infoFields);
+		if (infoFields.length > 2) {
+			serial = infoFields[0];
+			state = infoFields[1];
+
+			for (int i = 2; i < infoFields.length; i++) {
+				String field = infoFields[i];
+				int idx = field.indexOf(':');
+				if (idx > 0) {
+					String key = field.substring(0, idx);
+					String value = field.substring(idx + 1);
+					if (!value.isEmpty()) {
+						propertiesMap.put(key, value);
+					}
+				}
+			}
+			model = propertiesMap.getOrDefault("model", serial);
+		} else {
+			LOG.error("Unable to extract device information from {}", LogUtils.escape(info));
+			serial = "";
+			state = "unknown";
+			model = "unknown";
+		}
+		adbHost = host;
+		adbPort = port;
+	}
 
 	public boolean isOnline() {
 		return state.equals("device");
+	}
+
+	public String getAdbHost() {
+		return adbHost;
+	}
+
+	public int getAdbPort() {
+		return adbPort;
+	}
+
+	public String getSerial() {
+		return serial;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public String getModel() {
+		return model;
+	}
+
+	public String getAllInfo() {
+		return allInfo;
+	}
+
+	public String getProperty(String key) {
+		return this.propertiesMap.get(key);
 	}
 
 	@Override
@@ -17,26 +88,4 @@ public class ADBDeviceInfo {
 		return allInfo;
 	}
 
-	static ADBDeviceInfo make(String info, String host, int port) {
-		ADBDeviceInfo deviceInfo = new ADBDeviceInfo();
-		String[] infoFields = info.trim().split("\\s+");
-		deviceInfo.allInfo = String.join(" ", infoFields);
-		if (infoFields.length > 2) {
-			deviceInfo.serial = infoFields[0];
-			deviceInfo.state = infoFields[1];
-		}
-		int pos = info.indexOf("model:");
-		if (pos != -1) {
-			int spacePos = info.indexOf(" ", pos);
-			if (spacePos != -1) {
-				deviceInfo.model = info.substring(pos + "model:".length(), spacePos);
-			}
-		}
-		if (deviceInfo.model == null || deviceInfo.model.equals("")) {
-			deviceInfo.model = deviceInfo.serial;
-		}
-		deviceInfo.adbHost = host;
-		deviceInfo.adbPort = port;
-		return deviceInfo;
-	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/dialog/ADBDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/dialog/ADBDialog.java
@@ -359,7 +359,7 @@ public class ADBDialog extends JDialog implements ADB.DeviceStateListener, ADB.J
 		try {
 			return mainWindow.getDebuggerPanel().showDebugger(
 					debugSetter.name,
-					debugSetter.device.getDeviceInfo().adbHost,
+					debugSetter.device.getDeviceInfo().getAdbHost(),
 					debugSetter.forwardTcpPort,
 					debugSetter.ver);
 		} catch (Exception e) {
@@ -569,10 +569,10 @@ public class ADBDialog extends JDialog implements ADB.DeviceStateListener, ADB.J
 
 		void refresh() {
 			ADBDeviceInfo info = device.getDeviceInfo();
-			String text = info.model;
+			String text = info.getModel();
 			if (text != null) {
-				if (!text.equals(info.serial)) {
-					text += String.format(" [serial: %s]", info.serial);
+				if (!text.equals(info.getSerial())) {
+					text += String.format(" [serial: %s]", info.getSerial());
 				}
 				text += String.format(" [state: %s]", info.isOnline() ? "online" : "offline");
 				tNode.setUserObject(text);
@@ -668,8 +668,8 @@ public class ADBDialog extends JDialog implements ADB.DeviceStateListener, ADB.J
 			String jdwpPid = " jdwp:" + pid;
 			String tcpPort = " tcp:" + forwardTcpPort;
 			try {
-				List<String> list = ADB.listForward(device.getDeviceInfo().adbHost,
-						device.getDeviceInfo().adbPort);
+				List<String> list = ADB.listForward(device.getDeviceInfo().getAdbHost(),
+						device.getDeviceInfo().getAdbPort());
 				for (String s : list) {
 					if (s.startsWith(device.getSerial()) && s.endsWith(jdwpPid) && !s.contains(tcpPort)) {
 						String[] fields = s.split("\\s+");
@@ -693,8 +693,8 @@ public class ADBDialog extends JDialog implements ADB.DeviceStateListener, ADB.J
 			String jdwpPid = " jdwp:" + pid;
 			String tcpPort = " tcp:" + forwardTcpPort;
 			try {
-				List<String> list = ADB.listForward(device.getDeviceInfo().adbHost,
-						device.getDeviceInfo().adbPort);
+				List<String> list = ADB.listForward(device.getDeviceInfo().getAdbHost(),
+						device.getDeviceInfo().getAdbPort());
 				for (String s : list) {
 					if (s.startsWith(device.getSerial()) && s.endsWith(jdwpPid)) {
 						return !s.contains(tcpPort);


### PR DESCRIPTION
Fixed a minor problem when a device disconnects and reconnects: in that case the device data can be incomplete and a device with `null` serial was created.

Furthermore I improved `ADBDeviceInfo` class a bit (getter and constructor). 