### PR TITLE
Adding automatic patching for semi-corrupted APKs

### DIFF
--- a/jadx-cli/src/main/java/jadx/cli/tools/ConvertArscFile.java
+++ b/jadx-cli/src/main/java/jadx/cli/tools/ConvertArscFile.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import jadx.api.JadxArgs;
 import jadx.core.dex.nodes.RootNode;
 import jadx.core.utils.android.TextResMapFile;
+import jadx.core.utils.files.ZipFile;
 import jadx.core.xmlgen.ResTableBinaryParser;
 
 /**

--- a/jadx-core/src/main/java/jadx/api/ResourcesLoader.java
+++ b/jadx-core/src/main/java/jadx/api/ResourcesLoader.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +26,7 @@ import jadx.core.utils.android.Res9patchStreamDecoder;
 import jadx.core.utils.exceptions.JadxException;
 import jadx.core.utils.exceptions.JadxRuntimeException;
 import jadx.core.utils.files.FileUtils;
+import jadx.core.utils.files.ZipFile;
 import jadx.core.xmlgen.BinaryXMLParser;
 import jadx.core.xmlgen.IResTableParser;
 import jadx.core.xmlgen.ResContainer;

--- a/jadx-core/src/main/java/jadx/api/plugins/utils/ZipSecurity.java
+++ b/jadx-core/src/main/java/jadx/api/plugins/utils/ZipSecurity.java
@@ -8,7 +8,6 @@ import java.util.Enumeration;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -16,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import jadx.core.utils.Utils;
 import jadx.core.utils.exceptions.JadxRuntimeException;
+import jadx.core.utils.files.ZipFile;
 
 public class ZipSecurity {
 	private static final Logger LOG = LoggerFactory.getLogger(ZipSecurity.class);

--- a/jadx-core/src/main/java/jadx/core/utils/files/ZipFile.java
+++ b/jadx-core/src/main/java/jadx/core/utils/files/ZipFile.java
@@ -1,0 +1,200 @@
+package jadx.core.utils.files;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+public class ZipFile extends java.util.zip.ZipFile {
+
+	public ZipFile(File file) throws IOException {
+		this(file, OPEN_READ);
+	}
+
+	public ZipFile(File file, int mode) throws IOException {
+		this(file, mode, StandardCharsets.UTF_8);
+	}
+
+	public ZipFile(String name, Charset charset) throws IOException {
+		this(new File(name), OPEN_READ, charset);
+	}
+
+	public ZipFile(String name) throws IOException {
+		this(name, StandardCharsets.UTF_8);
+	}
+
+	public ZipFile(File file, int mode, Charset charset) throws IOException {
+		super(patchZipFile(file), mode, charset);
+	}
+
+	private static File patchZipFile(File file) throws IOException {
+		if (!file.getPath().toLowerCase().endsWith(".apk")) {
+			return file;
+		}
+
+		var raFile = new RandomAccessFile(file, "r");
+		var endOfCDirOffset = findEndOfCentralDir(raFile);
+
+		raFile.seek(endOfCDirOffset + 0x10);
+		var cDirOffset = Integer.toUnsignedLong(Integer.reverseBytes(raFile.readInt()));
+		raFile.seek(endOfCDirOffset + 0x0a);
+		var cDirNumEntries = Short.toUnsignedLong(Short.reverseBytes(raFile.readShort()));
+
+		var cDirEntriesToFix = new ArrayList<Long>();
+		var localHeaders = new ArrayList<Long>();
+
+		for (long i = 0, off = cDirOffset; i < cDirNumEntries; i++) {
+			var info = readHeader(raFile, off);
+
+			if (!info.validCompression()) {
+				cDirEntriesToFix.add(off);
+			}
+
+			raFile.seek(off + 0x2a);
+			localHeaders.add(Integer.toUnsignedLong(Integer.reverseBytes(raFile.readInt())));
+
+			off += info.dataOffset;
+		}
+
+		var localHeaderToFix = localHeaders
+				.stream()
+				.filter(off -> !readHeaderVexxed(raFile, off).validCompression())
+				.collect(Collectors.toList());
+
+		if (cDirEntriesToFix.isEmpty() && localHeaderToFix.isEmpty()) {
+			return file;
+		}
+
+		var newFile = copyFile(file);
+		var newRaFile = new RandomAccessFile(newFile, "rwd");
+
+		for (var off : cDirEntriesToFix) {
+			var info = readHeader(newRaFile, off);
+
+			newRaFile.seek(off + 0x0a);
+			newRaFile.writeShort(0);
+
+			newRaFile.seek(off + 0x14);
+			newRaFile.writeInt(Integer.reverseBytes((int) info.uncompressedSize));
+
+		}
+
+		for (var off : localHeaderToFix) {
+			var info = readHeader(newRaFile, off);
+
+			newRaFile.seek(off + 0x08);
+			newRaFile.writeShort(0);
+
+			newRaFile.seek(off + 0x12);
+			newRaFile.writeInt(Integer.reverseBytes((int) info.uncompressedSize));
+
+			newRaFile.seek(off + 0x1c);
+			newRaFile.writeShort(0);
+
+			moveBlockBack(newRaFile, off + info.dataOffset, info.uncompressedSize, info.extraLen);
+		}
+
+		return newFile;
+	}
+
+	private static void moveBlockBack(RandomAccessFile file, long offset, long size, long delta) throws IOException {
+		var buffer = new byte[1024 * 1024];
+
+		while (size > 0) {
+			var len = (int) Math.min(buffer.length, size);
+
+			file.seek(offset);
+			file.read(buffer, 0, len);
+			file.seek(offset - delta);
+			file.write(buffer, 0, len);
+
+			size -= len;
+			offset += len;
+		}
+	}
+
+	private static File copyFile(File file) throws IOException {
+		var newFile = File.createTempFile(file.getName(), ".apk");
+
+		try (var in = new FileInputStream(file)) {
+			try (var out = new FileOutputStream(newFile)) {
+				in.transferTo(out);
+			}
+		}
+
+		return newFile;
+	}
+
+	private static long findEndOfCentralDir(RandomAccessFile file) throws IOException {
+		var offset = file.length() - 0x15L + 1;
+
+		do {
+			if (offset <= 0) {
+				throw new IllegalArgumentException("File is not a valid ZIP: End of central directory record not found");
+			}
+			file.seek(--offset);
+		} while (Integer.reverseBytes(file.readInt()) != 0x06054b50);
+
+		return offset;
+	}
+
+	private static class HeaderInfo {
+		short compression;
+		long uncompressedSize;
+		long dataOffset;
+		long extraLen;
+
+		boolean validCompression() {
+			return compression == 0x0 || compression == 0x8;
+		}
+	}
+
+	private static HeaderInfo readHeaderVexxed(RandomAccessFile file, long offset) {
+		try {
+			return readHeader(file, offset);
+		} catch (IOException e) {
+			throw new UndeclaredThrowableException(e);
+		}
+	}
+
+	private static HeaderInfo readHeader(RandomAccessFile file, long offset) throws IOException {
+		var info = new HeaderInfo();
+
+		file.seek(offset);
+		var signature = Integer.reverseBytes(file.readInt());
+
+		if (signature != 0x02014b50 && signature != 0x04034b50) {
+			throw new IllegalArgumentException(
+					String.format("Invalid ZIP header signature %x at offset %x",
+							signature, offset));
+		}
+
+		var isCentralHeader = signature == 0x02014b50;
+		var delta = isCentralHeader ? 0 : -2;
+
+		file.seek(offset + 0x0a + delta);
+		info.compression = Short.reverseBytes(file.readShort());
+
+		file.seek(offset + 0x18 + delta);
+		info.uncompressedSize = Integer.toUnsignedLong(Integer.reverseBytes(file.readInt()));
+
+		file.seek(offset + 0x1c + delta);
+		var nameLen = Short.toUnsignedLong(Short.reverseBytes(file.readShort()));
+		info.extraLen = Short.toUnsignedLong(Short.reverseBytes(file.readShort()));
+		var commentLen = 0L;
+
+		if (isCentralHeader) {
+			commentLen = Short.toUnsignedLong(Short.reverseBytes(file.readShort()));
+		}
+
+		info.dataOffset = (isCentralHeader ? 0x2e : 0x1e) + nameLen + info.extraLen + commentLen;
+
+		return info;
+	}
+}

--- a/jadx-core/src/main/java/jadx/core/utils/files/ZipFile.java
+++ b/jadx-core/src/main/java/jadx/core/utils/files/ZipFile.java
@@ -8,6 +8,7 @@ import java.io.RandomAccessFile;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
@@ -120,7 +121,7 @@ public class ZipFile extends java.util.zip.ZipFile {
 	}
 
 	private static File copyFile(File file) throws IOException {
-		var newFile = File.createTempFile(file.getName(), ".apk");
+		var newFile = Files.createTempFile(file.getName(), ".apk").toFile();
 
 		try (var in = new FileInputStream(file)) {
 			try (var out = new FileOutputStream(newFile)) {

--- a/jadx-plugins/jadx-xapk-input/src/main/java/jadx/plugins/input/xapk/XapkCustomCodeInput.kt
+++ b/jadx-plugins/jadx-xapk-input/src/main/java/jadx/plugins/input/xapk/XapkCustomCodeInput.kt
@@ -4,9 +4,9 @@ import jadx.api.plugins.input.ICodeLoader
 import jadx.api.plugins.input.JadxCodeInput
 import jadx.api.plugins.utils.CommonFileUtils
 import jadx.api.plugins.utils.ZipSecurity
+import jadx.core.utils.files.ZipFile
 import java.io.File
 import java.nio.file.Path
-import java.util.zip.ZipFile
 
 class XapkCustomCodeInput(
 	private val plugin: XapkInputPlugin,

--- a/jadx-plugins/jadx-xapk-input/src/main/java/jadx/plugins/input/xapk/XapkUtils.kt
+++ b/jadx-plugins/jadx-xapk-input/src/main/java/jadx/plugins/input/xapk/XapkUtils.kt
@@ -3,9 +3,9 @@ package jadx.plugins.input.xapk
 import com.google.gson.Gson
 import jadx.api.plugins.utils.ZipSecurity
 import jadx.core.utils.files.FileUtils
+import jadx.core.utils.files.ZipFile
 import java.io.File
 import java.io.InputStreamReader
-import java.util.zip.ZipFile
 
 object XapkUtils {
 	fun getManifest(file: File): XapkManifest? {


### PR DESCRIPTION
Threat actors are yet again exploiting another lenient-ism in the Android APK loader machinery. I've recently found two APKs whose AndroidManifest.xml ZIP headers was **semi-corrupted in a way that prevents ordinary tools (including Jadx) from correctly processing them**. Android was loading them just fine, though.

### Corruption of the headers

The APKs are attached in the ZIP below (password: `infected`) and belongs to two (presumably) very different TAs: one comes from a campaign against Russians using OnlyFans as a bait, the other targets the user of an Italian bank. Thus, I'm inclined to believe this corruptions are intentional and will be used again in the future.

 Since APKs are just ZIPs, a little knowledge of the PKZIP format is required. These APKs have the following anomalies:
 
 * The compression method set for a corrupted entry in the Central Directory Header (CDH) is invalid. The compression is specified as a 16-bit number, a random one is used. The original compression method was *none* (i.e. no compression at all). I guess Android default to that in case of an invalid value.
 * The compressed size set for a corrupted entry in the CDH is invalid. I assume Android just look at the *uncompressed size* file in case of no compression.
 * The same two corruptions of above are also applied at the Local Header level.
 * The Local Header for a corrupted entities also have invalid *extra data*. I guess Android just skip that (since it's useless).
 
 ### Jadx patch 
 
 This corruption can be undone, this PR attempts to introduce such undoing into Jadx. I'm not totally satisfied with the approach I took but it was the quickest.    
 
 Since the APK is visited everywhere with the standard `ZipFile` class, I opted for subclassing it, copying the original file into a temporary one and preprocessing it before calling the `super` constructor with the path of the temporary file. This allows for a drop-in replacement of `java.util.zip.ZipFile` with `jadx.core.utils.files.ZipFile`. And that's just what the code in this PR does.
 
 The drawback is that **a temporary file is created** if the APK is detected as corrupted (if it is not, **no temporary file is created**).  The temporary file is not deleted since it couldn't find a way to store the temporary filename in the instance without hacky code (it will be deleted by the OS, though).    
Note however that the **APK signature verification panel shows an exception** because the original file is passed to the Android framework and this time it cannot correctly process it. I don't know if this is a show stopper.  

I also forgot to comment the code 😳.

If somebody have suggestions they are welcome.

### How the APK is patched

For the sake of completeness, the patching is done as follow when an invalid compression method is found:

1. Set the compression method to *none* in the Local and Central Directory headers.
2. Set the compressed size to equal the uncompressed size in the Local and Central Directory headers.
3. Set the *extra len* field to 0 in the Local Header and move the local data back by that amount.

#### Before

![before](https://github.com/user-attachments/assets/b56d30ed-bcc9-4272-b315-477d9c7e0657)

#### After
![after](https://github.com/user-attachments/assets/c52dd2fe-2c4e-43e6-a0a3-f51ab4c0ec35)


 
[semi-corrupted-apks.zip](https://github.com/user-attachments/files/17324903/semi-corrupted-apks.zip)


