### PR TITLE
Java.perform added for frida-snippet

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/FridaAction.java
@@ -47,6 +47,7 @@ public final class FridaAction extends JNodeAction {
 	public void runAction(JNode node) {
 		try {
 			String fridaSnippet = generateFridaSnippet(node);
+			fridaSnippet = "Java.perform(function() {\n\t" + fridaSnippet + "\n});"; 
 			LOG.info("Frida snippet:\n{}", fridaSnippet);
 			UiUtils.copyToClipboard(fridaSnippet);
 		} catch (Exception e) {


### PR DESCRIPTION
Currently the generated frida-snippet can not be executed by frida because it needs to be inside the ```Java.perform```.
I have added this possibility at this commit.
