### PR TITLE
Kotlin toString renamer produces illegal filenames and may override files during export

### DIFF
--- a/jadx-plugins/jadx-kotlin-metadata/src/main/kotlin/jadx/plugins/kotlin/metadata/pass/KotlinMetadataDecompilePass.kt
+++ b/jadx-plugins/jadx-kotlin-metadata/src/main/kotlin/jadx/plugins/kotlin/metadata/pass/KotlinMetadataDecompilePass.kt
@@ -4,6 +4,7 @@ import jadx.api.plugins.input.data.AccessFlags
 import jadx.api.plugins.pass.JadxPassInfo
 import jadx.api.plugins.pass.impl.OrderedJadxPassInfo
 import jadx.api.plugins.pass.types.JadxDecompilePass
+import jadx.core.deobf.NameMapper
 import jadx.core.dex.attributes.AFlag
 import jadx.core.dex.attributes.nodes.RenameReasonAttr
 import jadx.core.dex.nodes.ClassNode
@@ -106,14 +107,14 @@ class KotlinMetadataDecompilePass(
 		val toString = wrapper.parseToString()
 		toString?.run {
 			clsAlias?.let { alias ->
-				if (AFlag.DONT_RENAME !in cls) {
+				if (NameMapper.isValidIdentifier(alias) && AFlag.DONT_RENAME !in cls) {
 					RenameReasonAttr.forNode(cls).append(TO_STRING_REASON)
 					cls.rename(alias)
 				}
 			}
 
 			fields.forEach { (field, alias) ->
-				if (AFlag.DONT_RENAME !in field) {
+				if (NameMapper.isValidIdentifier(alias) && AFlag.DONT_RENAME !in field) {
 					RenameReasonAttr.forNode(field).append(TO_STRING_REASON)
 					field.rename(alias)
 				}


### PR DESCRIPTION
Steps to reproduce: 
* Open Jadx GUI (latest git), verify that the option [Plugins -> Kotlin Metadata -> rename fields using toString] is enabled
* Open https://github.com/niranjan94/show-java/releases/download/v3.0.5/ShowJava_v3_0_5.apk (and decompile Jadx itself)
* Navigate in structure tree to package "kotlin.jvm.internal": All class names in that package are valid
* Export sources as gradle project -> now there are two empty items in package "kotlin.jvm.internal"
* Show source code for both items: The class name is " " in both cases and an invalid file "app/src/main/java/kotlin/jvm/internal/ .java" was created.

This PR fixes this issue with a check for valid identifiers before rename. An working alternate fix would be using BetterName, since it includes the valid identifier check, but I wasn't sure if the BetterName metric for java is the same as for kotlin. If you prefer BetterName, please reject my PR and I'll fix this with BetterName.

This PR will fix lots of syntax errors in exported sources.

With other apps I've also seen class names like "." generating a filename "..java", but I haven't found any apps with path traversal attacks yet.