### PR TITLE
Fix exception when AndroidManifest.xml is not found in go to main activity action

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/android/AndroidManifestParser.java
+++ b/jadx-core/src/main/java/jadx/core/utils/android/AndroidManifestParser.java
@@ -223,6 +223,10 @@ public class AndroidManifestParser {
 	}
 
 	private static Document parseAndroidManifest(ResourceFile androidManifest) {
+		if (androidManifest == null) {
+			return null;
+		}
+
 		String content = androidManifest.loadContent().getText().getCodeStr();
 
 		return parseXml(content);


### PR DESCRIPTION
After refactoring code in pr #1971, forgot to add a check to ensure AndroidManifest.xml is found before proceeding to look for main activity, which causes a confusing NullPointerException to be thrown.
