### PR TITLE
Fixing wrong order in removeUnreachableBlocks

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockProcessor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockProcessor.java
@@ -654,13 +654,14 @@ public class BlockProcessor extends AbstractVisitor {
 			return;
 		}
 
-		toRemove.forEach(BlockSplitter::detachBlock);
-		mth.getBasicBlocks().removeAll(toRemove);
 		long notEmptyBlocks = toRemove.stream().filter(block -> !block.getInstructions().isEmpty()).count();
 		if (notEmptyBlocks != 0) {
 			int insnsCount = toRemove.stream().mapToInt(block -> block.getInstructions().size()).sum();
 			mth.addWarnComment("Unreachable blocks removed: " + notEmptyBlocks + ", instructions: " + insnsCount);
 		}
+
+		toRemove.forEach(BlockSplitter::detachBlock);
+		mth.getBasicBlocks().removeAll(toRemove);
 	}
 
 	private static void clearBlocksState(MethodNode mth) {

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockSplitter.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockSplitter.java
@@ -455,7 +455,6 @@ public class BlockSplitter extends AbstractVisitor {
 			successor.getPredecessors().remove(block);
 		}
 		block.add(AFlag.REMOVE);
-		block.getInstructions().clear();
 		block.getPredecessors().clear();
 		block.getSuccessors().clear();
 	}

--- a/jadx-core/src/test/smali/conditions/TestTernary4.smali
+++ b/jadx-core/src/test/smali/conditions/TestTernary4.smali
@@ -133,8 +133,6 @@
     .catchall {:try_start_14 .. :try_end_50} :catchall_4e
 
     throw p1
-
-    return-void
 .end method
 
 .method private getValueObject(Ljava/lang/String;)Ljava/lang/Object;


### PR DESCRIPTION
The counting of removed blocks and removed instructions is not in the right order in `removeUnreachableBlocks`.
`detachBlock` method will zero the instructions of a block before it is analyzed by the code and no warning of the method can be done.

The fix is to reverse the order