### PR TITLE
fix: add parentheses around multiple lambda arguments

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/InsnGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/InsnGen.java
@@ -1003,12 +1003,18 @@ public class InsnGen {
 		} else {
 			int callArgsCount = callArgs.size();
 			int startArg = callArgsCount - implArgs.size();
+			if (callArgsCount - startArg > 1) {
+				code.add('(');
+			}
 			for (int i = startArg; i < callArgsCount; i++) {
 				if (i != startArg) {
 					code.add(", ");
 				}
 				CodeVar argCodeVar = callArgs.get(i).getSVar().getCodeVar();
 				defVar(code, argCodeVar);
+			}
+			if (callArgsCount - startArg > 1) {
+				code.add(')');
 			}
 		}
 		// force set external arg names into call method args

--- a/jadx-core/src/test/java/jadx/tests/integration/java8/TestLambdaArgs.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/java8/TestLambdaArgs.java
@@ -1,0 +1,37 @@
+package jadx.tests.integration.java8;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestLambdaArgs extends IntegrationTest {
+
+	public static class TestCls {
+		public void test1() {
+			call1(a -> -a);
+		}
+
+		public void test2() {
+			call2((a, b) -> a - b);
+		}
+
+		private void call1(Function<Integer, Integer> func) {
+		}
+
+		private void call2(BiFunction<Integer, Integer, Integer> func) {
+		}
+	}
+
+	@Test
+	public void test() {
+		assertThat(getClassNode(TestCls.class))
+				.code()
+				.containsOne("call1(a ->")
+				.containsOne("call2((a, b) ->");
+	}
+}


### PR DESCRIPTION
### Before
```java
foo(1, a -> { return a; });
foo(1, a, b -> { return a + b; });
```
### After
```java
foo(1, a -> { return a; });
foo(1, (a, b) -> { return a + b; });
```