### PR TITLE
More lenient AXML parsing: allow for non-standard attributes sizes and avoid index exceptions when decoding some strings

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -265,9 +265,10 @@ public class BinaryXMLParser extends CommonBinaryParser {
 			die("startNS's attributeStart is not 0x14");
 		}
 		int attributeSize = is.readInt16();
-		if (attributeSize != 0x14) {
-			die("startNS's attributeSize is not 0x14");
+		if (attributeSize < 0x14) {
+			die("startNS's attributeSize is less than 0x14");
 		}
+
 		int attributeCount = is.readInt16();
 		int idIndex = is.readInt16();
 		int classIndex = is.readInt16();
@@ -289,7 +290,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		Set<String> attrCache = new HashSet<>();
 		boolean attrNewLine = attributeCount != 1 && this.attrNewLine;
 		for (int i = 0; i < attributeCount; i++) {
-			parseAttribute(i, attrNewLine, attrCache);
+			parseAttribute(i, attrNewLine, attrCache, attributeSize);
 		}
 		long endPos = is.getPos();
 		if (endPos - startPos + 0x4 < elementSize) {
@@ -297,13 +298,15 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		}
 	}
 
-	private void parseAttribute(int i, boolean newLine, Set<String> attrCache) throws IOException {
+	private void parseAttribute(int i, boolean newLine, Set<String> attrCache, int attributeSize) throws IOException {
 		int attributeNS = is.readInt32();
 		int attributeName = is.readInt32();
 		int attributeRawValue = is.readInt32();
 		is.skip(3);
 		int attrValDataType = is.readInt8();
 		int attrValData = is.readInt32();
+
+		is.skip(attributeSize-0x14);
 
 		String shortNsName = null;
 		if (attributeNS != -1) {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -306,7 +306,7 @@ public class BinaryXMLParser extends CommonBinaryParser {
 		int attrValDataType = is.readInt8();
 		int attrValData = is.readInt32();
 
-		is.skip(attributeSize-0x14);
+		is.skip(attributeSize - 0x14);
 
 		String shortNsName = null;
 		if (attributeNS != -1) {

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BinaryXMLStrings {
+	public static final String INVALID_STRING_PLACEHOLDER = "⟨STRING_DECODE_ERROR⟩";
 	private final int stringCount;
 
 	private final long stringsStart;
@@ -40,6 +41,10 @@ public class BinaryXMLStrings {
 			return cached;
 		}
 
+		if (id*4 >= buffer.limit() - 3) {
+			return INVALID_STRING_PLACEHOLDER;
+		}
+
 		long offset = stringsStart + buffer.getInt(id * 4);
 		String extracted;
 		if (isUtf8) {
@@ -63,7 +68,7 @@ public class BinaryXMLStrings {
 
 	private static String extractString8(byte[] strArray, int offset) {
 		if (offset >= strArray.length) {
-			return "STRING_DECODE_ERROR";
+			return INVALID_STRING_PLACEHOLDER;
 		}
 		int start = offset + skipStrLen8(strArray, offset);
 		int len = strArray[start++];
@@ -78,6 +83,10 @@ public class BinaryXMLStrings {
 	}
 
 	private static String extractString16(byte[] strArray, int offset) {
+		if (offset + 2 >= strArray.length) {
+			return INVALID_STRING_PLACEHOLDER;
+		}
+
 		int len = strArray.length;
 		int start = offset + skipStrLen16(strArray, offset);
 		int end = start;

--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLStrings.java
@@ -41,7 +41,7 @@ public class BinaryXMLStrings {
 			return cached;
 		}
 
-		if (id*4 >= buffer.limit() - 3) {
+		if (id * 4 >= buffer.limit() - 3) {
 			return INVALID_STRING_PLACEHOLDER;
 		}
 


### PR DESCRIPTION
Almost all malicious APKs are now shipped with corrupted manifest. The corruption seep in where the official Android parse is more lenient, particularly the manifest present in these malware has one or more of the following:

- The strings count in the string chunk is almost always invalid. Jadx is immune to this because it correctly ignores it and decode the string on demand, given an index.
- The attributes size of the XML elements is greater than 20 (0x14). I've only seen 24 (0x18) being used, I don't know if Android extended the format (the extra DWORD seems to always be 0).
- Every XML element has an android:tag referencing an invalid string index.

In this patch the attributes size of an XML element is now accounted for.   
This size must be at least 20 (0x14) bytes but can be greater. Extra bytes are just skipped. 

When decoding a string, if such decoding is impossible a placeholder string is returned instead of throwing an exception. Not all code paths has been inspected, though (just what was necessary to make jadx parse the corrupted manifests at hand).

The attached [test-corrupted-manifest.zip](https://github.com/user-attachments/files/16086410/test-corrupted-manifest.zip) is an empty APK (or ZIP, same thing) with just a corrupted manifest from a real BRATA malware campaign. This can be useful to test this PR.