### PR TITLE
fix(gradle): add legacy support for vector drawables

### DIFF
--- a/jadx-core/src/main/java/jadx/api/TaskBarrier.java
+++ b/jadx-core/src/main/java/jadx/api/TaskBarrier.java
@@ -1,0 +1,22 @@
+package jadx.api;
+
+import java.util.concurrent.CountDownLatch;
+
+public class TaskBarrier {
+
+	private CountDownLatch taskCountDown = null;
+
+	public void setUpBarrier(final int numTasks) {
+		taskCountDown = new CountDownLatch(numTasks);
+	}
+
+	public CountDownLatch getTaskCountDown() {
+		return taskCountDown;
+	}
+
+	public void finishTask() {
+		if (taskCountDown != null) {
+			taskCountDown.countDown();
+		}
+	}
+}

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
@@ -46,6 +46,7 @@ import jadx.core.dex.visitors.DepthTraversal;
 import jadx.core.dex.visitors.IDexTreeVisitor;
 import jadx.core.dex.visitors.typeinference.TypeCompare;
 import jadx.core.dex.visitors.typeinference.TypeUpdate;
+import jadx.core.export.GradleInfoStorage;
 import jadx.core.utils.CacheStorage;
 import jadx.core.utils.ErrorsCounter;
 import jadx.core.utils.PassMerge;
@@ -77,6 +78,8 @@ public class RootNode {
 	private final MethodUtils methodUtils;
 	private final TypeUtils typeUtils;
 	private final AttributeStorage attributes = new AttributeStorage();
+
+	private final GradleInfoStorage gradleInfoStorage = new GradleInfoStorage();
 
 	private final Map<ClassInfo, ClassNode> clsMap = new HashMap<>();
 	private final Map<String, ClassNode> rawClsMap = new HashMap<>();
@@ -711,5 +714,9 @@ public class RootNode {
 
 	public boolean isProto() {
 		return isProto;
+	}
+
+	public GradleInfoStorage getGradleInfoStorage() {
+		return gradleInfoStorage;
 	}
 }

--- a/jadx-core/src/main/java/jadx/core/export/ExportGradleTask.java
+++ b/jadx-core/src/main/java/jadx/core/export/ExportGradleTask.java
@@ -1,0 +1,79 @@
+package jadx.core.export;
+
+import java.io.File;
+import java.util.List;
+
+import jadx.api.ResourceFile;
+import jadx.api.ResourceType;
+import jadx.api.TaskBarrier;
+import jadx.core.dex.nodes.RootNode;
+import jadx.core.utils.exceptions.JadxRuntimeException;
+import jadx.core.utils.files.FileUtils;
+import jadx.core.xmlgen.ResContainer;
+
+public class ExportGradleTask implements Runnable {
+
+	private final List<ResourceFile> resources;
+
+	private final RootNode root;
+	private final File projectDir;
+	private final File appDir;
+	private final File srcOutDir;
+	private final File resOutDir;
+
+	private final TaskBarrier barrier;
+
+	public ExportGradleTask(List<ResourceFile> resources, RootNode root, File projectDir, TaskBarrier barrier) {
+		this.resources = resources;
+		this.projectDir = projectDir;
+		this.root = root;
+		this.appDir = new File(projectDir, "app");
+		this.srcOutDir = new File(appDir, "src/main/java");
+		this.resOutDir = new File(appDir, "src/main");
+		this.barrier = barrier;
+	}
+
+	@Override
+	public void run() {
+		ResourceFile androidManifest = resources.stream()
+				.filter(resourceFile -> resourceFile.getType() == ResourceType.MANIFEST)
+				.findFirst()
+				.orElseThrow(IllegalStateException::new);
+
+		ResContainer strings = resources.stream()
+				.filter(resourceFile -> resourceFile.getType() == ResourceType.ARSC)
+				.findFirst()
+				.orElseThrow(IllegalStateException::new)
+				.loadContent()
+				.getSubFiles()
+				.stream()
+				.filter(resContainer -> resContainer.getFileName().contains("strings.xml"))
+				.findFirst()
+				.orElseThrow(IllegalStateException::new);
+
+		ExportGradleProject export = new ExportGradleProject(root, projectDir, androidManifest, strings);
+
+		// wait until all sources and resources are exported and all necessary info for gradle export are
+		// collected
+		try {
+			barrier.getTaskCountDown().await();
+		} catch (InterruptedException e) {
+			throw new JadxRuntimeException("Gradle export failed", e);
+		}
+
+		export.generateGradleFiles();
+	}
+
+	public void init() {
+		FileUtils.makeDirs(srcOutDir);
+		FileUtils.makeDirs(resOutDir);
+	}
+
+	public File getSrcOutDir() {
+		return srcOutDir;
+	}
+
+	public File getResOutDir() {
+		return resOutDir;
+	}
+}

--- a/jadx-core/src/main/java/jadx/core/export/GradleInfoStorage.java
+++ b/jadx-core/src/main/java/jadx/core/export/GradleInfoStorage.java
@@ -1,0 +1,24 @@
+package jadx.core.export;
+
+public class GradleInfoStorage {
+
+	private boolean vectorPathData;
+
+	private boolean vectorFillType;
+
+	public boolean isVectorPathData() {
+		return vectorPathData;
+	}
+
+	public void setVectorPathData(boolean vectorPathData) {
+		this.vectorPathData = vectorPathData;
+	}
+
+	public boolean isVectorFillType() {
+		return vectorFillType;
+	}
+
+	public void setVectorFillType(boolean vectorFillType) {
+		this.vectorFillType = vectorFillType;
+	}
+}

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -316,6 +316,13 @@ public class BinaryXMLParser extends CommonBinaryParser {
 			decodeAttribute(attributeNS, attrValDataType, attrValData,
 					shortNsName, attrName);
 		}
+		if (shortNsName != null && shortNsName.equals("android")) {
+			if (attrName.equals("pathData")) {
+				rootNode.getGradleInfoStorage().setVectorPathData(true);
+			} else if (attrName.equals("fillType")) {
+				rootNode.getGradleInfoStorage().setVectorFillType(true);
+			}
+		}
 		writer.add('"');
 	}
 

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResourcesSaver.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResourcesSaver.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import jadx.api.ResourceFile;
 import jadx.api.ResourcesLoader;
+import jadx.api.TaskBarrier;
 import jadx.api.plugins.utils.ZipSecurity;
 import jadx.core.dex.visitors.SaveCode;
 import jadx.core.utils.exceptions.JadxException;
@@ -22,9 +23,17 @@ public class ResourcesSaver implements Runnable {
 	private final ResourceFile resourceFile;
 	private final File outDir;
 
+	private TaskBarrier barrier = null;
+
 	public ResourcesSaver(File outDir, ResourceFile resourceFile) {
 		this.resourceFile = resourceFile;
 		this.outDir = outDir;
+	}
+
+	public ResourcesSaver(File outDir, ResourceFile resourceFile, TaskBarrier barrier) {
+		this.resourceFile = resourceFile;
+		this.outDir = outDir;
+		this.barrier = barrier;
 	}
 
 	@Override
@@ -33,6 +42,10 @@ public class ResourcesSaver implements Runnable {
 			saveResources(resourceFile.loadContent());
 		} catch (Throwable e) {
 			LOG.warn("Failed to save resource: {}", resourceFile.getOriginalName(), e);
+		} finally {
+			if (barrier != null) {
+				barrier.finishTask();
+			}
 		}
 	}
 

--- a/jadx-core/src/main/resources/export/app.build.gradle.tmpl
+++ b/jadx-core/src/main/resources/export/app.build.gradle.tmpl
@@ -12,7 +12,7 @@ android {
         targetSdkVersion {{targetSdkVersion}}
         versionCode {{versionCode}}
         versionName "{{versionName}}"
-
+{{additionalOptions}}
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/jadx-core/src/test/java/jadx/tests/export/OptionalTargetSdkVersion.java
+++ b/jadx-core/src/test/java/jadx/tests/export/OptionalTargetSdkVersion.java
@@ -12,7 +12,7 @@ public class OptionalTargetSdkVersion extends ExportGradleTest {
 	void test() {
 		exportGradle("OptionalTargetSdkVersion.xml", "strings.xml");
 
-		assertThat(getAppGradleBuild()).contains("targetSdkVersion 14");
+		assertThat(getAppGradleBuild()).contains("targetSdkVersion 14").doesNotContain("        vectorDrawables.useSupportLibrary = true");
 	}
 
 }

--- a/jadx-core/src/test/java/jadx/tests/export/VectorDrawablesUseSupportLibrary.java
+++ b/jadx-core/src/test/java/jadx/tests/export/VectorDrawablesUseSupportLibrary.java
@@ -1,0 +1,28 @@
+package jadx.tests.export;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.core.export.GradleInfoStorage;
+import jadx.tests.api.ExportGradleTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class VectorDrawablesUseSupportLibrary extends ExportGradleTest {
+
+	@Test
+	void test() {
+		GradleInfoStorage gradleInfo = getRootNode().getGradleInfoStorage();
+		gradleInfo.setVectorFillType(true);
+		exportGradle("OptionalTargetSdkVersion.xml", "strings.xml");
+		assertThat(getAppGradleBuild()).contains("        vectorDrawables.useSupportLibrary = true");
+
+		gradleInfo.setVectorFillType(false);
+		gradleInfo.setVectorPathData(true);
+		exportGradle("OptionalTargetSdkVersion.xml", "strings.xml");
+		assertThat(getAppGradleBuild()).contains("        vectorDrawables.useSupportLibrary = true");
+
+		exportGradle("MinSdkVersion25.xml", "strings.xml");
+		assertThat(getAppGradleBuild()).doesNotContain("        vectorDrawables.useSupportLibrary = true");
+
+	}
+}

--- a/jadx-core/src/test/java/jadx/tests/functional/TemplateFileTest.java
+++ b/jadx-core/src/test/java/jadx/tests/functional/TemplateFileTest.java
@@ -17,6 +17,7 @@ public class TemplateFileTest {
 		tmpl.add("targetSdkVersion", 2);
 		tmpl.add("versionCode", 3);
 		tmpl.add("versionName", "1.2.3");
+		tmpl.add("additionalOptions", "useLibrary 'org.apache.http.legacy'");
 		String res = tmpl.build();
 		System.out.println(res);
 

--- a/jadx-core/src/test/manifest/MinSdkVersion25.xml
+++ b/jadx-core/src/test/manifest/MinSdkVersion25.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" android:compileSdkVersion="33" android:compileSdkVersionCodename="13" package="jadx.test.app" platformBuildVersionCode="33" platformBuildVersionName="13">
+    <uses-sdk android:minSdkVersion="25" android:targetSdkVersion="32"/>
+    <application android:label="JadxTestApp">
+    </application>
+</manifest>


### PR DESCRIPTION
At the moment missing legacy support for vector drawables (https://developer.android.com/studio/write/vector-asset-studio) is one of the top reasons why recompilation fails. In most cases there wouldn't be a problem if the original dependencies were used (e.g. original material design dependency). Since we don't have any dependency info (yet) in jadx, I would like to propose this PR to add "vectorDrawables.useSupportLibrary = true" when it's needed to continue with the build. I identified two cases for api level 21 and  24.

Example 1 (api level 21):
https://github.com/niranjan94/show-java/releases/download/v3.0.5/ShowJava_v3_0_5.apk ( let Jadx decompile itself :-) )

`File was preprocessed as vector drawable support was added in Android 5.0 (API level 21)`

Example 2 (api level 24): https://github.com/corona-warn-app/cwa-app-android / https://m.apkpure.com/de/corona-warn-app/de.rki.coronawarnapp

`File was preprocessed as vector drawable android:filltype support was added in Android 7.0 (API level 24)`

To detect vector drawables resources must be processed before gradle export starts. So I had to create a task to run gradle export as final step. (I my opinion there are at least 2 more use cases why gradle export has to be the final task: https://github.com/skylot/jadx/issues/1847 and apache http legacy client detection).

Off topic: Some thoughts about an export process in the future:
In my opinion a batch execution model with fork join patterns might fit better for future requirements. I'm thinking of a workflow like this:

- step 1: initialization
- step 2: analyze all resources (not saving) in parallel​
- step 3: analyze all sources (not saving) in parallel
- step 4: run additional plugins and execute scripts (sequential execution, allow plugins and scripts to filter resources and sources)
- step 5/6: rerun step 2 and 3 (e.g. resolving types or deobfuscation (https://github.com/skylot/jadx/issues/66, https://github.com/skylot/jadx/issues/1459) based on dependencies detected by plugins and scripts), save sources and resources
- step 7: export gradle files
- step 8: run post processing plugins and scripts (e.g. security analysis, privacy leakage detection, ...)