### PR TITLE
Fixing removeUnreachable not searching in all blocks

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockProcessor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockProcessor.java
@@ -644,14 +644,13 @@ public class BlockProcessor extends AbstractVisitor {
 	}
 
 	private static void removeUnreachableBlocks(MethodNode mth) {
-		Set<BlockNode> toRemove = null;
+		Set<BlockNode> toRemove = new LinkedHashSet<>();
 		for (BlockNode block : mth.getBasicBlocks()) {
 			if (block.getPredecessors().isEmpty() && block != mth.getEnterBlock()) {
-				toRemove = new LinkedHashSet<>();
 				BlockSplitter.collectSuccessors(block, mth.getEnterBlock(), toRemove);
 			}
 		}
-		if (toRemove == null || toRemove.isEmpty()) {
+		if (toRemove.isEmpty()) {
 			return;
 		}
 


### PR DESCRIPTION
The method `removeUnreachableBlocks` was iterating through all the methods basic blocks but only keeping the last result found (in `toRemove`).

This will create an error later when the method `checkForUnreachableBlocks` is called.

Therefore, the fix is to use only one instance of the object `toRemove` and keep all the information there.