### PR TITLE
give ability to plugins to edit blocks before locking

### DIFF
--- a/jadx-core/src/main/java/jadx/core/Jadx.java
+++ b/jadx-core/src/main/java/jadx/core/Jadx.java
@@ -47,6 +47,7 @@ import jadx.core.dex.visitors.ReplaceNewArray;
 import jadx.core.dex.visitors.ShadowFieldVisitor;
 import jadx.core.dex.visitors.SignatureProcessor;
 import jadx.core.dex.visitors.SimplifyVisitor;
+import jadx.core.dex.visitors.blocks.BlockFinisher;
 import jadx.core.dex.visitors.blocks.BlockProcessor;
 import jadx.core.dex.visitors.blocks.BlockSplitter;
 import jadx.core.dex.visitors.debuginfo.DebugInfoApplyVisitor;
@@ -131,6 +132,7 @@ public class Jadx {
 		// blocks IR
 		passes.add(new BlockSplitter());
 		passes.add(new BlockProcessor());
+		passes.add(new BlockFinisher());
 		if (args.isRawCFGOutput()) {
 			passes.add(DotGraphVisitor.dumpRaw());
 		}

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockFinisher.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockFinisher.java
@@ -1,0 +1,17 @@
+package jadx.core.dex.visitors.blocks;
+
+import jadx.core.dex.attributes.AFlag;
+import jadx.core.dex.nodes.MethodNode;
+import jadx.core.dex.visitors.AbstractVisitor;
+
+public class BlockFinisher extends AbstractVisitor {
+	@Override
+	public void visit(MethodNode mth) {
+		if (mth.isNoCode() || mth.getBasicBlocks().isEmpty()) {
+			return;
+		}
+		if (!mth.contains(AFlag.DISABLE_BLOCKS_LOCK)) {
+			mth.finishBasicBlocks();
+		}
+	}
+}

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockProcessor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/blocks/BlockProcessor.java
@@ -92,9 +92,6 @@ public class BlockProcessor extends AbstractVisitor {
 		PostDominatorTree.compute(mth);
 
 		updateCleanSuccessors(mth);
-		if (!mth.contains(AFlag.DISABLE_BLOCKS_LOCK)) {
-			mth.finishBasicBlocks();
-		}
 	}
 
 	static void updateCleanSuccessors(MethodNode mth) {


### PR DESCRIPTION
Plugins can use .before('BlockFinisher') to edit blocks before they are locked.

### Description
If any plugin wants to edit control flow graph after BlockProcessor, blocks are locked. This PR moves `mth.finishBasicBlocks();` line to another visitor called BlockFinisher. So plugins can use .before('BlockFinisher') to edit blocks before they are locked. 

BlockProcessor adds many informations to methodnode, loops, dominators etc.. These are very useful for tracing control flow and editing (for example removing control flow flattening)
Fixes : https://github.com/skylot/jadx/issues/2335