### PR TITLE
Change callMethodName of constructors in Frida action

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -79,11 +79,11 @@ public final class FridaAction extends JNodeAction {
 		JavaMethod javaMethod = jMth.getJavaMethod();
 		MethodInfo methodInfo = javaMethod.getMethodNode().getMethodInfo();
 		String methodName = StringEscapeUtils.escapeEcmaScript(methodInfo.getName());
-		
+
 		if (methodInfo.isConstructor()) {
 			methodName = "$init";
 		}
-		
+
 		String callMethodName = methodName;
 		String shortClassName = javaMethod.getDeclaringClass().getName();
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -83,6 +83,7 @@ public final class FridaAction extends JNodeAction {
 		if (methodInfo.isConstructor()) {
 			methodName = "$init";
 		}
+		
 		String callMethodName = methodName;
 		String shortClassName = javaMethod.getDeclaringClass().getName();
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -79,12 +79,11 @@ public final class FridaAction extends JNodeAction {
 		JavaMethod javaMethod = jMth.getJavaMethod();
 		MethodInfo methodInfo = javaMethod.getMethodNode().getMethodInfo();
 		String methodName = StringEscapeUtils.escapeEcmaScript(methodInfo.getName());
-		String callMethodName = methodName;
-
+		
 		if (methodInfo.isConstructor()) {
 			methodName = "$init";
-			callMethodName = "$new";
 		}
+		String callMethodName = methodName;
 		String shortClassName = javaMethod.getDeclaringClass().getName();
 
 		String functionUntilImplementation;


### PR DESCRIPTION
Don't use `$new` as `callMethodName` for constructors in frida snippets, but `$init`.
Fixes: https://github.com/skylot/jadx/issues/1714
