### PR TITLE
Change deobf whitelist behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ options:
   --deobf                             - activate deobfuscation
   --deobf-min                         - min length of name, renamed if shorter, default: 3
   --deobf-max                         - max length of name, renamed if longer, default: 64
-  --deobf-whitelist                   - space separated list of classes (full name) and packages (ends with '.*') to exclude from deobfuscation, default: android.support.v4.* android.support.v7.* android.support.v4.os.* android.support.annotation.Px androidx.core.os.* androidx.annotation.Px
+  --deobf-whitelist                   - space separated list of classes (full name) and packages (ends with '.*') to exclude from deobfuscation
   --deobf-cfg-file                    - deobfuscation mappings file used for JADX auto-generated names (in the JOBF file format), default: same dir and name as input file with '.jobf' extension
   --deobf-cfg-file-mode               - set mode for handling the JADX auto-generated names' deobfuscation map file:
                                          'read' - read if found, don't save (default)

--- a/jadx-cli/src/main/java/jadx/cli/JadxCLIArgs.java
+++ b/jadx-cli/src/main/java/jadx/cli/JadxCLIArgs.java
@@ -28,7 +28,6 @@ import jadx.api.args.GeneratedRenamesMappingFileMode;
 import jadx.api.args.IntegerFormat;
 import jadx.api.args.ResourceNameSource;
 import jadx.api.args.UserRenamesMappingsMode;
-import jadx.core.deobf.conditions.DeobfWhitelist;
 import jadx.core.utils.exceptions.JadxArgsValidateException;
 import jadx.core.utils.files.FileUtils;
 
@@ -146,7 +145,7 @@ public class JadxCLIArgs {
 			names = { "--deobf-whitelist" },
 			description = "space separated list of classes (full name) and packages (ends with '.*') to exclude from deobfuscation"
 	)
-	protected String deobfuscationWhitelistStr = DeobfWhitelist.DEFAULT_STR;
+	protected String deobfuscationWhitelistStr = "";
 
 	@Parameter(
 			names = { "--deobf-cfg-file" },

--- a/jadx-core/src/main/java/jadx/api/JadxArgs.java
+++ b/jadx-core/src/main/java/jadx/api/JadxArgs.java
@@ -32,7 +32,6 @@ import jadx.api.plugins.loader.JadxPluginLoader;
 import jadx.api.usage.IUsageInfoCache;
 import jadx.api.usage.impl.InMemoryUsageInfoCache;
 import jadx.core.deobf.DeobfAliasProvider;
-import jadx.core.deobf.conditions.DeobfWhitelist;
 import jadx.core.deobf.conditions.JadxRenameConditions;
 import jadx.core.plugins.PluginContext;
 import jadx.core.utils.files.FileUtils;
@@ -110,7 +109,7 @@ public class JadxArgs implements Closeable {
 	/**
 	 * List of classes and packages (ends with '.*') to exclude from deobfuscation
 	 */
-	private List<String> deobfuscationWhitelist = DeobfWhitelist.DEFAULT_LIST;
+	private List<String> deobfuscationWhitelist = new ArrayList<>();
 
 	/**
 	 * Nodes alias provider for deobfuscator and rename visitor


### PR DESCRIPTION
This PR changes the behavior of the `--deobf-whitelist' arg:
1. I haven't found any references to why this option has predefined values. As a researcher, I can say that there is no practical reason to leave the `androidx.*` or `android.support.*` libraries undeobfuscated. If it is a non-obfuscated application, it will not be changed anyway. However, if some crazy obfuscation is applied, it might get moved to weird packages like `p000`. So I removed the defaults
2. Now the behavior is applied to all members of the provided whitelist pattern, including child packages, member fields and methods