### PR TITLE
Fix Xposed code generation

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.java
@@ -101,9 +101,18 @@ public class XposedAction extends JNodeAction {
 			return String.format(xposedFormatStr, xposedMethod, rawClassName, methodName);
 		}
 		String params = mthArgs.stream()
-				.map(type -> (type.isGeneric() ? type.getObject() : type) + ".class, ")
+				.map(type -> fixTypeContent(type) + ".class, ")
 				.collect(Collectors.joining());
 		return String.format(xposedFormatStr, xposedMethod, rawClassName, methodName + params);
+	}
+
+	private String fixTypeContent(ArgType type) {
+		if (type.isGeneric()) {
+			return type.getObject();
+		} else if (type.isGenericType() && type.isObject() && type.isTypeKnown()) {
+			return "Object";
+		}
+		return type.toString();
 	}
 
 	private String generateClassSnippet(JClass jc) {
@@ -120,6 +129,6 @@ public class XposedAction extends JNodeAction {
 		String isStatic = javaField.getAccessFlags().isStatic() ? "Static" : "";
 		String type = PRIMITIVE_TYPE_MAPPING.getOrDefault(javaField.getFieldNode().getType().toString(), "Object");
 		String xposedMethod = "XposedHelpers.get" + isStatic + type + "Field";
-		return String.format("%s(/*runtimeObject*/, \"%s\");", xposedMethod, javaField.getName());
+		return String.format("%s(/*runtimeObject*/, \"%s\");", xposedMethod, javaField.getFieldNode().getFieldInfo().getName());
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.java
@@ -1,6 +1,7 @@
 package jadx.gui.ui.codearea;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.swing.JOptionPane;
@@ -9,11 +10,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jadx.api.JavaClass;
+import jadx.api.JavaField;
 import jadx.api.JavaMethod;
 import jadx.core.dex.instructions.args.ArgType;
 import jadx.core.dex.nodes.MethodNode;
 import jadx.core.utils.exceptions.JadxRuntimeException;
 import jadx.gui.treemodel.JClass;
+import jadx.gui.treemodel.JField;
 import jadx.gui.treemodel.JMethod;
 import jadx.gui.treemodel.JNode;
 import jadx.gui.ui.action.ActionModel;
@@ -23,6 +26,16 @@ import jadx.gui.utils.UiUtils;
 public class XposedAction extends JNodeAction {
 	private static final Logger LOG = LoggerFactory.getLogger(XposedAction.class);
 	private static final long serialVersionUID = 2641585141624592578L;
+	private static final Map<String, String> PRIMITIVE_TYPE_MAPPING = Map.of(
+			"int", "Int",
+			"byte", "Byte",
+			"short", "Short",
+			"long", "Long",
+			"float", "Float",
+			"double", "Double",
+			"char", "Char",
+			"boolean", "Boolean"
+	);
 
 	public XposedAction(CodeArea codeArea) {
 		super(ActionModel.XPOSED_COPY, codeArea);
@@ -43,7 +56,7 @@ public class XposedAction extends JNodeAction {
 
 	@Override
 	public boolean isActionEnabled(JNode node) {
-		return node instanceof JMethod || node instanceof JClass;
+		return node instanceof JMethod || node instanceof JClass || node instanceof JField;
 	}
 
 	private String generateXposedSnippet(JNode node) {
@@ -52,6 +65,9 @@ public class XposedAction extends JNodeAction {
 		}
 		if (node instanceof JClass) {
 			return generateClassSnippet((JClass) node);
+		}
+		if (node instanceof JField) {
+			return generateFieldSnippet((JField) node);
 		}
 		throw new JadxRuntimeException("Unsupported node type: " + (node != null ? node.getClass() : "null"));
 	}
@@ -84,7 +100,7 @@ public class XposedAction extends JNodeAction {
 		if (mthArgs.isEmpty()) {
 			return String.format(xposedFormatStr, xposedMethod, rawClassName, methodName);
 		}
-		String params = mthArgs.stream().map(type -> type + ".class, ").collect(Collectors.joining());
+		String params = mthArgs.stream().map(type -> (type.isGeneric() ? type.getObject() : type) + ".class, ").collect(Collectors.joining());
 		return String.format(xposedFormatStr, xposedMethod, rawClassName, methodName + params);
 	}
 
@@ -92,8 +108,18 @@ public class XposedAction extends JNodeAction {
 		JavaClass javaClass = jc.getCls();
 		String rawClassName = javaClass.getRawName();
 		String shortClassName = javaClass.getName();
-		return String.format("ClassLoader classLoader=lpparam.classLoader;\n"
-				+ "Class %sClass=classLoader.loadClass(\"%s\");",
+		return String.format("ClassLoader classLoader = lpparam.classLoader;\n"
+						+ "Class<?> %sClass = classLoader.loadClass(\"%s\");",
 				shortClassName, rawClassName);
+	}
+
+	private String generateFieldSnippet(JField jf) {
+		JavaField javaField = jf.getJavaField();
+		String isStatic = javaField.getAccessFlags().isStatic() ? "Static" : "";
+		String type = PRIMITIVE_TYPE_MAPPING.getOrDefault(javaField.getFieldNode().getType().toString(), "Object");
+		String xposedMethod = "XposedHelpers.get" + isStatic + type + "Field";
+		return String.format("%s(/*runtimeObject*/, \"%s\");",
+				xposedMethod, javaField.getName());
+
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.java
@@ -26,6 +26,7 @@ import jadx.gui.utils.UiUtils;
 public class XposedAction extends JNodeAction {
 	private static final Logger LOG = LoggerFactory.getLogger(XposedAction.class);
 	private static final long serialVersionUID = 2641585141624592578L;
+
 	private static final Map<String, String> PRIMITIVE_TYPE_MAPPING = Map.of(
 			"int", "Int",
 			"byte", "Byte",
@@ -34,8 +35,7 @@ public class XposedAction extends JNodeAction {
 			"float", "Float",
 			"double", "Double",
 			"char", "Char",
-			"boolean", "Boolean"
-	);
+			"boolean", "Boolean");
 
 	public XposedAction(CodeArea codeArea) {
 		super(ActionModel.XPOSED_COPY, codeArea);
@@ -100,7 +100,9 @@ public class XposedAction extends JNodeAction {
 		if (mthArgs.isEmpty()) {
 			return String.format(xposedFormatStr, xposedMethod, rawClassName, methodName);
 		}
-		String params = mthArgs.stream().map(type -> (type.isGeneric() ? type.getObject() : type) + ".class, ").collect(Collectors.joining());
+		String params = mthArgs.stream()
+				.map(type -> (type.isGeneric() ? type.getObject() : type) + ".class, ")
+				.collect(Collectors.joining());
 		return String.format(xposedFormatStr, xposedMethod, rawClassName, methodName + params);
 	}
 
@@ -109,7 +111,7 @@ public class XposedAction extends JNodeAction {
 		String rawClassName = javaClass.getRawName();
 		String shortClassName = javaClass.getName();
 		return String.format("ClassLoader classLoader = lpparam.classLoader;\n"
-						+ "Class<?> %sClass = classLoader.loadClass(\"%s\");",
+				+ "Class<?> %sClass = classLoader.loadClass(\"%s\");",
 				shortClassName, rawClassName);
 	}
 
@@ -118,8 +120,6 @@ public class XposedAction extends JNodeAction {
 		String isStatic = javaField.getAccessFlags().isStatic() ? "Static" : "";
 		String type = PRIMITIVE_TYPE_MAPPING.getOrDefault(javaField.getFieldNode().getType().toString(), "Object");
 		String xposedMethod = "XposedHelpers.get" + isStatic + type + "Field";
-		return String.format("%s(/*runtimeObject*/, \"%s\");",
-				xposedMethod, javaField.getName());
-
+		return String.format("%s(/*runtimeObject*/, \"%s\");", xposedMethod, javaField.getName());
 	}
 }


### PR DESCRIPTION
### Description
Resolved the issue where Xposed code generation was incorrect when dealing with generic parameters and alias fields.


![image](https://github.com/skylot/jadx/assets/72244576/b88ed252-0aa5-4315-9ff1-eb1aad553e44)
![image](https://github.com/skylot/jadx/assets/72244576/efa59967-7fbc-4e68-bc91-46efc2c13c71)

![image](https://github.com/skylot/jadx/assets/72244576/3aff07db-62f3-4834-8975-63c09fb8281c)

[mapTest.class.zip](https://github.com/skylot/jadx/files/13638370/mapTest.class.zip)
