### PR TITLE
Use jadx-gui as a library in plugins

### DIFF
--- a/jadx-gui/build.gradle.kts
+++ b/jadx-gui/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("jadx-kotlin")
 	id("application")
+	id("jadx-library")
 	id("edu.sc.seis.launch4j") version "3.0.6"
 	id("com.gradleup.shadow") version "8.3.3"
 	id("org.beryx.runtime") version "1.13.1"

--- a/jadx-gui/src/main/java/jadx/gui/device/debugger/SmaliDebugger.java
+++ b/jadx-gui/src/main/java/jadx/gui/device/debugger/SmaliDebugger.java
@@ -533,7 +533,7 @@ public class SmaliDebugger {
 	/**
 	 * @param startIndex less than 0 means 0
 	 * @param len        less than or equals 0 means the maximum value 99 or the rest of the elements.
-	 * @return An entry, The key is the total length of this array when len is <= 0, otherwise 0,
+	 * @return An entry, The key is the total length of this array when len is &lt;= 0, otherwise 0,
 	 *         the value, if this array is an object array then it's object ids.
 	 */
 	public Entry<Integer, List<Long>> readArray(RuntimeValue reg, int startIndex, int len) throws SmaliDebuggerException {

--- a/jadx-gui/src/main/java/jadx/gui/device/protocol/ADBDevice.java
+++ b/jadx-gui/src/main/java/jadx/gui/device/protocol/ADBDevice.java
@@ -123,7 +123,7 @@ public class ADBDevice {
 	}
 
 	/**
-	 * @Return binary output of logcat
+	 * @return binary output of logcat
 	 */
 	public byte[] getBinaryLogcat() throws IOException {
 
@@ -133,7 +133,7 @@ public class ADBDevice {
 	}
 
 	/**
-	 * @Return binary output of logcat after provided timestamp
+	 * @return binary output of logcat after provided timestamp
 	 *         Timestamp is in the format 09-08 02:18:03.131
 	 */
 	public byte[] getBinaryLogcat(String timestamp) throws IOException {
@@ -147,7 +147,7 @@ public class ADBDevice {
 	}
 
 	/**
-	 * @Return binary output of logcat -c
+	 * Binary output of logcat -c
 	 */
 	public void clearLogcat() throws IOException {
 		Socket socket = ADB.connect(info.getAdbHost(), info.getAdbPort());

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodePanel.java
@@ -39,7 +39,7 @@ import jadx.gui.utils.UiUtils;
 import jadx.gui.utils.ui.MousePressedHandler;
 
 /**
- * A panel combining a {@link SearchBar and a scollable {@link CodeArea}
+ * A panel combining a {@link SearchBar} and a scollable {@link CodeArea}
  */
 public class CodePanel extends JPanel {
 	private static final long serialVersionUID = 1117721869391885865L;

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/SmaliTokenMaker.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/SmaliTokenMaker.java
@@ -1280,7 +1280,7 @@ public class SmaliTokenMaker extends AbstractJFlexCTokenMaker {
 	 *
 	 * All internal variables are reset, the old input stream
 	 * <b>cannot</b> be reused (internal buffer is discarded and lost).
-	 * Lexical state is set to <tt>YY_INITIAL</tt>.
+	 * Lexical state is set to <code>YY_INITIAL</code>
 	 *
 	 * @param reader the new input stream
 	 */
@@ -1371,7 +1371,7 @@ public class SmaliTokenMaker extends AbstractJFlexCTokenMaker {
 	}
 
 	/**
-	 * Returns the character at position <tt>pos</tt> from the
+	 * Returns the character at position<code>pos</code> from the
 	 * matched text.
 	 *
 	 * It is equivalent to yytext().charAt(pos), but faster


### PR DESCRIPTION
For my latest plugin (https://github.com/nitram84/jadx-apkspy-plugin) I needed a compile dependency to jadx-gui. To build jadx-gui as a library I had to fix some issues, mostly javadoc issues. I'd like to remove this workaround for my plugin, so I would like to propose my changes as a PR.