### PR TITLE
feat: don't try to guess a better class name when "use source file name" is on

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/rename/SourceFileRename.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/rename/SourceFileRename.java
@@ -15,7 +15,6 @@ import jadx.core.dex.attributes.nodes.RenameReasonAttr;
 import jadx.core.dex.nodes.ClassNode;
 import jadx.core.dex.nodes.RootNode;
 import jadx.core.dex.visitors.AbstractVisitor;
-import jadx.core.utils.BetterName;
 import jadx.core.utils.StringUtils;
 import jadx.core.utils.exceptions.JadxException;
 
@@ -61,14 +60,6 @@ public class SourceFileRename extends AbstractVisitor {
 	}
 
 	private static void applyRename(ClassNode cls, String alias) {
-		if (cls.getClassInfo().hasAlias()) {
-			// ignore source name if current alias is "better"
-			String currentAlias = cls.getAlias();
-			String betterName = BetterName.compareAndGet(alias, currentAlias);
-			if (betterName.equals(currentAlias)) {
-				return;
-			}
-		}
 		cls.getClassInfo().changeShortName(alias);
 		cls.addAttr(new RenameReasonAttr(cls).append("use source file name"));
 	}

--- a/jadx-core/src/test/java/jadx/tests/integration/deobf/TestBadSourceFile.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/deobf/TestBadSourceFile.java
@@ -34,7 +34,8 @@ public class TestBadSourceFile extends SmaliTest {
 		args.setDeobfuscationMinLength(100); // rename everything
 		assertThat(searchCls(loadFromSmaliFiles(), "b"))
 				.code()
-				.containsOne("class C0000b {")
-				.containsOne("/* compiled from: a.java */");
+				.containsOne("class a {")
+				.containsOne("/* compiled from: a.java */")
+				.containsOne("/* renamed from: b, reason: use source file name */");
 	}
 }


### PR DESCRIPTION
This PR makes the app ___use source file name as class name alias___ if the "___Use source file name as class name alias___" checkbox is checked, without implicit attempts to guess a better name.