### PR TITLE
Access node under caret/mouse and jump

### DIFF
--- a/jadx-core/src/main/java/jadx/api/plugins/gui/JadxGuiContext.java
+++ b/jadx-core/src/main/java/jadx/api/plugins/gui/JadxGuiContext.java
@@ -49,4 +49,15 @@ public interface JadxGuiContext {
 	 * Access to GUI settings
 	 */
 	JadxGuiSettings settings();
+
+	ICodeNodeRef getNodeUnderCaret();
+	ICodeNodeRef getNodeUnderMouse();
+	ICodeNodeRef getEnclosingNodeUnderCaret();
+	ICodeNodeRef getEnclosingNodeUnderMouse();
+
+	/**
+	 * Jump to a code ref
+	 * @return if successfully jumped to the code ref
+	 */
+	boolean open(ICodeNodeRef ref);
 }

--- a/jadx-core/src/main/java/jadx/api/plugins/gui/JadxGuiContext.java
+++ b/jadx-core/src/main/java/jadx/api/plugins/gui/JadxGuiContext.java
@@ -51,12 +51,16 @@ public interface JadxGuiContext {
 	JadxGuiSettings settings();
 
 	ICodeNodeRef getNodeUnderCaret();
+
 	ICodeNodeRef getNodeUnderMouse();
+
 	ICodeNodeRef getEnclosingNodeUnderCaret();
+
 	ICodeNodeRef getEnclosingNodeUnderMouse();
 
 	/**
 	 * Jump to a code ref
+	 *
 	 * @return if successfully jumped to the code ref
 	 */
 	boolean open(ICodeNodeRef ref);

--- a/jadx-gui/src/main/java/jadx/gui/plugins/context/GuiPluginContext.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/context/GuiPluginContext.java
@@ -1,11 +1,20 @@
 package jadx.gui.plugins.context;
 
+import java.awt.Container;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 
+import jadx.core.dex.nodes.ClassNode;
+import jadx.core.dex.nodes.FieldNode;
+import jadx.core.dex.nodes.MethodNode;
+import jadx.gui.treemodel.JNode;
+import jadx.gui.ui.codearea.AbstractCodeArea;
+import jadx.gui.ui.codearea.AbstractCodeContentPanel;
+import jadx.gui.ui.codearea.CodeArea;
+import jadx.gui.utils.JNodeCache;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,4 +95,85 @@ public class GuiPluginContext implements JadxGuiContext {
 	public @Nullable ISettingsGroup getCustomSettingsGroup() {
 		return customSettingsGroup;
 	}
+
+	@Nullable
+	private CodeArea getCodeArea() {
+		Container contentPane = commonContext.getMainWindow().getTabbedPane().getSelectedContentPanel();
+		if (contentPane instanceof AbstractCodeContentPanel) {
+			AbstractCodeArea codeArea = ((AbstractCodeContentPanel) contentPane).getCodeArea();
+			if (codeArea instanceof CodeArea) {
+				return (CodeArea) codeArea;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public ICodeNodeRef getNodeUnderCaret() {
+		CodeArea codeArea = getCodeArea();
+		if (codeArea != null) {
+			JNode nodeUnderCaret = codeArea.getNodeUnderCaret();
+			if (nodeUnderCaret != null) {
+				return nodeUnderCaret.getCodeNodeRef();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public ICodeNodeRef getNodeUnderMouse() {
+		CodeArea codeArea = getCodeArea();
+		if (codeArea != null) {
+			JNode nodeUnderMouse = codeArea.getNodeUnderMouse();
+			if (nodeUnderMouse != null) {
+				return nodeUnderMouse.getCodeNodeRef();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public ICodeNodeRef getEnclosingNodeUnderCaret() {
+		CodeArea codeArea = getCodeArea();
+		if (codeArea != null) {
+			JNode nodeUnderMouse = codeArea.getEnclosingNodeUnderCaret();
+			if (nodeUnderMouse != null) {
+				return nodeUnderMouse.getCodeNodeRef();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public ICodeNodeRef getEnclosingNodeUnderMouse() {
+		CodeArea codeArea = getCodeArea();
+		if (codeArea != null) {
+			JNode nodeUnderMouse = codeArea.getEnclosingNodeUnderMouse();
+			if (nodeUnderMouse != null) {
+				return nodeUnderMouse.getCodeNodeRef();
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public boolean open(ICodeNodeRef ref) {
+		JNodeCache cache = commonContext.getMainWindow().getWrapper().getCache().getNodeCache();
+		JNode node;
+		if (ref instanceof ClassNode) {
+			node = cache.makeFrom(((ClassNode) ref).getJavaNode());
+		} else if (ref instanceof MethodNode) {
+			node = cache.makeFrom(((MethodNode) ref).getJavaNode());
+		} else if (ref instanceof FieldNode) {
+			node = cache.makeFrom(((FieldNode) ref).getJavaNode());
+		} else {
+			// Package node - cannot jump to it
+			// TODO: Var node - might be possible
+			return false;
+		}
+
+		commonContext.getMainWindow().getTabbedPane().codeJump(node);
+		return true;
+	}
+
 }

--- a/jadx-gui/src/main/java/jadx/gui/plugins/context/GuiPluginContext.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/context/GuiPluginContext.java
@@ -7,14 +7,6 @@ import java.util.function.Function;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 
-import jadx.core.dex.nodes.ClassNode;
-import jadx.core.dex.nodes.FieldNode;
-import jadx.core.dex.nodes.MethodNode;
-import jadx.gui.treemodel.JNode;
-import jadx.gui.ui.codearea.AbstractCodeArea;
-import jadx.gui.ui.codearea.AbstractCodeContentPanel;
-import jadx.gui.ui.codearea.CodeArea;
-import jadx.gui.utils.JNodeCache;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +15,15 @@ import jadx.api.metadata.ICodeNodeRef;
 import jadx.api.plugins.gui.ISettingsGroup;
 import jadx.api.plugins.gui.JadxGuiContext;
 import jadx.api.plugins.gui.JadxGuiSettings;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.core.dex.nodes.FieldNode;
+import jadx.core.dex.nodes.MethodNode;
 import jadx.core.plugins.PluginContext;
+import jadx.gui.treemodel.JNode;
+import jadx.gui.ui.codearea.AbstractCodeArea;
+import jadx.gui.ui.codearea.AbstractCodeContentPanel;
+import jadx.gui.ui.codearea.CodeArea;
+import jadx.gui.utils.JNodeCache;
 import jadx.gui.utils.UiUtils;
 
 public class GuiPluginContext implements JadxGuiContext {

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -214,10 +214,40 @@ public final class CodeArea extends AbstractCodeArea {
 	}
 
 	@Nullable
+	public JNode getEnclosingNodeUnderCaret() {
+		int caretPos = getCaretPosition();
+		Token token = modelToToken(caretPos);
+		if (token == null) {
+			return null;
+		}
+		int start = adjustOffsetForToken(token);
+		if (start == -1) {
+			start = caretPos;
+		}
+		return getEnclosingJNodeAtOffset(start);
+	}
+
+	@Nullable
 	public JNode getNodeUnderMouse() {
 		Point pos = UiUtils.getMousePosition(this);
 		int offset = adjustOffsetForToken(viewToToken(pos));
 		return getJNodeAtOffset(offset);
+	}
+
+	@Nullable
+	public JNode getEnclosingNodeUnderMouse() {
+		Point pos = UiUtils.getMousePosition(this);
+		int offset = adjustOffsetForToken(viewToToken(pos));
+		return getEnclosingJNodeAtOffset(offset);
+	}
+
+	@Nullable
+	public JNode getEnclosingJNodeAtOffset(int offset) {
+		JavaNode javaNode = getEnclosingJavaNode(offset);
+		if (javaNode != null) {
+			return convertJavaNode(javaNode);
+		}
+		return null;
 	}
 
 	@Nullable
@@ -247,6 +277,15 @@ public final class CodeArea extends AbstractCodeArea {
 	public JavaNode getClosestJavaNode(int offset) {
 		try {
 			return getJadxWrapper().getDecompiler().getClosestJavaNode(getCodeInfo(), offset);
+		} catch (Exception e) {
+			LOG.error("Can't get java node by offset: {}", offset, e);
+			return null;
+		}
+	}
+
+	public JavaNode getEnclosingJavaNode(int offset) {
+		try {
+			return getJadxWrapper().getDecompiler().getEnclosingNode(getCodeInfo(), offset);
 		} catch (Exception e) {
 			LOG.error("Can't get java node by offset: {}", offset, e);
 			return null;

--- a/jadx-plugins/jadx-script/examples/scripts/gui/bookmark.jadx.kts
+++ b/jadx-plugins/jadx-script/examples/scripts/gui/bookmark.jadx.kts
@@ -4,7 +4,6 @@ import jadx.core.dex.nodes.MethodNode
 val jadx = getJadxInstance()
 var savedBookmark: ICodeNodeRef? = null
 
-
 jadx.gui.ifAvailable {
 	addPopupMenuAction(
 		"Set bookmark",
@@ -13,13 +12,11 @@ jadx.gui.ifAvailable {
 		action = ::setBookmark,
 	)
 
-
 	addMenuAction(
 		"Jump to bookmark",
-		action = ::jumpToBookmark
+		action = ::jumpToBookmark,
 	)
 }
-
 
 fun setBookmark(node: ICodeNodeRef) {
 	val enclosing = jadx.gui.enclosingNodeUnderCaret ?: run {

--- a/jadx-plugins/jadx-script/examples/scripts/gui/bookmark.jadx.kts
+++ b/jadx-plugins/jadx-script/examples/scripts/gui/bookmark.jadx.kts
@@ -1,0 +1,46 @@
+import jadx.api.metadata.ICodeNodeRef
+import jadx.core.dex.nodes.MethodNode
+
+val jadx = getJadxInstance()
+var savedBookmark: ICodeNodeRef? = null
+
+
+jadx.gui.ifAvailable {
+	addPopupMenuAction(
+		"Set bookmark",
+		enabled = { true },
+		keyBinding = "B",
+		action = ::setBookmark,
+	)
+
+
+	addMenuAction(
+		"Jump to bookmark",
+		action = ::jumpToBookmark
+	)
+}
+
+
+fun setBookmark(node: ICodeNodeRef) {
+	val enclosing = jadx.gui.enclosingNodeUnderCaret ?: run {
+		jadx.log.info { "No enclosing node" }
+		return
+	}
+
+	// You can bookmark a field, method or a class
+	val target = if (enclosing is MethodNode) enclosing else node
+
+	jadx.log.info { "Setting bookmark to: $target" }
+	savedBookmark = target
+}
+
+fun jumpToBookmark() {
+	if (savedBookmark == null) {
+		jadx.log.info { "No bookmark" }
+	} else {
+		val res = jadx.gui.open(savedBookmark!!)
+		if (!res) {
+			jadx.log.info { "Failed to jump to bookmark" }
+		}
+	}
+}

--- a/jadx-plugins/jadx-script/examples/scripts/gui/caret_mouse.jadx.kts
+++ b/jadx-plugins/jadx-script/examples/scripts/gui/caret_mouse.jadx.kts
@@ -1,0 +1,20 @@
+import jadx.api.metadata.ICodeNodeRef
+
+val jadx = getJadxInstance()
+
+jadx.gui.ifAvailable {
+	addPopupMenuAction(
+		"Print enclosing symbols under caret or mouse",
+		enabled = { true },
+		keyBinding = "G",
+		action = ::runAction,
+	)
+}
+
+
+fun runAction(node: ICodeNodeRef) {
+	jadx.log.info { "Node under caret: ${jadx.gui.nodeUnderCaret}" }
+	jadx.log.info { "Enclosing node under caret: ${jadx.gui.enclosingNodeUnderCaret}" }
+	jadx.log.info { "Node under mouse: ${jadx.gui.nodeUnderMouse}" }
+	jadx.log.info { "Enclosing Node under mouse: ${jadx.gui.enclosingNodeUnderMouse}" }
+}

--- a/jadx-plugins/jadx-script/examples/scripts/gui/caret_mouse.jadx.kts
+++ b/jadx-plugins/jadx-script/examples/scripts/gui/caret_mouse.jadx.kts
@@ -11,7 +11,6 @@ jadx.gui.ifAvailable {
 	)
 }
 
-
 fun runAction(node: ICodeNodeRef) {
 	jadx.log.info { "Node under caret: ${jadx.gui.nodeUnderCaret}" }
 	jadx.log.info { "Enclosing node under caret: ${jadx.gui.enclosingNodeUnderCaret}" }

--- a/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/data/Gui.kt
+++ b/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/data/Gui.kt
@@ -40,6 +40,17 @@ class Gui(
 		context().copyToClipboard(str)
 	}
 
+	fun open(ref: ICodeNodeRef): Boolean = context().open(ref)
+
+	val nodeUnderCaret: ICodeNodeRef?
+		get() = context().nodeUnderCaret
+	val nodeUnderMouse: ICodeNodeRef?
+		get() = context().nodeUnderMouse
+	val enclosingNodeUnderCaret: ICodeNodeRef?
+		get() = context().enclosingNodeUnderCaret
+	val enclosingNodeUnderMouse: ICodeNodeRef?
+		get() = context().enclosingNodeUnderMouse
+
 	private fun context(): JadxGuiContext =
 		guiContext ?: throw IllegalStateException("GUI plugins context not available!")
 }


### PR DESCRIPTION
### Description
This fixes the last bullet of #1832 by providing the following two features:
* jump to a `ICodeNodeRef` by exposing `jadx.gui.open`.   
The implementation is a simple wrapper over `mainWindow.tabbedPane.codeJump`. It uses `JNodeCache` to cache the `JNode`s created.
* Expose access to the enclosing node for actions, by adding `jadx.gui.(enclosing)?NodeUnder(Caret|mouse)`.   
It is useful for scripts that operates on methods (like Graffiti), as it allows the user to activate the action anywhere inside the function, not only on the function name.

In addition, I've added two sample scripts:
* `gui/caret_mouse.jadx.kts` - Shows the return value of `jadx.gui.(enclosing)?NodeUnder(Caret|mouse)`
* `gui/bookmark.jadx.kts` - Shows the usefulness of `jadx.gui.open` by implementing a single bookmark support in jadx. It can be extended to provide a normal bookmarks feature.

I'm not fully familiar with the codebase, so I hope those are the current implementations for those functionalities.  
