### PR TITLE
More AXML/Manifest parsing improvements

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/BinaryXMLParser.java
@@ -441,7 +441,13 @@ public class BinaryXMLParser extends CommonBinaryParser {
 				}
 			}
 		} else {
-			String str = valuesParser.decodeValue(attrValDataType, attrValData);
+			String str;
+			try {
+				str = valuesParser.decodeValue(attrValDataType, attrValData);
+			} catch (JadxRuntimeException e) {
+				LOG.error("Failed to decode attribute value of \"{}\"", attrFullName, e);
+				str = null;
+			}
 			memorizePackageName(attrFullName, str);
 			if (isDeobfCandidateAttr(attrFullName)) {
 				str = deobfClassName(str);

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ParserConstants.java
@@ -12,7 +12,7 @@ public class ParserConstants {
 	protected static final String ANDROID_NS_VALUE = "android";
 
 	/**
-	 * Chunk types
+	 * Chunk types as defined in frameworks/base/libs/androidfw/include/androidfw/ResourceTypes.h (AOSP)
 	 */
 	protected static final int RES_NULL_TYPE = 0x0000;
 	protected static final int RES_STRING_POOL_TYPE = 0x0001;

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ResTableBinaryParser.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ResTableBinaryParser.java
@@ -123,8 +123,8 @@ public class ResTableBinaryParser extends CommonBinaryParser implements IResTabl
 		long start = is.getPos();
 		is.checkInt16(RES_TABLE_PACKAGE_TYPE, "Not a table chunk");
 		int headerSize = is.readInt16();
-		if (headerSize != 0x011c && headerSize != 0x0120) {
-			die("Unexpected package header size");
+		if (headerSize < 0x011c) {
+			die("Package header size too small");
 		}
 		long size = is.readUInt32();
 		long endPos = start + size;
@@ -138,10 +138,12 @@ public class ResTableBinaryParser extends CommonBinaryParser implements IResTabl
 		long keyStringsOffset = start + is.readInt32();
 		/* int lastPublicKey = */
 		is.readInt32();
-		if (headerSize == 0x0120) {
+
+		if (headerSize >= 0x0120) {
 			/* int typeIdOffset = */
 			is.readInt32();
 		}
+		is.skipToPos(start + headerSize, "package header end");
 
 		BinaryXMLStrings typeStrings = null;
 		if (typeStringsOffset != 0) {


### PR DESCRIPTION
This PR fixes one of the problems that prevents Jadx from loading AndroidManifest.xml included in the sample APK of issue #2182.

Unfortunately I wasn't able to fix all problems so the APK still doesn't load. But may be the changes in this PR will be helpful for other obfuscated APK/AXML files. 