### PR TITLE
fix: gradle export for APKs without strings.xml

### DIFF
--- a/jadx-core/src/main/java/jadx/core/export/ExportGradleTask.java
+++ b/jadx-core/src/main/java/jadx/core/export/ExportGradleTask.java
@@ -55,7 +55,7 @@ public class ExportGradleTask implements Runnable {
 				.orElseGet(() -> resContainers.stream()
 						.filter(resContainer -> resContainer.getFileName().contains("strings.xml"))
 						.findFirst()
-						.orElseThrow(IllegalStateException::new));
+						.orElse(null));
 
 		ExportGradleProject export = new ExportGradleProject(root, projectDir, androidManifest, strings);
 

--- a/jadx-core/src/main/java/jadx/core/utils/android/AndroidManifestParser.java
+++ b/jadx-core/src/main/java/jadx/core/utils/android/AndroidManifestParser.java
@@ -36,8 +36,6 @@ public class AndroidManifestParser {
 
 		this.androidManifest = parseAndroidManifest(androidManifestRes);
 		this.appStrings = parseAppStrings(appStrings);
-
-		validateAttrs();
 	}
 
 	public boolean isManifestFound() {
@@ -58,12 +56,6 @@ public class AndroidManifestParser {
 		}
 
 		return parseAttributes();
-	}
-
-	private void validateAttrs() {
-		if (parseAttrs.contains(AppAttribute.APPLICATION_LABEL) && appStrings == null) {
-			throw new IllegalArgumentException("APPLICATION_LABEL attribute requires non null appStrings");
-		}
 	}
 
 	private ApplicationParams parseAttributes() {
@@ -113,6 +105,9 @@ public class AndroidManifestParser {
 		if (application.hasAttribute("android:label")) {
 			String appLabelName = application.getAttribute("android:label");
 			if (appLabelName.startsWith("@string")) {
+				if (appStrings == null) {
+					throw new IllegalArgumentException("APPLICATION_LABEL attribute requires non null appStrings");
+				}
 				appLabelName = appLabelName.split("/")[1];
 				NodeList strings = appStrings.getElementsByTagName("string");
 


### PR DESCRIPTION
When I try to export this APK (https://python-helper.apk.gold/) as gradle project, I'm getting the same exception like in https://github.com/skylot/jadx/issues/2044 , https://github.com/skylot/jadx/issues/1920 and https://github.com/skylot/jadx/issues/1918

```
java.lang.IllegalStateException
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at jadx.core.export.ExportGradleTask.lambda$run$3(ExportGradleTask.java:58)
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at jadx.core.export.ExportGradleTask.run(ExportGradleTask.java:55)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

The gradle export always expects a strings.xml, but this assumption isn't true, so my proposition is to postpone this check. I'm sure this PR fixes will also fix https://github.com/skylot/jadx/issues/1920.