### PR TITLE
fix(build): configure launch4j to not change current directory (#2162)

### DIFF
--- a/jadx-gui/build.gradle.kts
+++ b/jadx-gui/build.gradle.kts
@@ -111,6 +111,7 @@ launch4j {
 	windowTitle.set("jadx")
 	companyName.set("jadx")
 	jreMinVersion.set("11")
+	chdir.set("")
 	jvmOptions.set(application.applicationDefaultJvmArgs.toSet())
 	requires64Bit.set(true)
 	initialHeapPercent.set(5)


### PR DESCRIPTION
Change default `chdir` launch4j config from `"."` to `""` which disables changes working directory to the jadx-gui.exe program directory.