### PR TITLE
Parse strings only when they are referenced

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -45,7 +45,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 	private final Map<String, String> tagAttrDeobfNames = new HashMap<>();
 
 	private ICodeWriter writer;
-	private String[] strings;
+	private BinaryXMLStrings strings;
 	private String currentTag = "ERROR";
 	private boolean firstElement;
 	private ValuesParser valuesParser;
@@ -387,8 +387,8 @@ public class BinaryXMLParser extends CommonBinaryParser {
 	}
 
 	private String getString(int strId) {
-		if (0 <= strId && strId < strings.length) {
-			return strings[strId];
+		if (0 <= strId && strId < strings.size()) {
+			return strings.get(strId);
 		}
 		return "NOT_FOUND_STR_0x" + Integer.toHexString(strId);
 	}

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
@@ -4,18 +4,19 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 public class BinaryXMLStrings {
-	final private int stringCount;
+	private final int stringCount;
 
-	final private long stringsStart;
+	private final long stringsStart;
 
-	final private ByteBuffer buffer;
+	private final ByteBuffer buffer;
 
-	final private boolean isUtf8;
+	private final boolean isUtf8;
 
 	// This cache include strings that have been overridden by the deobfuscator.
-	final private HashMap<Integer, String> cache = new HashMap<>();
+	private final Map<Integer, String> cache = new HashMap<>();
 
 	public BinaryXMLStrings() {
 		stringCount = 0;

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
@@ -1,0 +1,103 @@
+package jadx.core.xmlgen;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class BinaryXMLStrings {
+	final private int stringCount;
+
+	final private long stringsStart;
+
+	final private ByteBuffer buffer;
+
+	final private boolean isUtf8;
+
+	// This cache include strings that have been overridden by the deobfuscator.
+	final private HashMap<Integer, String> cache = new HashMap<>();
+
+	public BinaryXMLStrings() {
+		stringCount = 0;
+		stringsStart = 0;
+		buffer = ByteBuffer.allocate(0);
+		buffer.order(ByteOrder.LITTLE_ENDIAN);
+		isUtf8 = false;
+	}
+
+	public BinaryXMLStrings(int stringCount, long stringsStart, byte[] buffer, boolean isUtf8) {
+		this.stringCount = stringCount;
+		this.stringsStart = stringsStart;
+		this.buffer = ByteBuffer.wrap(buffer);
+		this.buffer.order(ByteOrder.LITTLE_ENDIAN);
+		this.isUtf8 = isUtf8;
+	}
+
+	public String get(int id) {
+		String cached = cache.get(id);
+		if (cached != null) {
+			return cached;
+		}
+
+		long offset = stringsStart + buffer.getInt(id * 4);
+		String extracted;
+		if (isUtf8) {
+			extracted = extractString8(this.buffer.array(), (int) offset);
+		} else {
+			// don't trust specified string length, read until \0
+			// stringsOffset can be same for different indexes
+			extracted = extractString16(this.buffer.array(), (int) offset);
+		}
+		cache.put(id, extracted);
+		return extracted;
+	}
+
+	public void put(int id, String content) {
+		cache.put(id, content);
+	}
+
+	public int size() {
+		return this.stringCount;
+	}
+
+	private static String extractString8(byte[] strArray, int offset) {
+		if (offset >= strArray.length) {
+			return "STRING_DECODE_ERROR";
+		}
+		int start = offset + skipStrLen8(strArray, offset);
+		int len = strArray[start++];
+		if (len == 0) {
+			return "";
+		}
+		if ((len & 0x80) != 0) {
+			len = (len & 0x7F) << 8 | strArray[start++] & 0xFF;
+		}
+		byte[] arr = Arrays.copyOfRange(strArray, start, start + len);
+		return new String(arr, ParserStream.STRING_CHARSET_UTF8);
+	}
+
+	private static String extractString16(byte[] strArray, int offset) {
+		int len = strArray.length;
+		int start = offset + skipStrLen16(strArray, offset);
+		int end = start;
+		while (true) {
+			if (end + 1 >= len) {
+				break;
+			}
+			if (strArray[end] == 0 && strArray[end + 1] == 0) {
+				break;
+			}
+			end += 2;
+		}
+		byte[] arr = Arrays.copyOfRange(strArray, start, end);
+		return new String(arr, ParserStream.STRING_CHARSET_UTF16);
+	}
+
+	private static int skipStrLen8(byte[] strArray, int offset) {
+		return (strArray[offset] & 0x80) == 0 ? 1 : 2;
+	}
+
+	private static int skipStrLen16(byte[] strArray, int offset) {
+		return (strArray[offset + 1] & 0x80) == 0 ? 2 : 4;
+	}
+}

--- a/jadx-core/src/main/java/jadx/core/xmlgen/CommonBinaryParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/CommonBinaryParser.java
@@ -1,7 +1,6 @@
 package jadx.core.xmlgen;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 public class CommonBinaryParser extends ParserConstants {
 	protected ParserStream is;
@@ -32,8 +31,7 @@ public class CommonBinaryParser extends ParserConstants {
 				stringCount,
 				stringsStart,
 				buffer,
-				(flags & UTF8_FLAG) != 0
-		);
+				(flags & UTF8_FLAG) != 0);
 	}
 
 	protected void die(String message) throws IOException {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/CommonBinaryParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/CommonBinaryParser.java
@@ -6,12 +6,12 @@ import java.util.Arrays;
 public class CommonBinaryParser extends ParserConstants {
 	protected ParserStream is;
 
-	protected String[] parseStringPool() throws IOException {
+	protected BinaryXMLStrings parseStringPool() throws IOException {
 		is.checkInt16(RES_STRING_POOL_TYPE, "String pool expected");
 		return parseStringPoolNoType();
 	}
 
-	protected String[] parseStringPoolNoType() throws IOException {
+	protected BinaryXMLStrings parseStringPoolNoType() throws IOException {
 		long start = is.getPos() - 2;
 		is.checkInt16(0x001c, "String pool header size not 0x001c");
 		long size = is.readUInt32();
@@ -23,68 +23,17 @@ public class CommonBinaryParser extends ParserConstants {
 		long stringsStart = is.readInt32();
 		long stylesStart = is.readInt32();
 
-		int[] stringsOffset = is.readInt32Array(stringCount);
-		int[] stylesOffset = is.readInt32Array(styleCount);
-
-		is.skipToPos(start + stringsStart, "Expected strings start");
-		String[] strings = new String[stringCount];
-		byte[] strData = is.readInt8Array((int) (chunkEnd - is.getPos()));
-		if ((flags & UTF8_FLAG) != 0) {
-			// UTF-8
-			for (int i = 0; i < stringCount; i++) {
-				strings[i] = extractString8(strData, stringsOffset[i]);
-			}
-		} else {
-			// UTF-16
-			for (int i = 0; i < stringCount; i++) {
-				// don't trust specified string length, read until \0
-				// stringsOffset can be same for different indexes
-				strings[i] = extractString16(strData, stringsOffset[i]);
-			}
-		}
+		// Correct the offset of actual strings, as the header is already read.
+		stringsStart = stringsStart - (is.getPos() - start);
+		byte[] buffer = is.readInt8Array((int) (chunkEnd - is.getPos()));
 		is.checkPos(chunkEnd, "Expected strings pool end");
-		return strings;
-	}
 
-	private static String extractString8(byte[] strArray, int offset) {
-		if (offset >= strArray.length) {
-			return "STRING_DECODE_ERROR";
-		}
-		int start = offset + skipStrLen8(strArray, offset);
-		int len = strArray[start++];
-		if (len == 0) {
-			return "";
-		}
-		if ((len & 0x80) != 0) {
-			len = (len & 0x7F) << 8 | strArray[start++] & 0xFF;
-		}
-		byte[] arr = Arrays.copyOfRange(strArray, start, start + len);
-		return new String(arr, ParserStream.STRING_CHARSET_UTF8);
-	}
-
-	private static String extractString16(byte[] strArray, int offset) {
-		int len = strArray.length;
-		int start = offset + skipStrLen16(strArray, offset);
-		int end = start;
-		while (true) {
-			if (end + 1 >= len) {
-				break;
-			}
-			if (strArray[end] == 0 && strArray[end + 1] == 0) {
-				break;
-			}
-			end += 2;
-		}
-		byte[] arr = Arrays.copyOfRange(strArray, start, end);
-		return new String(arr, ParserStream.STRING_CHARSET_UTF16);
-	}
-
-	private static int skipStrLen8(byte[] strArray, int offset) {
-		return (strArray[offset] & 0x80) == 0 ? 1 : 2;
-	}
-
-	private static int skipStrLen16(byte[] strArray, int offset) {
-		return (strArray[offset + 1] & 0x80) == 0 ? 2 : 4;
+		return new BinaryXMLStrings(
+				stringCount,
+				stringsStart,
+				buffer,
+				(flags & UTF8_FLAG) != 0
+		);
 	}
 
 	protected void die(String message) throws IOException {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/IResParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/IResParser.java
@@ -9,5 +9,5 @@ public interface IResParser {
 
 	ResourceStorage getResStorage();
 
-	String[] getStrings();
+	BinaryXMLStrings getStrings();
 }

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResProtoParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResProtoParser.java
@@ -39,7 +39,7 @@ public class ResProtoParser implements IResParser {
 
 	public ResContainer decodeFiles(InputStream inputStream) throws IOException {
 		decode(inputStream);
-		ValuesParser vp = new ValuesParser(new String[0], resStorage.getResourcesNames());
+		ValuesParser vp = new ValuesParser(new BinaryXMLStrings(), resStorage.getResourcesNames());
 		ResXmlGen resGen = new ResXmlGen(resStorage, vp);
 		ICodeInfo content = XmlGenUtils.makeXmlDump(root.makeCodeWriter(), resStorage);
 		List<ResContainer> xmlFiles = resGen.makeResourcesXml();
@@ -252,7 +252,7 @@ public class ResProtoParser implements IResParser {
 	}
 
 	@Override
-	public String[] getStrings() {
-		return new String[0];
+	public BinaryXMLStrings getStrings() {
+		return new BinaryXMLStrings();
 	}
 }

--- a/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import jadx.core.xmlgen.BinaryXMLStrings;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,10 +20,10 @@ public class ValuesParser extends ParserConstants {
 
 	private static Map<Integer, String> androidResMap;
 
-	private final String[] strings;
+	private final BinaryXMLStrings strings;
 	private final Map<Integer, String> resMap;
 
-	public ValuesParser(String[] strings, Map<Integer, String> resMap) {
+	public ValuesParser(BinaryXMLStrings strings, Map<Integer, String> resMap) {
 		this.strings = strings;
 		this.resMap = resMap;
 		getAndroidResMap();
@@ -105,7 +106,7 @@ public class ValuesParser extends ParserConstants {
 			case TYPE_NULL:
 				return null;
 			case TYPE_STRING:
-				return strings[data];
+				return strings.get(data);
 			case TYPE_INT_DEC:
 				return Integer.toString(data);
 			case TYPE_INT_HEX:

--- a/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/entry/ValuesParser.java
@@ -5,13 +5,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import jadx.core.xmlgen.BinaryXMLStrings;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jadx.core.utils.android.TextResMapFile;
 import jadx.core.utils.exceptions.JadxRuntimeException;
+import jadx.core.xmlgen.BinaryXMLStrings;
 import jadx.core.xmlgen.ParserConstants;
 import jadx.core.xmlgen.XmlGenUtils;
 

--- a/jadx-core/src/test/java/jadx/core/xmlgen/ResXmlGenTest.java
+++ b/jadx-core/src/test/java/jadx/core/xmlgen/ResXmlGenTest.java
@@ -135,7 +135,9 @@ class ResXmlGenTest {
 		re.setNamedValues(Lists.list());
 		resStorage.add(re);
 
-		ValuesParser vp = new ValuesParser(new String[] { "Jadx Decompiler App" }, resStorage.getResourcesNames());
+		BinaryXMLStrings strings = new BinaryXMLStrings();
+		strings.put(0, "Jadx Decompiler App");
+		ValuesParser vp = new ValuesParser(strings, resStorage.getResourcesNames());
 		ResXmlGen resXmlGen = new ResXmlGen(resStorage, vp);
 		List<ResContainer> files = resXmlGen.makeResourcesXml();
 
@@ -155,7 +157,9 @@ class ResXmlGenTest {
 				Lists.list(new RawNamedValue(16777216, new RawValue(3, 0))));
 		resStorage.add(re);
 
-		ValuesParser vp = new ValuesParser(new String[] { "Let's go" }, resStorage.getResourcesNames());
+		BinaryXMLStrings strings = new BinaryXMLStrings();
+		strings.put(0, "Let's go");
+		ValuesParser vp = new ValuesParser(strings, resStorage.getResourcesNames());
 		ResXmlGen resXmlGen = new ResXmlGen(resStorage, vp);
 		List<ResContainer> files = resXmlGen.makeResourcesXml();
 


### PR DESCRIPTION
Fix #1926.

Works well enough on all the APKs available locally to me (malicious or not), including the sample provided in the referenced issue.


BTW, this sample [AndroidManifest.xml.zip](https://github.com/skylot/jadx/files/11844183/AndroidManifest.xml.zip) uses another technique (an extremely large Unicode string in the place of namespace identifier, where Android doesn't care) to try to crash JADX, any idea on how we could defend against this?
