### PR TITLE
Add indents for namespace declarations

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -303,7 +303,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 
 		String shortNsName = null;
 		if (attributeNS != -1) {
-			shortNsName = getAttributeNS(attributeNS);
+			shortNsName = getAttributeNS(attributeNS, newLine);
 		}
 		String attrName = getValidTagAttributeName(getAttributeName(attributeName));
 		String attrFullName = shortNsName != null ? shortNsName + ":" + attrName : attrName;
@@ -340,7 +340,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		writer.add('"');
 	}
 
-	private String getAttributeNS(int attributeNS) {
+	private String getAttributeNS(int attributeNS, boolean newLine) {
 		String attrUrl = getString(attributeNS);
 		if (attrUrl == null || attrUrl.isEmpty()) {
 			if (isResInternalId(attributeNS)) {
@@ -351,12 +351,12 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		}
 		String attrName = nsMap.get(attrUrl);
 		if (attrName == null) {
-			attrName = generateNameForNS(attrUrl);
+			attrName = generateNameForNS(attrUrl, newLine);
 		}
 		return attrName;
 	}
 
-	private String generateNameForNS(String attrUrl) {
+	private String generateNameForNS(String attrUrl, boolean newLine) {
 		String attrName;
 		if (ANDROID_NS_URL.equals(attrUrl)) {
 			attrName = ANDROID_NS_VALUE;
@@ -371,6 +371,11 @@ public class BinaryXMLParser extends CommonBinaryParser {
 					break;
 				}
 			}
+		}
+		if (newLine) {
+			writer.startLine().addIndent();
+		} else {
+			writer.add(' ');
 		}
 		writer.add("xmlns:").add(attrName).add("=\"").add(attrUrl).add("\" ");
 		return attrName;


### PR DESCRIPTION
Jadx generated invalid XML because of missing spaces, e.g.:
```xml
<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="20053842" android:versionName="3.0.609145868" android:compileSdkVersion="34" android:compileSdkVersionCodename="VanillaIceCream" package="com.google.android.apps.adwords" platformBuildVersionCode="34" platformBuildVersionName="VanillaIceCream"xmlns:ns1="http://schemas.android.com/apk/distribution"  ns1:requiredSplitTypes="base__abi"xmlns:ns2="http://schemas.android.com/apk/distribution"  ns2:splitTypes="">
```