### PR TITLE
fix(gui): support filtering files with multiple extensions in file dialog

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/filedialog/CustomFileChooser.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/filedialog/CustomFileChooser.java
@@ -13,7 +13,6 @@ import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.UIManager;
-import javax.swing.filechooser.FileNameExtensionFilter;
 
 import jadx.api.plugins.utils.CommonFileUtils;
 import jadx.core.utils.Utils;
@@ -44,7 +43,7 @@ class CustomFileChooser extends JFileChooser {
 		List<String> fileExtList = data.getFileExtList();
 		if (Utils.notEmpty(fileExtList)) {
 			String description = NLS.str("file_dialog.supported_files") + ": (" + Utils.listToString(fileExtList) + ')';
-			setFileFilter(new FileNameExtensionFilter(description, fileExtList.toArray(new String[0])));
+			setFileFilter(new FileNameMultiExtensionFilter(description, fileExtList.toArray(new String[0])));
 		}
 		if (data.getSelectedFile() != null) {
 			setSelectedFile(data.getSelectedFile().toFile());

--- a/jadx-gui/src/main/java/jadx/gui/ui/filedialog/FileNameMultiExtensionFilter.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/filedialog/FileNameMultiExtensionFilter.java
@@ -1,0 +1,41 @@
+package jadx.gui.ui.filedialog;
+
+import javax.swing.filechooser.FileFilter;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.io.File;
+
+/**
+ * Custom file filter for filtering files with multiple extensions.
+ * It overcomes the limitation of {@link FileNameExtensionFilter},
+ * which treats only the last file extension split by dots as the 
+ * file extension, and does not support multiple extensions such as
+ * {@code .jadx.kts}.
+ */
+class FileNameMultiExtensionFilter extends FileFilter {
+	private final FileNameExtensionFilter delegate;
+	private final String[] extensions;
+
+	public FileNameMultiExtensionFilter(String description, String... extensions) {
+		this.delegate = new FileNameExtensionFilter(description, extensions[0]);
+		this.extensions = extensions;
+	}
+
+	@Override
+	public boolean accept(File file) {
+		if (file.isDirectory()) {
+			return true;
+		}
+		String fileName = file.getName();
+		for (String extension : extensions) {
+			if (fileName.endsWith(extension)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public String getDescription() {
+		return delegate.getDescription();
+	}
+}

--- a/jadx-gui/src/main/java/jadx/gui/ui/filedialog/FileNameMultiExtensionFilter.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/filedialog/FileNameMultiExtensionFilter.java
@@ -1,13 +1,14 @@
 package jadx.gui.ui.filedialog;
 
+import java.io.File;
+
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import java.io.File;
 
 /**
  * Custom file filter for filtering files with multiple extensions.
  * It overcomes the limitation of {@link FileNameExtensionFilter},
- * which treats only the last file extension split by dots as the 
+ * which treats only the last file extension split by dots as the
  * file extension, and does not support multiple extensions such as
  * {@code .jadx.kts}.
  */


### PR DESCRIPTION
Fixes https://github.com/skylot/jadx/issues/2184

After this commit:
![image](https://github.com/skylot/jadx/assets/31790712/b566f1be-71de-401e-92a6-310a8afeab2b)

The origional filter uses the last segment split by `.` from file name to match files, so extensions like `.jadx.kts` won't be accepted

```java
public final class FileNameExtensionFilter extends FileFilter {
    // ...
    public boolean accept(File f) {
        if (f != null) {
            if (f.isDirectory()) {
                return true;
            }
            // NOTE: we tested implementations using Maps, binary search
            // on a sorted list and this implementation. All implementations
            // provided roughly the same speed, most likely because of
            // overhead associated with java.io.File. Therefor we've stuck
            // with the simple lightweight approach.
            String fileName = f.getName();
            int i = fileName.lastIndexOf('.');
            if (i > 0 && i < fileName.length() - 1) {
                String desiredExtension = fileName.substring(i+1).
                        toLowerCase(Locale.ENGLISH);
                for (String extension : lowerCaseExtensions) {
                    if (desiredExtension.equals(extension)) {
                        return true;
                    }
                }
            }
        }
        return false;
    }
    // ...
```