### PR TITLE
fix some manifest decode Error.

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -193,6 +193,9 @@ public class BinaryXMLParser extends CommonBinaryParser {
 			die("NAMESPACE end is not 0x10 big");
 		}
 		int dataSize = is.readInt32();
+		if (dataSize != 0x18) {
+			LOG.warn("Invalid namespace end size");
+		}
 		int endLineNumber = is.readInt32();
 		int comment = is.readInt32();
 		int endPrefix = is.readInt32();

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -246,7 +246,8 @@ public class BinaryXMLParser extends CommonBinaryParser {
 			die("ELEMENT HEADER SIZE is not 0x10");
 		}
 		// TODO: Check element chunk size
-		is.readInt32();
+		long startPos = is.getPos();
+		int elementSize = is.readInt32();
 		int elementBegLineNumber = is.readInt32();
 		int comment = is.readInt32();
 		int startNS = is.readInt32();
@@ -290,6 +291,10 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		boolean attrNewLine = attributeCount != 1 && this.attrNewLine;
 		for (int i = 0; i < attributeCount; i++) {
 			parseAttribute(i, attrNewLine, attrCache);
+		}
+		long endPos = is.getPos();
+		if (endPos - startPos + 0x4 < elementSize) {
+			is.skip(elementSize - (endPos - startPos + 0x4));
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -193,11 +193,6 @@ public class BinaryXMLParser extends CommonBinaryParser {
 			die("NAMESPACE end is not 0x10 big");
 		}
 		int dataSize = is.readInt32();
-		if (dataSize > 0x18) {
-			LOG.warn("Invalid namespace size");
-		} else if (dataSize < 0x18) {
-			die("NAMESPACE header chunk is not 0x18 big");
-		}
 		int endLineNumber = is.readInt32();
 		int comment = is.readInt32();
 		int endPrefix = is.readInt32();


### PR DESCRIPTION
1. The elementSize may be larger than the actual size of the element chunk.
2. End namespace chunk size can be any value. also fix issue https://github.com/skylot/jadx/issues/1232 .

[AndroidManifest.zip](https://github.com/skylot/jadx/files/14555279/AndroidManifest.zip)

 issue https://github.com/skylot/jadx/issues/1232  APK file.
[com.vmos.pro.apk.zip](https://github.com/skylot/jadx/files/14555312/com.vmos.pro.apk.zip)

