### PR TITLE
feat: add support for switching over strings

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/RegionGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/RegionGen.java
@@ -256,7 +256,6 @@ public class RegionGen extends InsnGen {
 			List<Object> keys = caseInfo.getKeys();
 			IContainer c = caseInfo.getContainer();
 			for (Object k : keys) {
-				// TODO: support switch over string
 				if (k == SwitchRegion.DEFAULT_CASE_KEY) {
 					code.startLine("default:");
 				} else {
@@ -272,6 +271,7 @@ public class RegionGen extends InsnGen {
 	}
 
 	private void addCaseKey(ICodeWriter code, InsnArg arg, Object k) throws CodegenException {
+		// TODO: support switch over string
 		if (k instanceof FieldNode) {
 			FieldNode fld = (FieldNode) k;
 			useField(code, fld.getFieldInfo(), fld);

--- a/jadx-core/src/main/java/jadx/core/codegen/RegionGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/RegionGen.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import jadx.api.plugins.input.data.attributes.IJadxAttribute;
-import jadx.core.dex.attributes.nodes.SkipMethodArgsAttr;
 import jadx.core.dex.info.MethodInfo;
 import jadx.core.dex.instructions.ConstStringNode;
 import jadx.core.dex.instructions.IfNode;
@@ -261,9 +259,7 @@ public class RegionGen extends InsnGen {
 			}
 			InvokeNode wrapInsnInode = (InvokeNode) wrapInsn;
 			MethodInfo methodInfo = wrapInsnInode.getCallMth();
-			if (!(methodInfo.getName().equals("hashCode") && methodInfo.getReturnType() == ArgType.INT)) {
-				return false;
-			}
+			return methodInfo.getName().equals("hashCode") && methodInfo.getReturnType() == ArgType.INT;
 		}
 		return true;
 	}
@@ -315,7 +311,7 @@ public class RegionGen extends InsnGen {
 			if (!(wrapInsn instanceof InvokeNode))
 				continue;
             InvokeNode invokeNode = (InvokeNode) wrapInsn;
-			MethodInfo mth = invokeNode.getCallMth();
+//			MethodInfo mth = invokeNode.getCallMth();
 			InsnArg firstEqArgA = invokeNode.getArg(1);
 			String firstEqArg = null;
 			if (firstEqArgA.isInsnWrap()) {

--- a/jadx-core/src/main/java/jadx/core/codegen/RegionGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/RegionGen.java
@@ -256,6 +256,7 @@ public class RegionGen extends InsnGen {
 			List<Object> keys = caseInfo.getKeys();
 			IContainer c = caseInfo.getContainer();
 			for (Object k : keys) {
+				// TODO: support switch over string
 				if (k == SwitchRegion.DEFAULT_CASE_KEY) {
 					code.startLine("default:");
 				} else {


### PR DESCRIPTION
# Add support for switching over strings

This adds support for switching over strings,
currently, it will just compare hash codes and check them via equals (that's part of the APK).

## Tasks

- [x] Transform the case to a string
- [ ] Inline the if statement's contents (because we don't have to check for hash collisions, there are non, because we aren't hashing it!)
- [ ] Add tests
- [ ] Refactor the code (I wanted to get this out as soon as possible, even though this took me hours when it probably could've taken 3 or 2 hours but this is also the first time I've contributed)

## Related issues

Fixes #2278
