### PR TITLE
feat: improve search bar behavior when using key bindings

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
@@ -64,7 +64,7 @@ public class CodePanel extends JPanel {
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				searchBar.toggle();
+				searchBar.showAndFocus();
 			}
 		});
 		JMenuItem searchItem = new JMenuItem();

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/SearchBar.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/SearchBar.java
@@ -140,6 +140,24 @@ public class SearchBar extends JToolBar {
 		setVisible(false);
 	}
 
+	/*
+	 * Replicates IntelliJ's search bar behavior
+	 * 1.1. If the user has selected text, use that as the search text
+	 * 1.2. Otherwise, use the previous search text (or empty if none)
+	 * 2. Select all text in the search bar and give it focus
+	 */
+	public void showAndFocus() {
+		setVisible(true);
+
+		String selectedText = rTextArea.getSelectedText();
+		if (!StringUtils.isEmpty(selectedText)) {
+			searchField.setText(selectedText);
+		}
+
+		searchField.selectAll();
+		searchField.requestFocus();
+	}
+
 	public void toggle() {
 		boolean visible = !isVisible();
 		setVisible(visible);
@@ -149,8 +167,8 @@ public class SearchBar extends JToolBar {
 			if (!StringUtils.isEmpty(preferText)) {
 				searchField.setText(preferText);
 			}
-			searchField.requestFocus();
 			searchField.selectAll();
+			searchField.requestFocus();
 		} else {
 			rTextArea.requestFocus();
 		}


### PR DESCRIPTION
Before, the search bar would toggle when using the key binding to trigger it (Ctrl + f), which was quite annoying. Now, it replicates IntelliJ's search bar behaviour.

1.1. If the user has selected text, use that as the search text
1.2. Otherwise, use the previous search text (or empty if none)
2. Select all text in the search bar and give it focus
