### PR TITLE
fix(res): support formatted=false for strings

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResXmlGen.java
@@ -250,6 +250,11 @@ public class ResXmlGen {
 				cw.add(' ').add(attrName).add("=\"").add(attrValue).add('"');
 			}
 		}
+
+		if (itemTag.equals("string") && valueStr.contains("%") && StringFormattedCheck.hasMultipleNonPositionalSubstitutions(valueStr)) {
+			cw.add(" formatted=\"false\"");
+		}
+
 		if (valueStr.equals("")) {
 			cw.add(" />");
 		} else {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/StringFormattedCheck.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/StringFormattedCheck.java
@@ -1,0 +1,104 @@
+package jadx.core.xmlgen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/*
+ * This class contains source code form https://github.com/iBotPeaches/Apktool/
+ * see:
+ * https://github.com/iBotPeaches/Apktool/blob/master/brut.apktool/apktool-lib/src/main/java/brut/
+ * androlib/res/xml/ResXmlEncoders.java
+ */
+public class StringFormattedCheck {
+
+	public static boolean hasMultipleNonPositionalSubstitutions(String str) {
+		Duo<List<Integer>, List<Integer>> tuple = findSubstitutions(str, 4);
+		return !tuple.m1.isEmpty() && tuple.m1.size() + tuple.m2.size() > 1;
+	}
+
+	@SuppressWarnings("checkstyle:ClassTypeParameterName")
+	private static class Duo<T1, T2> {
+		public final T1 m1;
+		public final T2 m2;
+
+		public Duo(T1 t1, T2 t2) {
+			this.m1 = t1;
+			this.m2 = t2;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			@SuppressWarnings("unchecked")
+			final Duo<T1, T2> other = (Duo<T1, T2>) obj;
+			if (!Objects.equals(this.m1, other.m1)) {
+				return false;
+			}
+			return Objects.equals(this.m2, other.m2);
+		}
+
+		@Override
+		public int hashCode() {
+			int hash = 3;
+			hash = 71 * hash + (this.m1 != null ? this.m1.hashCode() : 0);
+			hash = 71 * hash + (this.m2 != null ? this.m2.hashCode() : 0);
+			return hash;
+		}
+	}
+
+	/**
+	 * It returns a tuple of:
+	 * - a list of offsets of non positional substitutions. non-pos is defined as any "%" which isn't
+	 * "%%" nor "%\d+\$"
+	 * - a list of offsets of positional substitutions
+	 */
+	@SuppressWarnings({ "checkstyle:NeedBraces", "checkstyle:EmptyStatement" })
+	private static Duo<List<Integer>, List<Integer>> findSubstitutions(String str, int nonPosMax) {
+		if (nonPosMax == -1) {
+			nonPosMax = Integer.MAX_VALUE;
+		}
+		int pos;
+		int pos2 = 0;
+		List<Integer> nonPositional = new ArrayList<>();
+		List<Integer> positional = new ArrayList<>();
+
+		if (str == null) {
+			return new Duo<>(nonPositional, positional);
+		}
+
+		int length = str.length();
+
+		while ((pos = str.indexOf('%', pos2)) != -1) {
+			pos2 = pos + 1;
+			if (pos2 == length) {
+				nonPositional.add(pos);
+				break;
+			}
+			char c = str.charAt(pos2++);
+			if (c == '%') {
+				continue;
+			}
+			if (c >= '0' && c <= '9' && pos2 < length) {
+				while ((c = str.charAt(pos2++)) >= '0' && c <= '9' && pos2 < length)
+					;
+				if (c == '$') {
+					positional.add(pos);
+					continue;
+				}
+			}
+
+			nonPositional.add(pos);
+			if (nonPositional.size() >= nonPosMax) {
+				break;
+			}
+		}
+
+		return new Duo<>(nonPositional, positional);
+	}
+}

--- a/jadx-core/src/test/java/jadx/core/xmlgen/ResXmlGenTest.java
+++ b/jadx-core/src/test/java/jadx/core/xmlgen/ResXmlGenTest.java
@@ -150,6 +150,28 @@ class ResXmlGenTest {
 	}
 
 	@Test
+	void testStringFormattedFalse() {
+		ResourceStorage resStorage = new ResourceStorage();
+		ResourceEntry re = new ResourceEntry(2130903103, "jadx.gui.app", "string", "app_name", "");
+		re.setSimpleValue(new RawValue(3, 0));
+		re.setNamedValues(Lists.list());
+		resStorage.add(re);
+
+		BinaryXMLStrings strings = new BinaryXMLStrings();
+		strings.put(0, "%s at %s");
+		ValuesParser vp = new ValuesParser(strings, resStorage.getResourcesNames());
+		ResXmlGen resXmlGen = new ResXmlGen(resStorage, vp);
+		List<ResContainer> files = resXmlGen.makeResourcesXml();
+
+		assertEquals(1, files.size());
+		assertEquals("res/values/strings.xml", files.get(0).getFileName());
+		assertEquals("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+				+ "<resources>\n"
+				+ "    <string name=\"app_name\" formatted=\"false\">%s at %s</string>\n"
+				+ "</resources>", files.get(0).getText().toString());
+	}
+
+	@Test
 	void testArrayEscape() {
 		ResourceStorage resStorage = new ResourceStorage();
 		ResourceEntry re = new ResourceEntry(2130903103, "jadx.gui.app", "array", "single_quote_escape_sample", "");


### PR DESCRIPTION
There is an error message in some cases when a percent sign (%) appears in a resources xml inside a string. The error message is e.g.:

`/app/src/main/res/values/strings.xml:143:4: Multiple substitutions specified in non-positional format of string resource string/certificate_person_details_card_expiration. Did you mean to add the formatted="false" attribute?`

Steps to reproduce:
Export this app to gradle and run a build: https://github.com/corona-warn-app/cwa-app-android / https://m.apkpure.com/de/corona-warn-app/de.rki.coronawarnapp

The problem is causes by strings like:
https://github.com/corona-warn-app/cwa-app-android/blob/d98f9c20c595ca5dc877f87f032b47d8b8175a79/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml#L34

Unlike the devs of SAP jadx does not place quotes around all strings. Apktool solves the issue by setting `formatted="false"`: https://github.com/iBotPeaches/Apktool/blob/2b8121584624f0a1b1602992a48fcdbf60c0347d/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResStringValue.java#L59-L61

It's possible to borrow and reuse their implementation (https://github.com/iBotPeaches/Apktool/blob/2b8121584624f0a1b1602992a48fcdbf60c0347d/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncoders.java#L139-L142
and 
https://github.com/iBotPeaches/Apktool/blob/2b8121584624f0a1b1602992a48fcdbf60c0347d/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/xml/ResXmlEncoders.java#L163-L208 ) directly in jadx to solve this issue. I suppressed all warning instead of fixing them - with less changes it's easier to sync with upstream.

(Btw: Fixing all resource issues of this app is one change ahead: set compileSdkVersion to 31, buildToolsVersion to 31.0.0 and update android gradle plugin to e.g. 7.4.0 and all resource issues are fixed)