### PR TITLE
upgrade to kotlin-logging 5

### DIFF
--- a/jadx-plugins/jadx-script/examples/build.gradle.kts
+++ b/jadx-plugins/jadx-script/examples/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 	implementation(kotlin("stdlib-common"))
 	implementation(kotlin("script-runtime"))
 
-	implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+	implementation("io.github.oshai:kotlin-logging-jvm:5.0.1")
 
 	// script context support in IDE is poor, use stubs and manual imports for now
 	// kotlinScriptDef(project(":jadx-plugins:jadx-script:jadx-script-runtime"))

--- a/jadx-plugins/jadx-script/examples/context/Stubs.kt
+++ b/jadx-plugins/jadx-script/examples/context/Stubs.kt
@@ -1,7 +1,7 @@
 @file:Suppress("MayBeConstant", "unused")
 
 import jadx.plugins.script.runtime.JadxScriptInstance
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KotlinLogging
 
 /**
  * Stubs for JadxScriptBaseClass script super class

--- a/jadx-plugins/jadx-script/examples/context/Stubs.kt
+++ b/jadx-plugins/jadx-script/examples/context/Stubs.kt
@@ -1,7 +1,7 @@
 @file:Suppress("MayBeConstant", "unused")
 
-import jadx.plugins.script.runtime.JadxScriptInstance
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jadx.plugins.script.runtime.JadxScriptInstance
 
 /**
  * Stubs for JadxScriptBaseClass script super class

--- a/jadx-plugins/jadx-script/jadx-script-ide/build.gradle.kts
+++ b/jadx-plugins/jadx-script/jadx-script-ide/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
 	implementation(kotlin("scripting-ide-services"))
 
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
-	implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+	implementation("io.github.oshai:kotlin-logging-jvm:5.0.1")
 }

--- a/jadx-plugins/jadx-script/jadx-script-plugin/build.gradle.kts
+++ b/jadx-plugins/jadx-script/jadx-script-plugin/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
 	implementation(kotlin("scripting-jvm"))
 	implementation(kotlin("scripting-jvm-host"))
 
-	implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+	implementation("io.github.oshai:kotlin-logging-jvm:5.0.1")
 
 	testImplementation(project(":jadx-core"))
 }

--- a/jadx-plugins/jadx-script/jadx-script-runtime/build.gradle.kts
+++ b/jadx-plugins/jadx-script/jadx-script-runtime/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 	implementation(kotlin("scripting-dependencies-maven"))
 
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
-	implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+	implementation("io.github.oshai:kotlin-logging-jvm:5.0.1")
 
 	runtimeOnly(project(":jadx-plugins:jadx-dex-input"))
 	runtimeOnly(project(":jadx-plugins:jadx-smali-input"))

--- a/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/JadxScriptTemplate.kt
+++ b/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/JadxScriptTemplate.kt
@@ -44,11 +44,11 @@ abstract class JadxScriptTemplate(
 	fun getJadxInstance() = scriptInstance
 
 	fun println(message: Any?) {
-		log.info(message?.toString())
+		log.info { message }
 	}
 
 	fun print(message: Any?) {
-		log.info(message?.toString())
+		log.info { message }
 	}
 }
 

--- a/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/ScriptRuntime.kt
+++ b/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/ScriptRuntime.kt
@@ -3,6 +3,8 @@
 
 package jadx.plugins.script.runtime
 
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jadx.api.JadxArgs
 import jadx.api.JadxDecompiler
 import jadx.api.JavaClass
@@ -18,8 +20,6 @@ import jadx.plugins.script.runtime.data.Rename
 import jadx.plugins.script.runtime.data.Replace
 import jadx.plugins.script.runtime.data.Search
 import jadx.plugins.script.runtime.data.Stages
-import io.github.oshai.kotlinlogging.KLogger
-import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 
 const val JADX_SCRIPT_LOG_PREFIX = "JadxScript:"

--- a/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/ScriptRuntime.kt
+++ b/jadx-plugins/jadx-script/jadx-script-runtime/src/main/kotlin/jadx/plugins/script/runtime/ScriptRuntime.kt
@@ -18,8 +18,8 @@ import jadx.plugins.script.runtime.data.Rename
 import jadx.plugins.script.runtime.data.Replace
 import jadx.plugins.script.runtime.data.Search
 import jadx.plugins.script.runtime.data.Stages
-import mu.KLogger
-import mu.KotlinLogging
+import io.github.oshai.kotlinlogging.KLogger
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.File
 
 const val JADX_SCRIPT_LOG_PREFIX = "JadxScript:"


### PR DESCRIPTION
Hi, I created a PR to upgrade kotlin-logging to v5, hope you will be open to accept it. I am the lib maintainer and since this is a breaking change and pact is pretty popular I thought to assist with the upgrade.

Notable changes:

- replace `import mu.` with `import io.github.oshai.kotlinlogging.`
- replace dependency `'io.github.microutils:kotlin-logging-jvm:3.0.5'` to  `io.github.oshai:kotlin-logging-jvm:5.0.1`.

