### PR TITLE
fix(core): fix primitive-to-primitive conversions

### DIFF
--- a/jadx-core/src/test/java/jadx/core/dex/visitors/typeinference/PrimitiveConversionsTests.java
+++ b/jadx-core/src/test/java/jadx/core/dex/visitors/typeinference/PrimitiveConversionsTests.java
@@ -1,0 +1,128 @@
+package jadx.core.dex.visitors.typeinference;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import jadx.api.JadxArgs;
+import jadx.core.dex.instructions.args.ArgType;
+import jadx.core.dex.nodes.RootNode;
+
+import static jadx.core.dex.instructions.args.ArgType.BOOLEAN;
+import static jadx.core.dex.instructions.args.ArgType.BYTE;
+import static jadx.core.dex.instructions.args.ArgType.CHAR;
+import static jadx.core.dex.instructions.args.ArgType.DOUBLE;
+import static jadx.core.dex.instructions.args.ArgType.FLOAT;
+import static jadx.core.dex.instructions.args.ArgType.INT;
+import static jadx.core.dex.instructions.args.ArgType.LONG;
+import static jadx.core.dex.instructions.args.ArgType.SHORT;
+import static jadx.core.dex.instructions.args.ArgType.VOID;
+import static jadx.core.dex.visitors.typeinference.TypeCompareEnum.CONFLICT;
+import static jadx.core.dex.visitors.typeinference.TypeCompareEnum.EQUAL;
+import static jadx.core.dex.visitors.typeinference.TypeCompareEnum.NARROW;
+import static jadx.core.dex.visitors.typeinference.TypeCompareEnum.WIDER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PrimitiveConversionsTests {
+
+	private static TypeCompare comparator;
+
+	@BeforeAll
+	static void before() {
+		JadxArgs args = new JadxArgs();
+		RootNode root = new RootNode(args);
+		comparator = new TypeCompare(root);
+	}
+
+	@DisplayName("Check conversion of numeric types")
+	@ParameterizedTest(name = "{0} -> {1} (should be {2})")
+	@MethodSource("provideArgsForNumericConversionsTest")
+	void testNumericConversions(ArgType firstType, ArgType secondType, TypeCompareEnum expectedResult) {
+		assertThat(comparator.compareTypes(firstType, secondType)).isEqualTo(expectedResult);
+	}
+
+	@DisplayName("Ensure that `boolean` is not convertible to other primitive types")
+	@ParameterizedTest(name = "{0} <-> boolean")
+	@MethodSource("providePrimitiveTypesWithVoid")
+	void testBooleanConversions(ArgType type) {
+		final var expectedResult = type.equals(BOOLEAN) ? EQUAL : CONFLICT;
+		assertThat(comparator.compareTypes(type, BOOLEAN)).isEqualTo(expectedResult);
+		assertThat(comparator.compareTypes(BOOLEAN, type)).isEqualTo(expectedResult);
+	}
+
+	@DisplayName("Ensure that `void` is not convertible to other primitive types")
+	@ParameterizedTest(name = "{0} <-> void")
+	@MethodSource("providePrimitiveTypesWithVoid")
+	void testVoidConversions(ArgType type) {
+		final var expectedResult = type.equals(VOID) ? EQUAL : CONFLICT;
+		assertThat(comparator.compareTypes(type, VOID)).isEqualTo(expectedResult);
+		assertThat(comparator.compareTypes(VOID, type)).isEqualTo(expectedResult);
+	}
+
+	private static Stream<Arguments> provideArgsForNumericConversionsTest() {
+		return Stream.of(
+				Arguments.of(BYTE, BYTE, EQUAL),
+				Arguments.of(BYTE, SHORT, NARROW),
+				Arguments.of(BYTE, CHAR, WIDER),
+				Arguments.of(BYTE, INT, NARROW),
+				Arguments.of(BYTE, LONG, NARROW),
+				Arguments.of(BYTE, FLOAT, NARROW),
+				Arguments.of(BYTE, DOUBLE, NARROW),
+
+				Arguments.of(SHORT, BYTE, WIDER),
+				Arguments.of(SHORT, SHORT, EQUAL),
+				Arguments.of(SHORT, CHAR, WIDER),
+				Arguments.of(SHORT, INT, NARROW),
+				Arguments.of(SHORT, LONG, NARROW),
+				Arguments.of(SHORT, FLOAT, NARROW),
+				Arguments.of(SHORT, DOUBLE, NARROW),
+
+				Arguments.of(CHAR, BYTE, WIDER),
+				Arguments.of(CHAR, SHORT, WIDER),
+				Arguments.of(CHAR, CHAR, EQUAL),
+				Arguments.of(CHAR, INT, NARROW),
+				Arguments.of(CHAR, LONG, NARROW),
+				Arguments.of(CHAR, FLOAT, NARROW),
+				Arguments.of(CHAR, DOUBLE, NARROW),
+
+				Arguments.of(INT, BYTE, WIDER),
+				Arguments.of(INT, SHORT, WIDER),
+				Arguments.of(INT, CHAR, WIDER),
+				Arguments.of(INT, INT, EQUAL),
+				Arguments.of(INT, LONG, NARROW),
+				Arguments.of(INT, FLOAT, NARROW),
+				Arguments.of(INT, DOUBLE, NARROW),
+
+				Arguments.of(LONG, BYTE, WIDER),
+				Arguments.of(LONG, SHORT, WIDER),
+				Arguments.of(LONG, CHAR, WIDER),
+				Arguments.of(LONG, INT, WIDER),
+				Arguments.of(LONG, LONG, EQUAL),
+				Arguments.of(LONG, FLOAT, NARROW),
+				Arguments.of(LONG, DOUBLE, NARROW),
+
+				Arguments.of(FLOAT, BYTE, WIDER),
+				Arguments.of(FLOAT, SHORT, WIDER),
+				Arguments.of(FLOAT, CHAR, WIDER),
+				Arguments.of(FLOAT, INT, WIDER),
+				Arguments.of(FLOAT, LONG, WIDER),
+				Arguments.of(FLOAT, FLOAT, EQUAL),
+				Arguments.of(FLOAT, DOUBLE, NARROW),
+
+				Arguments.of(DOUBLE, BYTE, WIDER),
+				Arguments.of(DOUBLE, SHORT, WIDER),
+				Arguments.of(DOUBLE, CHAR, WIDER),
+				Arguments.of(DOUBLE, INT, WIDER),
+				Arguments.of(DOUBLE, LONG, WIDER),
+				Arguments.of(DOUBLE, FLOAT, WIDER),
+				Arguments.of(DOUBLE, DOUBLE, EQUAL));
+	}
+
+	private static Stream<ArgType> providePrimitiveTypesWithVoid() {
+		return Stream.of(BYTE, SHORT, CHAR, INT, LONG, FLOAT, DOUBLE, BOOLEAN, VOID);
+	}
+}

--- a/jadx-core/src/test/java/jadx/core/dex/visitors/typeinference/TypeCompareTest.java
+++ b/jadx-core/src/test/java/jadx/core/dex/visitors/typeinference/TypeCompareTest.java
@@ -14,7 +14,6 @@ import jadx.core.dex.instructions.args.ArgType;
 import jadx.core.dex.instructions.args.ArgType.WildcardBound;
 import jadx.core.dex.nodes.RootNode;
 
-import static jadx.core.dex.instructions.args.ArgType.BOOLEAN;
 import static jadx.core.dex.instructions.args.ArgType.BYTE;
 import static jadx.core.dex.instructions.args.ArgType.CHAR;
 import static jadx.core.dex.instructions.args.ArgType.CLASS;
@@ -23,7 +22,6 @@ import static jadx.core.dex.instructions.args.ArgType.INT;
 import static jadx.core.dex.instructions.args.ArgType.NARROW;
 import static jadx.core.dex.instructions.args.ArgType.NARROW_INTEGRAL;
 import static jadx.core.dex.instructions.args.ArgType.OBJECT;
-import static jadx.core.dex.instructions.args.ArgType.SHORT;
 import static jadx.core.dex.instructions.args.ArgType.STRING;
 import static jadx.core.dex.instructions.args.ArgType.THROWABLE;
 import static jadx.core.dex.instructions.args.ArgType.UNKNOWN;
@@ -53,26 +51,14 @@ public class TypeCompareTest {
 
 	@Test
 	public void compareTypes() {
-		firstIsNarrow(INT, UNKNOWN);
-
-		firstIsNarrow(array(UNKNOWN), UNKNOWN);
-		firstIsNarrow(array(UNKNOWN), NARROW);
-	}
-
-	@Test
-	public void comparePrimitives() {
 		check(INT, UNKNOWN_OBJECT, TypeCompareEnum.CONFLICT);
 		check(INT, OBJECT, TypeCompareEnum.CONFLICT);
 
-		check(INT, CHAR, TypeCompareEnum.WIDER);
-		check(INT, SHORT, TypeCompareEnum.WIDER);
-
-		check(BOOLEAN, INT, TypeCompareEnum.CONFLICT);
-		check(BOOLEAN, CHAR, TypeCompareEnum.CONFLICT);
-		check(CHAR, BYTE, TypeCompareEnum.CONFLICT);
-		check(CHAR, SHORT, TypeCompareEnum.CONFLICT);
-
+		firstIsNarrow(INT, UNKNOWN);
 		firstIsNarrow(CHAR, NARROW_INTEGRAL);
+
+		firstIsNarrow(array(UNKNOWN), UNKNOWN);
+		firstIsNarrow(array(UNKNOWN), NARROW);
 		firstIsNarrow(array(CHAR), UNKNOWN_OBJECT);
 	}
 

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestPrimitiveCasts2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestPrimitiveCasts2.java
@@ -1,0 +1,27 @@
+package jadx.tests.integration.others;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+// Source: https://github.com/skylot/jadx/issues/1620
+public class TestPrimitiveCasts2 extends IntegrationTest {
+
+	@SuppressWarnings("DataFlowIssue")
+	public static class TestCls {
+		long instanceCount;
+
+		{
+			float f = 50.231F;
+			instanceCount &= (long) f;
+		}
+	}
+
+	@Test
+	public void test() {
+		assertThat(getClassNode(TestCls.class))
+				.code();
+	}
+}


### PR DESCRIPTION
The PR fixes incorrect primitive-to-primitive conversions:
  - `byte` -> `char` - `WIDER` (not `CONFLICT`)
  - `short` -> `char` - `WIDER` (not `CONFLICT`)
  - `char` -> `byte` - `WIDER` (not `CONFLICT`)
  - `char` -> `short` - `WIDER` (not `CONFLICT`)
  - `long` -> `float` - `NARROW` (not `WIDER`)
  - `float` -> `long` - `WIDER` (not `NARROW`)
  - numeric -> `void` - `CONFLICT` (not `NARROW`)
  - `void` -> numeric - `CONFLICT` (not `WIDER`)

Fixes https://github.com/skylot/jadx/issues/1620, fixes https://github.com/skylot/jadx/issues/1621, fixes https://github.com/skylot/jadx/issues/1626, indirectly fixes `JadxRuntimeException: Unknown type in literalToString: void`.