### PR TITLE
Detecting tab click with mousePressed instead of mouseClicked.

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/TabComponent.java
@@ -79,7 +79,7 @@ public class TabComponent extends JPanel {
 
 		MouseAdapter clickAdapter = new MouseAdapter() {
 			@Override
-			public void mouseClicked(MouseEvent e) {
+			public void mousePressed(MouseEvent e) {
 				if (SwingUtilities.isMiddleMouseButton(e)) {
 					tabbedPane.closeCodePanel(contentPanel);
 				} else if (SwingUtilities.isRightMouseButton(e)) {


### PR DESCRIPTION
Hello! Changed `MouseAdapter` callback from `mouseClicked` to `mousePressed`. Reasons:
1. `MouseEvent.MOUSE_CLICKED` is only sent when there is no movement between press and release events, not even a single pixel. Maybe my mouse is too sensitive, but it is challenging to close or select a tab without significally slowing down the mouse or fully stopping it.
2. `BasicTabbedPaneUI.java` itself handles tab selecting within `mousePressed` (line 2611). As a result, the behavior differs when clicking at the tab's center compared (our handler) to clicking at its edges (parent's handler).