### PR TITLE
docs: Update badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ On Windows run `.bat` files with double-click\
 For Windows, you can download it from [oracle.com](https://www.oracle.com/java/technologies/downloads/#jdk17-windows) (select x64 Installer).
 
 ### Install
-1. Arch linux ![Arch Linux package](https://img.shields.io/archlinux/v/community/any/jadx?label=)
+1. Arch linux ![Arch Linux package](https://img.shields.io/archlinux/v/extra/any/jadx?label=)
     ```bash
     sudo pacman -S jadx
     ```


### PR DESCRIPTION
Arch package was moved to another repo:
> In the new layout extra would contain all packages that were previously in community
― [Official repositories - ArchWiki (archlinux.org)](https://wiki.archlinux.org/title/official_repositories)

See also:
Alternative badge that wouldn't have been broken by this change: ![](https://repology.org/badge/version-for-repo/arch/jadx.svg?header=), from https://repology.org/project/jadx/badges