### PR TITLE
fix(res): add missing namespace declarations

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -40,6 +40,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 	private final Map<Integer, String> resNames;
 	private Map<String, String> nsMap;
 	private Set<String> nsMapGenerated;
+	private Set<String> definedNamespaces;
 	private final Map<String, String> tagAttrDeobfNames = new HashMap<>();
 
 	private ICodeWriter writer;
@@ -78,11 +79,13 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		}
 		nsMapGenerated = new HashSet<>();
 		nsMap = new HashMap<>();
+		definedNamespaces = new HashSet<>();
 		writer = rootNode.makeCodeWriter();
 		writer.add("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
 		firstElement = true;
 		decode();
 		nsMap = null;
+		definedNamespaces = null;
 		ICodeInfo codeInfo = writer.finish();
 		this.classNameCache = null; // reset class name cache
 		return codeInfo;
@@ -269,15 +272,18 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		int idIndex = is.readInt16();
 		int classIndex = is.readInt16();
 		int styleIndex = is.readInt16();
-		if ("manifest".equals(currentTag) || writer.getIndent() == 0) {
+		if ("manifest".equals(currentTag) || writer.getIndent() == 0 || definedNamespaces.size() != nsMap.size()) {
 			for (Map.Entry<String, String> entry : nsMap.entrySet()) {
-				String nsValue = getValidTagAttributeName(entry.getValue());
-				writer.add(" xmlns");
-				if (nsValue != null && !nsValue.trim().isEmpty()) {
-					writer.add(':');
-					writer.add(nsValue);
+				if (!definedNamespaces.contains(entry.getKey())) {
+					definedNamespaces.add(entry.getKey());
+					String nsValue = getValidTagAttributeName(entry.getValue());
+					writer.add(" xmlns");
+					if (nsValue != null && !nsValue.trim().isEmpty()) {
+						writer.add(':');
+						writer.add(nsValue);
+					}
+					writer.add("=\"").add(StringUtils.escapeXML(entry.getKey())).add('"');
 				}
-				writer.add("=\"").add(StringUtils.escapeXML(entry.getKey())).add('"');
 			}
 		}
 		boolean attrNewLine = attributeCount != 1 && this.attrNewLine;

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -272,7 +272,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		int idIndex = is.readInt16();
 		int classIndex = is.readInt16();
 		int styleIndex = is.readInt16();
-		if ("manifest".equals(currentTag) || writer.getIndent() == 0 || definedNamespaces.size() != nsMap.size()) {
+		if ("manifest".equals(currentTag) || definedNamespaces.size() != nsMap.size()) {
 			for (Map.Entry<String, String> entry : nsMap.entrySet()) {
 				if (!definedNamespaces.contains(entry.getKey())) {
 					definedNamespaces.add(entry.getKey());


### PR DESCRIPTION
### Description

Steps to reproduce:

- download https://apkpure.net/python-documentation-guide/com.thiyagaraaj.learnpython/download/3.8
- decompile apk with latest git, export as gradle
- update `com.android.tools.build:gradle:4.2.2` to version 7.4.0 (newer version generates a more detailed error message, otherwise you would not be able to find the cause)
- add a gradle 7.5 wrapper
- rebuild:

```
./gradlew assembleDebug

> Task :app:processDebugMainManifest
package="com.thiyagaraaj.learnpython" found in source AndroidManifest.xml: app/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.

> Task :app:mergeDebugResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugResources'.
> Multiple task action failures occurred:
   > A failure occurred while executing com.android.build.gradle.internal.res.ResourceCompilerRunnable
      > Resource compilation failed (Failed to compile resource file: app/src/main/res/layout/activity_group_list.xml: . Cause: javax.xml.stream.XMLStreamException: ParseError at [row,col]:[82,47]
        Message: http://www.w3.org/TR/1999/REC-xml-names-19990114#AttributePrefixUnbound?com.google.android.gms.ads.AdView&ads:adSize&ads). Check logs for more details.
   > A failure occurred while executing com.android.build.gradle.internal.res.ResourceCompilerRunnable
      > Resource compilation failed (Failed to compile resource file: app/src/main/res/layout/activity_article_list.xml: . Cause: javax.xml.stream.XMLStreamException: ParseError at [row,col]:[80,47]
        Message: http://www.w3.org/TR/1999/REC-xml-names-19990114#AttributePrefixUnbound?com.google.android.gms.ads.AdView&ads:adSize&ads). Check logs for more details.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED
```


The namespace "ads" was declared in a parent node below the root node, but declared namespaces are written only for the root node, so BinaryXMLParser.generateNameForNS() won't write a namespace declaration too. With this fix the grade build will pass all resource steps. The result is even better than apktool: In case of new namespaces apktool redeclares all namespaces.

PS: the check `writer.getIndent() == 0` might not be necessary anymore