### PR TITLE
Pixeebot / Introduced protections against "zip slip" attacks 

### DIFF
--- a/buildSrc/src/main/kotlin/jadx-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/jadx-java.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
 	testCompileOnly("org.jetbrains:annotations:24.0.1")
+	
+	implementation("io.github.pixee:java-security-toolkit:1.0.7")
 }
 
 repositories {

--- a/jadx-core/src/main/java/jadx/core/clsp/ClsSet.java
+++ b/jadx-core/src/main/java/jadx/core/clsp/ClsSet.java
@@ -1,5 +1,6 @@
 package jadx.core.clsp;
 
+import io.github.pixee.security.ZipSecurity;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -196,7 +197,7 @@ public class ClsSet {
 			Files.copy(path, temp, StandardCopyOption.REPLACE_EXISTING);
 
 			try (ZipOutputStream out = new ZipOutputStream(Files.newOutputStream(path));
-					ZipInputStream in = new ZipInputStream(Files.newInputStream(temp))) {
+					ZipInputStream in = ZipSecurity.createHardenedInputStream(Files.newInputStream(temp))) {
 				String clst = CLST_PATH;
 				boolean clstReplaced = false;
 				ZipEntry entry = in.getNextEntry();

--- a/jadx-gui/build.gradle.kts
+++ b/jadx-gui/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
 	implementation("com.android.tools.build:apksig:8.1.1")
 	implementation("io.github.skylot:jdwp:2.0.0")
 
+	implementation("io.github.pixee:java-security-toolkit:1.0.7")
+
 	testImplementation(project(":jadx-core").dependencyProject.sourceSets.getByName("test").output)
 }
 


### PR DESCRIPTION
### Description
This change updates all new instances of [ZipInputStream](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/zip/ZipInputStream.html) to protect against malicious entries that attempt to escape their "file root" and overwrite other files on the running filesystem.

Normally, when you're using `ZipInputStream` it's because you're processing zip files. That code might look like this:

```java
File file = new File(unzipTargetDirectory, zipEntry.getName()); // use file name from zip entry
InputStream is = zip.getInputStream(zipEntry); // get the contents of the zip entry
IOUtils.copy(is, new FileOutputStream(file)); // write the contents to the provided file name
```

This looks fine when it encounters a normal zip entry within a zip file, looking something like this pseudo-data:
```binary
path: data/names.txt
contents: Zeus\nHelen\nLeda...
```

However, there's nothing to prevent an attacker from sending an evil entry in the zip that looks more like this:
```binary
path: ../../../../../etc/passwd
contents: root::0:0:root:/:/bin/sh
```

Yes, in the above code, which looks like [every](https://stackoverflow.com/a/23870468) [piece](https://stackoverflow.com/a/51285801) of [zip-processing](https://kodejava.org/how-do-i-decompress-a-zip-file-using-zipinputstream/)  code you can [find](https://www.tabnine.com/code/java/classes/java.util.zip.ZipInputStream) on the [Internet](https://www.baeldung.com/java-compress-and-uncompress), attackers could overwrite any files to which the application has access. This rule replaces the standard `ZipInputStream` with a hardened subclass which prevents access to entry paths that attempt to traverse directories above the current directory (which no normal zip file should ever do.) Our changes end up looking something like this:

```diff
+ import io.github.pixee.security.ZipSecurity;
  ...
- var zip = new ZipInputStream(is, StandardCharsets.UTF_8);
+ var zip = ZipSecurity.createHardenedInputStream(is, StandardCharsets.UTF_8);
```

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/harden-zip-entry-paths](https://docs.pixee.ai/codemods/java/pixee_java_harden-zip-entry-paths)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Czcarroll4%2Fjadx%7Cf7bc46c2f140c0253a07bc51806ea65717c21298)

<!--{"type":"DRIP","codemod":"pixee:java/harden-zip-entry-paths"}-->