### PR TITLE
core: Implemented parsing RES_TABLE_TYPE_LIBRARY chunks

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
@@ -28,9 +28,12 @@ public class ParserConstants {
 	protected static final int RES_XML_LAST_CHUNK_TYPE = 0x017f;
 	protected static final int RES_XML_RESOURCE_MAP_TYPE = 0x0180;
 
-	protected static final int RES_TABLE_PACKAGE_TYPE = 0x0200;
-	protected static final int RES_TABLE_TYPE_TYPE = 0x0201;
-	protected static final int RES_TABLE_TYPE_SPEC_TYPE = 0x0202;
+	protected static final int RES_TABLE_PACKAGE_TYPE = 0x0200; // 512
+	protected static final int RES_TABLE_TYPE_TYPE = 0x0201; // 513
+	protected static final int RES_TABLE_TYPE_SPEC_TYPE = 0x0202; // 514
+	protected static final int RES_TABLE_TYPE_LIBRARY = 0x0203; // 515
+	protected static final int RES_TABLE_TYPE_OVERLAY = 0x0204; // 516
+	protected static final int RES_TABLE_TYPE_STAGED_ALIAS = 0x0206; // 517
 
 	/**
 	 * Type constants

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResTableParser.java
@@ -150,16 +150,33 @@ public class ResTableParser extends CommonBinaryParser implements IResParser {
 		PackageChunk pkg = new PackageChunk(id, name, typeStrings, keyStrings);
 		resStorage.setAppPackage(name);
 
-		while (is.getPos() < endPos) {
+		chunkLoop: while (is.getPos() < endPos) {
 			long chunkStart = is.getPos();
 			int type = is.readInt16();
-			if (type == RES_NULL_TYPE) {
-				continue;
-			}
-			if (type == RES_TABLE_TYPE_SPEC_TYPE) {
-				parseTypeSpecChunk();
-			} else if (type == RES_TABLE_TYPE_TYPE) {
-				parseTypeChunk(chunkStart, pkg);
+			LOG.trace("res package chunk start at {} type {}", chunkStart, type);
+			switch (type) {
+				case RES_NULL_TYPE:
+					LOG.info("Null chunk type encountered at offset {}", chunkStart);
+					break;
+				case RES_TABLE_TYPE_TYPE: // 0x0201
+					parseTypeChunk(chunkStart, pkg);
+					break;
+				case RES_TABLE_TYPE_SPEC_TYPE: // 0x0202
+					parseTypeSpecChunk(chunkStart);
+					break;
+				case RES_TABLE_TYPE_LIBRARY: // 0x0203
+					parseLibraryTypeChunk(chunkStart);
+					break;
+				case RES_TABLE_TYPE_OVERLAY: // 0x0204
+					throw new IOException(
+							String.format("Encountered unsupported chunk type TYPE_OVERLAY at offset 0x%x ", chunkStart));
+				case RES_TABLE_TYPE_STAGED_ALIAS: // 0x0206
+					throw new IOException(
+							String.format("Encountered unsupported chunk type TYPE_STAGED_ALIAS at offset 0x%x ", chunkStart));
+				default:
+					// In some resources.arsc files endPos is not correctly set (e.g. points to the end of the file),
+					// so we have to stop when we encounter an unknown type entry
+					break chunkLoop;
 			}
 		}
 		return pkg;
@@ -192,16 +209,38 @@ public class ResTableParser extends CommonBinaryParser implements IResParser {
 	}
 
 	@SuppressWarnings("unused")
-	private void parseTypeSpecChunk() throws IOException {
+	private void parseTypeSpecChunk(long chunkStart) throws IOException {
 		is.checkInt16(0x0010, "Unexpected type spec header size");
-		/* int size = */
-		is.readInt32();
+		int chunkSize = is.readInt32();
+		long expectedEndPos = chunkStart + chunkSize;
 
 		int id = is.readInt8();
 		is.skip(3);
 		int entryCount = is.readInt32();
 		for (int i = 0; i < entryCount; i++) {
 			int entryFlag = is.readInt32();
+		}
+		if (is.getPos() != expectedEndPos) {
+			throw new IOException(String.format("Error reading type spec chunk at offset 0x%x", chunkStart));
+		}
+	}
+
+	private void parseLibraryTypeChunk(long chunkStart) throws IOException {
+		LOG.trace("parsing library type chunk starting at offset {}", chunkStart);
+		is.checkInt16(12, "Unexpected header size");
+		int chunkSize = is.readInt32();
+		long expectedEndPos = chunkStart + chunkSize;
+		int count = is.readInt32();
+		for (int i = 0; i < count; i++) {
+			int packageId = is.readInt32();
+			String packageName = is.readString16Fixed(128);
+			LOG.info("Found resource shared library {}, pkgId: {}", packageName, packageId);
+			if (is.getPos() > expectedEndPos) {
+				throw new IOException("reading after chunk end");
+			}
+		}
+		if (is.getPos() != expectedEndPos) {
+			throw new IOException(String.format("Error reading library chunk at offset 0x%x", chunkStart));
 		}
 	}
 


### PR DESCRIPTION
fixes #1663

Afterwards it is possible to load the provided sample of #1663 without errors, but the loaded resources in jadx-gui are not what I would expect for a 3.5MB resources.arsc file:
![image](https://user-images.githubusercontent.com/924885/188272439-5ea9e340-ff72-43ca-bb0d-f4fe22cb28d2.png)

Additionally most of the shown xml resource entries have next to no content. Therefore I assume that the current state of this PR is one step towards fixing this issue, but at the moment it seems to be incomplete and I don't yet understand what is the problem (thus the draft state).