### PR TITLE
fix(gui): Make code folding context menu actions appear 

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeArea.java
@@ -149,8 +149,8 @@ public abstract class AbstractCodeArea extends RSyntaxTextArea {
 			// to foldingMenuIndex, so we remove all components starting from foldingMenuIndex,
 			// call RTextArea.appendFoldingMenu(), and add the components back
 			ArrayList<Component> componentBackup = new ArrayList<>();
-			for (int i = getPopupMenu().getComponentCount() - 1; i >= foldingMenuIndex; i--) {
-				componentBackup.add(getPopupMenu().getComponent(i));
+			for (int i = popup.getComponentCount() - 1; i >= foldingMenuIndex; i--) {
+				componentBackup.add(0, popup.getComponent(i));
 				popup.remove(i);
 			}
 			appendFoldingMenu(popup);


### PR DESCRIPTION
## The Issue

At first, I was going to mark this as a feature, only to find out this is already implemented. However, the current implementation is erroneous, and never adds the actions. Here's the problem

Code folding is disabled by default. Its value is set using `AbstractCodeArea.setCodeFoldingEnabled()`.
However, AbstractCodeArea prebuilds the context menu in its constructor, fired in this line.
https://github.com/skylot/jadx/blob/61855a7ea1d936c36a894c9f3db9a81e165b54d7/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeArea.java#L93-L93

But superclass constructor is called before child constuctor, so AbstractCodeArea calls `isCodeFoldingEnabled()` before child gets to change it, so `isCodeFoldingEnabled()` below always returns its default value of `false` and code folding actions are never added.
https://github.com/skylot/jadx/blob/61855a7ea1d936c36a894c9f3db9a81e165b54d7/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeArea.java#L139-L145

## My Solution
I thought the best way to add it is to add the folding menu actions once `setCodeFoldingEnabled(true)` is called. However `RSyntaxTextArea.appendFoldingMenu(JPopupMenu)` only adds the actions to the end, so I made a workaround that removes present actions after target index, adds folding menu, and then adds present actions back.

https://github.com/Mino260806/jadx/blob/9daac915ef08a048cb39581335839229ac9ecf93/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeArea.java#L142-L172

I'll open a PR in RSyntaxTextArea that creates `RSyntaxTextArea.appendFoldingMenu(JPopupMenu, int)`, and we would fix this workaround once merged and released.