### PR TITLE
feat: replace constants in annotations of method arguments

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ModVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ModVisitor.java
@@ -14,6 +14,7 @@ import jadx.api.plugins.input.data.annotations.EncodedType;
 import jadx.api.plugins.input.data.annotations.EncodedValue;
 import jadx.api.plugins.input.data.annotations.IAnnotation;
 import jadx.api.plugins.input.data.attributes.JadxAttrType;
+import jadx.api.plugins.input.data.attributes.types.AnnotationMethodParamsAttr;
 import jadx.api.plugins.input.data.attributes.types.AnnotationsAttr;
 import jadx.core.dex.attributes.AFlag;
 import jadx.core.dex.attributes.AType;
@@ -279,12 +280,27 @@ public class ModVisitor extends AbstractVisitor {
 		if (cls.root().getArgs().isReplaceConsts()) {
 			replaceConstsInAnnotationForAttrNode(cls, cls);
 			cls.getFields().forEach(f -> replaceConstsInAnnotationForAttrNode(cls, f));
-			cls.getMethods().forEach(m -> replaceConstsInAnnotationForAttrNode(cls, m));
+			cls.getMethods().forEach((m) -> {
+				replaceConstsInAnnotationForAttrNode(cls, m);
+				replaceConstsInAnnotationForMethodParamsAttr(cls, m);
+			});
 		}
+	}
+
+	private void replaceConstsInAnnotationForMethodParamsAttr(ClassNode cls, MethodNode m) {
+		AnnotationMethodParamsAttr paramsAnnotation = m.get(JadxAttrType.ANNOTATION_MTH_PARAMETERS);
+		if (paramsAnnotation == null) {
+			return;
+		}
+		paramsAnnotation.getParamList().forEach(annotationsList -> replaceConstsInAnnotationsAttr(cls, annotationsList));
 	}
 
 	private void replaceConstsInAnnotationForAttrNode(ClassNode parentCls, AttrNode attrNode) {
 		AnnotationsAttr annotationsList = attrNode.get(JadxAttrType.ANNOTATION_LIST);
+		replaceConstsInAnnotationsAttr(parentCls, annotationsList);
+	}
+
+	private void replaceConstsInAnnotationsAttr(ClassNode parentCls, AnnotationsAttr annotationsList) {
 		if (annotationsList == null) {
 			return;
 		}

--- a/jadx-core/src/test/java/jadx/tests/integration/android/TestResConstReplace3.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/android/TestResConstReplace3.java
@@ -1,0 +1,33 @@
+package jadx.tests.integration.android;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestResConstReplace3 extends IntegrationTest {
+
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface UsesAndroidResource {
+		int value() default 0;
+	}
+
+	@UsesAndroidResource(17039370 /* android.R.string.ok */)
+	public static class TestCls {
+		public void test(@UsesAndroidResource(17039370 /* android.R.string.ok */) int i) {
+		}
+	}
+
+	@Test
+	public void test() {
+		disableCompilation();
+		assertThat(getClassNode(TestCls.class))
+				.code()
+				.containsOne("import android.R;")
+				.countString(2, "@TestResConstReplace3.UsesAndroidResource(R.string.ok)");
+	}
+}


### PR DESCRIPTION
This PR replaces constants in annotation of method arguments. Example:

Having an annotation like 

```java
@Retention(RetentionPolicy.RUNTIME)
public @interface UsesAndroidResource {
	int value() default 0;
}
```

this class 

```java

public static class TestCls {
	public void test(@UsesAndroidResource(17039370 /* android.R.string.ok */) int i) {
	}
}
```

would be decompiled to

```java
public static class TestCls {
	public void test(@UsesAndroidResource(R.string.ok) int i) {
	}
}
```

I need this fix to generate an issue with AGP > 8.0.0, I'd like to fix later.