### PR TITLE
Fix resource issues

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
@@ -43,6 +43,7 @@ import jadx.core.utils.Utils;
 import jadx.core.utils.android.AndroidResourcesUtils;
 import jadx.core.utils.exceptions.JadxRuntimeException;
 import jadx.core.xmlgen.IResParser;
+import jadx.core.xmlgen.ManifestAttributes;
 import jadx.core.xmlgen.ResDecoder;
 import jadx.core.xmlgen.ResourceStorage;
 import jadx.core.xmlgen.entry.ResourceEntry;
@@ -174,10 +175,16 @@ public class RootNode {
 			if (parser != null) {
 				processResources(parser.getResStorage());
 				updateObfuscatedFiles(parser, resources);
+				updateManifestAttribMap(parser);
 			}
 		} catch (Exception e) {
 			LOG.error("Failed to parse '.arsc' file", e);
 		}
+	}
+
+	private void updateManifestAttribMap(IResParser parser) {
+		ManifestAttributes manifestAttributes = ManifestAttributes.getInstance();
+		manifestAttributes.updateAttributes(parser);
 	}
 
 	private @Nullable ResourceFile getResourceFile(List<ResourceFile> resources) {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ManifestAttributes.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ManifestAttributes.java
@@ -211,7 +211,7 @@ public class ManifestAttributes {
 				MAttrType attrTyp;
 				if (first.getRawValue().getData() == ValuesParser.ATTR_TYPE_FLAGS) {
 					attrTyp = MAttrType.FLAG;
-				} else if (first.getRawValue().getData() == ValuesParser.ATTR_TYPE_ENUM) {
+				} else if (first.getRawValue().getData() == ValuesParser.ATTR_TYPE_ENUM || first.getRawValue().getData() == 65600) {
 					attrTyp = MAttrType.ENUM;
 				} else {
 					continue;

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -109,10 +109,10 @@ public class ResXmlGen {
 			addSimpleValue(cw, ri.getTypeName(), ri.getTypeName(), "name", ri.getKeyName(), valueStr);
 		} else {
 			cw.startLine();
-			cw.add('<').add(ri.getTypeName()).add(' ');
+			cw.add('<').add(ri.getTypeName()).add(" name=\"");
 			String itemTag = "item";
 			if (ri.getTypeName().equals("attr") && !ri.getNamedValues().isEmpty()) {
-				cw.add("name=\"").add(ri.getKeyName());
+				cw.add(ri.getKeyName());
 				int type = ri.getNamedValues().get(0).getRawValue().getData();
 				if ((type & ValuesParser.ATTR_TYPE_ENUM) != 0) {
 					itemTag = "enum";
@@ -125,13 +125,14 @@ public class ResXmlGen {
 				}
 				cw.add("\"");
 			} else {
-				cw.add("name=\"").add(ri.getKeyName()).add('\"');
+				cw.add(ri.getKeyName()).add('\"');
 			}
+			cw.add(" parent=\"");
 			if (ri.getParentRef() != 0) {
 				String parent = vp.decodeValue(TYPE_REFERENCE, ri.getParentRef());
-				cw.add(" parent=\"").add(parent).add('\"');
+				cw.add(parent);
 			}
-			cw.add(">");
+			cw.add("\">");
 
 			cw.incIndent();
 			for (RawNamedValue value : ri.getNamedValues()) {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -177,7 +177,7 @@ public class ResXmlGen {
 			if (dataType == ParserConstants.TYPE_INT_DEC && nameStr != null) {
 				try {
 					int intVal = Integer.parseInt(valueStr);
-					String newVal = ManifestAttributes.getInstance().decode(nameStr.replace("android:attr.", ""), intVal);
+					String newVal = ManifestAttributes.getInstance().decode(nameStr.replace("android:", "").replace("attr.", ""), intVal);
 					if (newVal != null) {
 						valueStr = newVal;
 					}
@@ -188,7 +188,7 @@ public class ResXmlGen {
 			if (dataType == ParserConstants.TYPE_INT_HEX && nameStr != null) {
 				try {
 					int intVal = Integer.decode(valueStr);
-					String newVal = ManifestAttributes.getInstance().decode(nameStr.replace("android:attr.", ""), intVal);
+					String newVal = ManifestAttributes.getInstance().decode(nameStr.replace("android:", "").replace("attr.", ""), intVal);
 					if (newVal != null) {
 						valueStr = newVal;
 					}

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -185,6 +185,17 @@ public class ResXmlGen {
 					// ignore
 				}
 			}
+			if (dataType == ParserConstants.TYPE_INT_HEX && nameStr != null) {
+				try {
+					int intVal = Integer.decode(valueStr);
+					String newVal = ManifestAttributes.getInstance().decode(nameStr.replace("android:attr.", ""), intVal);
+					if (newVal != null) {
+						valueStr = newVal;
+					}
+				} catch (NumberFormatException e) {
+					// ignore
+				}
+			}
 		}
 		switch (typeName) {
 			case "attr":

--- a/jadx-core/src/main/resources/export/build.gradle.tmpl
+++ b/jadx-core/src/main/resources/export/build.gradle.tmpl
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 


### PR DESCRIPTION
I tested recompiling with some random simple apps, e.g.

https://apkpure.com/typescript-tutorial/com.cosmiclearn.typescripttutorial
https://apkpure.com/gradle-dependencies-generator/com.androidgradle.app

and just fixed the first resource or gradle issue in each iteration. The first app now fails with a java issue. I used gradle 7.4.2 to take another bug (also reproducible with gradle 7.6). 

For review: Each commit fixes one bug. I used apktool as a reference for the exported resources.

The following issues can now be closed: https://github.com/skylot/jadx/issues/1073 and https://github.com/skylot/jadx/issues/1682

For the next issues a data structure to aggregate infos for gradle build file generation would help, e.g. for a flag to track usage of "android:pathData-Attributes" + minSdkVersion < 21 to set "vectorDrawables.useSupportLibrary = true" or a legacy Apache http client detection....