### PR TITLE
fix: check respectBytecodeAccModifiers before changing method access modifier in MarkMethodsForInline

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/MarkMethodsForInline.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/MarkMethodsForInline.java
@@ -150,7 +150,7 @@ public class MarkMethodsForInline extends AbstractVisitor {
 		if (insnType == InsnType.INVOKE) {
 			InvokeNode invoke = (InvokeNode) insn;
 			MethodNode callMthNode = mth.root().resolveMethod(invoke.getCallMth());
-			if (callMthNode != null) {
+			if (callMthNode != null && !callMthNode.root().getArgs().isRespectBytecodeAccModifiers()) {
 				FixAccessModifiers.changeVisibility(callMthNode, newVisFlag);
 			}
 			return true;


### PR DESCRIPTION
even when option "Respect bytecode access modifiers" is on, some method modifiers will still be changed. 
```java
    /* JADX INFO: Access modifiers changed from: private */
    public static String getPropertyNameOfSetter(String str) {
        if (str.startsWith("set")) {
            return str.substring(3);
        }
        return null;
    }
```

bugged dex: [1.zip](https://github.com/user-attachments/files/18058899/1.zip)

after inspect the code, i found that `Access modifiers changed from` is from `FixAccessModifiers.changeVisibility()`. 

it's a static method, so cannot use the boolean param in the same class. Instead, the caller of `changeVisibility()` should check the option by `root.getArgs().isRespectBytecodeAccModifiers()`

in the other place where `changeVisibility()` is called ([ClassModifier.java](https://github.com/skylot/jadx/blob/828cad32870514afb32bcf08a337eb3afaf36cc7/jadx-core/src/main/java/jadx/core/dex/visitors/ClassModifier.java#L287)), the options is checked, so here we should check it too.


