### PR TITLE
fix(xml): support min attr for attrs

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -108,6 +108,7 @@ public class ResXmlGen {
 			String valueStr = vp.decodeValue(ri.getSimpleValue());
 			addSimpleValue(cw, ri.getTypeName(), ri.getTypeName(), "name", ri.getKeyName(), valueStr);
 		} else {
+			boolean skipNamedValues = false;
 			cw.startLine();
 			cw.add('<').add(ri.getTypeName()).add(" name=\"");
 			String itemTag = "item";
@@ -123,6 +124,14 @@ public class ResXmlGen {
 				if (formatValue != null) {
 					cw.add("\" format=\"").add(formatValue);
 				}
+				if (ri.getNamedValues().size() > 1) {
+					for (RawNamedValue rv : ri.getNamedValues()) {
+						if (rv.getNameRef() == ParserConstants.ATTR_MIN) {
+							cw.add("\" min=\"").add(String.valueOf(rv.getRawValue().getData()));
+							skipNamedValues = true;
+						}
+					}
+				}
 			} else {
 				cw.add(ri.getKeyName());
 			}
@@ -135,11 +144,13 @@ public class ResXmlGen {
 			}
 			cw.add("\">");
 
-			cw.incIndent();
-			for (RawNamedValue value : ri.getNamedValues()) {
-				addItem(cw, itemTag, ri.getTypeName(), value);
+			if (!skipNamedValues) {
+				cw.incIndent();
+				for (RawNamedValue value : ri.getNamedValues()) {
+					addItem(cw, itemTag, ri.getTypeName(), value);
+				}
+				cw.decIndent();
 			}
-			cw.decIndent();
 			cw.startLine().add("</").add(ri.getTypeName()).add('>');
 		}
 	}

--- a/jadx-core/src/test/java/jadx/core/xmlgen/ResXmlGenTest.java
+++ b/jadx-core/src/test/java/jadx/core/xmlgen/ResXmlGenTest.java
@@ -80,6 +80,27 @@ class ResXmlGenTest {
 	}
 
 	@Test
+	void testAttrMin() {
+		ResourceStorage resStorage = new ResourceStorage();
+		ResourceEntry re = new ResourceEntry(2130903103, "jadx.gui.app", "attr", "size", "");
+		re.setNamedValues(
+				Lists.list(new RawNamedValue(16777216, new RawValue(16, 4)), new RawNamedValue(16777217, new RawValue(16, 1))));
+		resStorage.add(re);
+
+		ValuesParser vp = new ValuesParser(null, resStorage.getResourcesNames());
+		ResXmlGen resXmlGen = new ResXmlGen(resStorage, vp);
+		List<ResContainer> files = resXmlGen.makeResourcesXml();
+
+		assertEquals(1, files.size());
+		assertEquals("res/values/attrs.xml", files.get(0).getFileName());
+		assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+				+ "<resources>\n"
+				+ "    <attr name=\"size\" format=\"integer\" min=\"1\">\n"
+				+ "    </attr>\n"
+				+ "</resources>", files.get(0).getText().toString());
+	}
+
+	@Test
 	void testStyle() {
 		ResourceStorage resStorage = new ResourceStorage();
 		ResourceEntry re = new ResourceEntry(2130903103, "jadx.gui.app", "style", "JadxGui", "");


### PR DESCRIPTION
This PR adds support for "min"-attribute for attrs.

Steps to reproduce this issue:

Recompilation of this app https://github.com/ds10git/tvbrowserandroid/releases/download/release_0.7.0.8/TV-Browser-v0.7.0.8.apk with latest git fails with:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugResources'.
Task :app:mergeDebugResources FAILED
app/src/main/res/values/attrs.xml:1025:4: Unrecognized tag <item> of child element of <attr>.
```

With this PR all resource issues for this app are fixed.

This PR is still incomplete (apktool supports more attributes like "max" and "localization"), but I don't have sample apps to test these attributes.