### PR TITLE
XML "@null" decoding

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/Deobfuscator.java
@@ -428,7 +428,9 @@ public class Deobfuscator {
 			return "Enum";
 		}
 		String result = "";
-		if (cls.getAccessFlags().isAbstract()) {
+		if (cls.getAccessFlags().isInterface()) {
+			result += "Interface";
+		} else if (cls.getAccessFlags().isAbstract()) {
 			result += "Abstract";
 		}
 

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -168,11 +168,13 @@ public class ResXmlGen {
 	private void addItem(ICodeWriter cw, String itemTag, String typeName, RawNamedValue value) {
 		String nameStr = vp.decodeNameRef(value.getNameRef());
 		String valueStr = vp.decodeValue(value.getRawValue());
+		int dataType = value.getRawValue().getDataType();
+
 		if (!typeName.equals("attr")) {
-			if (valueStr == null || valueStr.equals("0")) {
+			if (dataType == ParserConstants.TYPE_REFERENCE && (valueStr == null || valueStr.equals("0"))) {
 				valueStr = "@null";
 			}
-			if (nameStr != null) {
+			if (dataType == ParserConstants.TYPE_INT_DEC && nameStr != null) {
 				try {
 					int intVal = Integer.parseInt(valueStr);
 					String newVal = ManifestAttributes.getInstance().decode(nameStr.replace("android:attr.", ""), intVal);

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -411,7 +411,7 @@ public class MainWindow extends JFrame {
 		// check if project file already saved with default name
 		Path projectPath = getProjectPathForFile(singleFile);
 		if (Files.exists(projectPath)) {
-			LOG.info("Loading project for this file");
+			LOG.info("Loading project {}", projectPath);
 			openProject(projectPath, onFinish);
 			return true;
 		}


### PR DESCRIPTION
Fix for #1583. `@null` is now restricted to values that have a data type of `TYPE_REFERENCE`.

Furthermore I restricted the attribute name replacement to `TYPE_INT_DEC` values, in my tests only attributes with that type had a successful replacement, all the other just caused a `NumberFormatException`.

I compared the resources of several apps decompiled by Jadx and by apktool regarding `@null` replacement. Most apps had the same reference counter of `@null` in both decompiled apps. Some apktool decompiled apps had a few references more but I wasn't able to detect where the exact difference was located as the xml files are often named differently and the attributes are created in a different order which makes comparison difficult.

Last but not least I noticed that deobfuscator had a rule for abstract classes but not for interfaces.