### PR TITLE
fix: filter invalid chars for gradle wrapper

### DIFF
--- a/jadx-core/src/main/java/jadx/core/export/ExportGradleProject.java
+++ b/jadx-core/src/main/java/jadx/core/export/ExportGradleProject.java
@@ -6,6 +6,7 @@ import java.io.StringReader;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import javax.xml.parsers.DocumentBuilder;
 
@@ -28,6 +29,8 @@ import jadx.core.xmlgen.XmlSecurity;
 public class ExportGradleProject {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ExportGradleProject.class);
+
+	private static final Pattern ILLEGAL_GRADLE_CHARS = Pattern.compile("[/\\\\:>\"?*|]");
 
 	private static final Set<String> IGNORE_CLS_NAMES = new HashSet<>(Arrays.asList(
 			"R",
@@ -72,7 +75,7 @@ public class ExportGradleProject {
 	private void saveSettingsGradle() throws IOException {
 		TemplateFile tmpl = TemplateFile.fromResources("/export/settings.gradle.tmpl");
 
-		tmpl.add("applicationName", applicationParams.getApplicationName());
+		tmpl.add("applicationName", ILLEGAL_GRADLE_CHARS.matcher(applicationParams.getApplicationName()).replaceAll(""));
 		tmpl.save(new File(projectDir, "settings.gradle"));
 	}
 

--- a/jadx-core/src/test/java/jadx/tests/api/ExportGradleTest.java
+++ b/jadx-core/src/test/java/jadx/tests/api/ExportGradleTest.java
@@ -67,4 +67,10 @@ public abstract class ExportGradleTest {
 		assertThat(appBuildGradle.exists());
 		return loadFileContent(appBuildGradle);
 	}
+
+	protected String getSettingsGradle() {
+		File settingsGradle = new File(exportDir, "settings.gradle");
+		assertThat(settingsGradle.exists());
+		return loadFileContent(settingsGradle);
+	}
 }

--- a/jadx-core/src/test/java/jadx/tests/export/IllegalCharsForGradleWrapper.java
+++ b/jadx-core/src/test/java/jadx/tests/export/IllegalCharsForGradleWrapper.java
@@ -1,0 +1,17 @@
+package jadx.tests.export;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.ExportGradleTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+class IllegalCharsForGradleWrapper extends ExportGradleTest {
+
+	@Test
+	void test() {
+		exportGradle("IllegalCharsForGradleWrapper.xml", "strings.xml");
+
+		assertThat(getSettingsGradle()).contains("'JadxTestApp'");
+	}
+}

--- a/jadx-core/src/test/manifest/IllegalCharsForGradleWrapper.xml
+++ b/jadx-core/src/test/manifest/IllegalCharsForGradleWrapper.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:compileSdkVersion="33" android:compileSdkVersionCodename="13" package="jadx.test.app" platformBuildVersionCode="33" platformBuildVersionName="13">
+    <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="32"/>
+    <application android:label="JadxTestApp/\:?*|">
+    </application>
+</manifest>


### PR DESCRIPTION
Some special chars in the app name can cause conflicts when you try to add a gradle wrapper. In this pull request I filter all invalid chars before generating settings.gradle

Here is an example app containing invalid chars: https://xn--who-becomes-rich--84ns4b8gwbu6jza3u.apk.gold/

Steps to reproduce:
- save as gradle project
- run 'gradle wrapper'

```
FAILURE: Build failed with an exception.

* Where:
Settings file 'settings.gradle' line: 2

* What went wrong:
A problem occurred evaluating settings.
> The project name 'Who Becomes Rich?' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |]. Set the 'rootProject.name' or adjust the 'include' statement (see https://docs.gradle.org/7.6/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[]) for more details).
```

This issue can also easily be reproduced with new Android Studio project. Android Studio does not allow any special chars in the application name when the app is generated, but AndroidManifest.xml can be edited later like in my unit test. 