### PR TITLE
fix(gui): sort resources by deobfuscated name

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JRoot.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JRoot.java
@@ -66,7 +66,7 @@ public class JRoot extends JNode {
 					if (i != count - 1) {
 						subRF = new JResource(null, name, JResType.DIR);
 					} else {
-						subRF = new JResource(rf, rf.getOriginalName(), name, JResType.FILE);
+						subRF = new JResource(rf, rf.getDeobfName(), name, JResType.FILE);
 					}
 					curRf.getFiles().add(subRF);
 				}


### PR DESCRIPTION
### Description
This PR should fix #1595 

- [x] Sort resources by deobfuscated name instead of original name. 