### PR TITLE
fix: use fully qualified package names for classes of defpackage

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
@@ -680,7 +680,7 @@ public class ClassGen {
 		}
 		// ignore classes from default package
 		if (extClsInfo.isDefaultPackage()) {
-			return shortName;
+			return fullName;
 		}
 		if (extClsInfo.getAliasPkg().equals(useCls.getAliasPkg())) {
 			fullName = extClsInfo.getAliasNameWithoutPackage();


### PR DESCRIPTION
fix #2027 