### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/jadx-core/src/main/resources/export/build.gradle.tmpl
+++ b/jadx-core/src/main/resources/export/build.gradle.tmpl
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
     	google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -11,7 +11,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
### Description
jcenter is deprecated, we can use mavenCentral as one of the default maven repo.
