### PR TITLE
fix(xml): fix regression - use parent attibute only for styles

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -123,14 +123,15 @@ public class ResXmlGen {
 				if (formatValue != null) {
 					cw.add("\" format=\"").add(formatValue);
 				}
-				cw.add("\"");
 			} else {
-				cw.add(ri.getKeyName()).add('\"');
+				cw.add(ri.getKeyName());
 			}
-			cw.add(" parent=\"");
-			if (ri.getParentRef() != 0) {
-				String parent = vp.decodeValue(TYPE_REFERENCE, ri.getParentRef());
-				cw.add(parent);
+			if (ri.getTypeName().equals("style") || ri.getParentRef() != 0) {
+				cw.add("\" parent=\"");
+				if (ri.getParentRef() != 0) {
+					String parent = vp.decodeValue(TYPE_REFERENCE, ri.getParentRef());
+					cw.add(parent);
+				}
 			}
 			cw.add("\">");
 


### PR DESCRIPTION
I'm sorry, my previous commit 378c747 introduced a regression. 378c747 added an empty parent attribute to arrays, plurals and attrs. This commit adds a check for type "style" to restore the previous behavior.