### PR TITLE
fix: attempt to improve field rename issues with "n" shortcut

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/dialog/RenameDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/dialog/RenameDialog.java
@@ -15,6 +15,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 import org.jetbrains.annotations.NotNull;
@@ -42,9 +43,11 @@ public class RenameDialog extends JDialog {
 	private transient JButton renameBtn;
 
 	public static boolean rename(MainWindow mainWindow, JRenameNode node) {
-		RenameDialog renameDialog = new RenameDialog(mainWindow, node);
-		UiUtils.uiRun(() -> renameDialog.setVisible(true));
-		UiUtils.uiRun(renameDialog::initRenameField); // wait for UI events to propagate
+		SwingUtilities.invokeLater(() -> {
+			RenameDialog renameDialog = new RenameDialog(mainWindow, node);
+			renameDialog.initRenameField();
+			renameDialog.setVisible(true);
+		});
 		return true;
 	}
 


### PR DESCRIPTION
This is an attempt to fix the issues that sometimes arise when renaming functions or variables using the "n" shortcut as stated in issue #1440.

The reasoning behind the change: The instance creation of the RenameDialog was somehow affecting the UI thread and not allowing for the key release event to be dispatched. By running everything inside the invokeLater block, this might get fixed as it will execute after all previous tasks are finished. We now also only show the dialog after EVERYTHING is set up, not before.

Only time will tell if this is fixed, but I have not been able to trigger the issue after this change.
