### PR TITLE
fix(gradle): avoid BuildConfig conflict (#1847)

### DIFF
--- a/jadx-core/src/main/resources/export/app.build.gradle.tmpl
+++ b/jadx-core/src/main/resources/export/app.build.gradle.tmpl
@@ -28,9 +28,13 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-        lintOptions {
-            abortOnError false
-        }
+    lintOptions {
+        abortOnError false
+    }
+
+    buildFeatures {
+        buildConfig = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
I changed my mind about implementing buildConfigFields to resolve BuildConfig conflicts (#1847):

```gradle
buildConfigField('Runnable', 'BACKGROUND_THREAD', 'new Runnable() { /* put all your code here */ public void run() { /* insert code with decompilation issues here */ }}')
```

This would create too many new problems. Here is a simple fix to resolve this issue. This setting will be the default in newer AGP versions anyway.