### PR TITLE
Make enum CLI arguments match documented format

### DIFF
--- a/jadx-cli/src/main/java/jadx/cli/JadxCLIArgs.java
+++ b/jadx-cli/src/main/java/jadx/cli/JadxCLIArgs.java
@@ -491,7 +491,7 @@ public class JadxCLIArgs {
 		@Override
 		public CommentsLevel convert(String value) {
 			try {
-				return CommentsLevel.valueOf(value.toUpperCase());
+				return CommentsLevel.valueOf(stringAsEnumName(value));
 			} catch (Exception e) {
 				throw new IllegalArgumentException(
 						'\'' + value + "' is unknown comments level, possible values are: "
@@ -504,7 +504,7 @@ public class JadxCLIArgs {
 		@Override
 		public UseKotlinMethodsForVarNames convert(String value) {
 			try {
-				return UseKotlinMethodsForVarNames.valueOf(value.replace('-', '_').toUpperCase());
+				return UseKotlinMethodsForVarNames.valueOf(stringAsEnumName(value));
 			} catch (Exception e) {
 				throw new IllegalArgumentException(
 						'\'' + value + "' is unknown, possible values are: "
@@ -517,7 +517,7 @@ public class JadxCLIArgs {
 		@Override
 		public DeobfuscationMapFileMode convert(String value) {
 			try {
-				return DeobfuscationMapFileMode.valueOf(value.toUpperCase());
+				return DeobfuscationMapFileMode.valueOf(stringAsEnumName(value));
 			} catch (Exception e) {
 				throw new IllegalArgumentException(
 						'\'' + value + "' is unknown, possible values are: "
@@ -530,7 +530,7 @@ public class JadxCLIArgs {
 		@Override
 		public ResourceNameSource convert(String value) {
 			try {
-				return ResourceNameSource.valueOf(value.toUpperCase());
+				return ResourceNameSource.valueOf(stringAsEnumName(value));
 			} catch (Exception e) {
 				throw new IllegalArgumentException(
 						'\'' + value + "' is unknown, possible values are: "
@@ -543,7 +543,7 @@ public class JadxCLIArgs {
 		@Override
 		public DecompilationMode convert(String value) {
 			try {
-				return DecompilationMode.valueOf(value.toUpperCase());
+				return DecompilationMode.valueOf(stringAsEnumName(value));
 			} catch (Exception e) {
 				throw new IllegalArgumentException(
 						'\'' + value + "' is unknown, possible values are: "
@@ -556,5 +556,10 @@ public class JadxCLIArgs {
 		return Stream.of(values)
 				.map(v -> v.name().replace('_', '-').toLowerCase(Locale.ROOT))
 				.collect(Collectors.joining(", "));
+	}
+
+	private static String stringAsEnumName(String raw) {
+        // inverse of enumValuesString conversion
+		return value.replace('-', '_').toUpperCase();
 	}
 }


### PR DESCRIPTION
Currently if you do `jadx --help`, it says the `--deobf-cfg-file-mode` option accepts the value `read-or-save`. 

However, if you give it that option, it instead prints the following error message:

```
java.lang.IllegalArgumentException: 'read-or-save' is unknown, possible values are: read, read-or-save, overwrite, ignore
	at jadx.cli.JadxCLIArgs$DeobfuscationMapFileModeConverter.convert(JadxCLIArgs.java:524)
	at jadx.cli.JadxCLIArgs$DeobfuscationMapFileModeConverter.convert(JadxCLIArgs.java:516)
	at com.beust.jcommander.JCommander.convertValue(JCommander.java:1340)
	at com.beust.jcommander.ParameterDescription.addValue(ParameterDescription.java:249)
	at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:920)
	at com.beust.jcommander.JCommander.processFixedArity(JCommander.java:901)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:731)
	at com.beust.jcommander.JCommander.parse(JCommander.java:363)
	at com.beust.jcommander.JCommander.parse(JCommander.java:342)
	at jadx.cli.JCommanderWrapper.parse(JCommanderWrapper.java:37)
	at jadx.cli.JadxCLIArgs.processArgs(JadxCLIArgs.java:211)
	at jadx.cli.JadxCLI.execute(JadxCLI.java:35)
	at jadx.cli.JadxCLI.main(JadxCLI.java:20)
```

This commit changes all the enum parsers - except the one that already does this - to do the inverse string of `enumValuesString`, so the documented behavior works.

:exclamation: Please review the [guidelines for contributing](https://github.com/skylot/jadx/blob/master/CONTRIBUTING.md#Pull-Request-Process)

### Description
Please describe your pull request.
Reference issue it fixes.
