### PR TITLE
BufferedInputStream: Allow jumping backwards to an already processed position 

### DIFF
--- a/jadx-cli/src/main/java/jadx/cli/tools/ConvertArscFile.java
+++ b/jadx-cli/src/main/java/jadx/cli/tools/ConvertArscFile.java
@@ -1,6 +1,5 @@
 package jadx.cli.tools;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -71,7 +70,7 @@ public class ConvertArscFile {
 				}
 			} else {
 				// Load resources.arsc from extracted file
-				try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(resFile))) {
+				try (InputStream inputStream = Files.newInputStream(resFile)) {
 					resTableParser.decode(inputStream);
 				}
 			}

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ParserStream.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ParserStream.java
@@ -18,6 +18,7 @@ public class ParserStream {
 
 	private final InputStream input;
 	private long readPos = 0;
+	private long markPos = 0;
 
 	public ParserStream(@NotNull InputStream inputStream) {
 		this.input = inputStream;
@@ -143,10 +144,12 @@ public class ParserStream {
 			throw new IOException("Mark not supported for input stream " + input.getClass());
 		}
 		input.mark(len);
+		markPos = readPos;
 	}
 
 	public void reset() throws IOException {
 		input.reset();
+		readPos = markPos;
 	}
 
 	public void readFully(byte[] b) throws IOException {


### PR DESCRIPTION
Some APK resources.arsc seem to use disordered entries, which collides with our approach to read them sequentially from the InputStream. 

As a workaround this PR introduces a BufferedInputStream and mark/reset support for `ParserStream` which allows us to jump back (up to 32k) in stream to read the disordered type chunk entries.

fixes #2343

