### PR TITLE
gradle: handle non-final res ids for AGP >8.0.0

### DIFF
--- a/jadx-core/src/main/java/jadx/core/Jadx.java
+++ b/jadx-core/src/main/java/jadx/core/Jadx.java
@@ -54,6 +54,7 @@ import jadx.core.dex.visitors.debuginfo.DebugInfoApplyVisitor;
 import jadx.core.dex.visitors.debuginfo.DebugInfoAttachVisitor;
 import jadx.core.dex.visitors.finaly.MarkFinallyVisitor;
 import jadx.core.dex.visitors.fixaccessmodifiers.FixAccessModifiers;
+import jadx.core.dex.visitors.gradle.NonFinalResIdsVisitor;
 import jadx.core.dex.visitors.kotlin.ProcessKotlinInternals;
 import jadx.core.dex.visitors.prepare.AddAndroidConstants;
 import jadx.core.dex.visitors.prepare.CollectConstValues;
@@ -186,6 +187,7 @@ public class Jadx {
 
 		passes.add(new EnumVisitor());
 		passes.add(new FixSwitchOverEnum());
+		passes.add(new NonFinalResIdsVisitor());
 		passes.add(new ExtractFieldInit());
 		passes.add(new FixAccessModifiers());
 		passes.add(new ClassModifier());

--- a/jadx-core/src/main/java/jadx/core/dex/visitors/gradle/NonFinalResIdsVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/gradle/NonFinalResIdsVisitor.java
@@ -1,0 +1,118 @@
+package jadx.core.dex.visitors.gradle;
+
+import java.util.Map;
+
+import jadx.api.plugins.input.data.annotations.AnnotationVisibility;
+import jadx.api.plugins.input.data.annotations.EncodedValue;
+import jadx.api.plugins.input.data.annotations.IAnnotation;
+import jadx.api.plugins.input.data.attributes.JadxAttrType;
+import jadx.api.plugins.input.data.attributes.types.AnnotationsAttr;
+import jadx.core.dex.attributes.nodes.CodeFeaturesAttr;
+import jadx.core.dex.info.ClassInfo;
+import jadx.core.dex.nodes.ClassNode;
+import jadx.core.dex.nodes.FieldNode;
+import jadx.core.dex.nodes.IFieldInfoRef;
+import jadx.core.dex.nodes.IRegion;
+import jadx.core.dex.nodes.MethodNode;
+import jadx.core.dex.nodes.RootNode;
+import jadx.core.dex.regions.SwitchRegion;
+import jadx.core.dex.visitors.AbstractVisitor;
+import jadx.core.dex.visitors.FixSwitchOverEnum;
+import jadx.core.dex.visitors.JadxVisitor;
+import jadx.core.dex.visitors.regions.DepthRegionTraversal;
+import jadx.core.dex.visitors.regions.IRegionIterativeVisitor;
+import jadx.core.export.GradleInfoStorage;
+import jadx.core.utils.android.AndroidResourcesUtils;
+import jadx.core.utils.exceptions.JadxException;
+
+@JadxVisitor(
+		name = "NonFinalResIdsVisitor",
+		desc = "Detect usage of android resource constants in cases where constant expressions are required.",
+		runAfter = FixSwitchOverEnum.class
+)
+public class NonFinalResIdsVisitor extends AbstractVisitor implements IRegionIterativeVisitor {
+
+	private boolean nonFinalResIdsFlagRequired = false;
+
+	private GradleInfoStorage gradleInfoStorage;
+
+	public void init(RootNode root) throws JadxException {
+		gradleInfoStorage = root.getGradleInfoStorage();
+	}
+
+	@Override
+	public boolean visit(ClassNode cls) throws JadxException {
+		if (nonFinalResIdsFlagRequired) {
+			return false;
+		}
+		AnnotationsAttr annotationsList = cls.get(JadxAttrType.ANNOTATION_LIST);
+		if (visitAnnotationList(annotationsList)) {
+			return false;
+		}
+		return super.visit(cls);
+	}
+
+	private static boolean isCustomResourceClass(ClassInfo cls) {
+		ClassInfo parentClass = cls.getParentClass();
+		return parentClass != null && parentClass.getShortName().equals("R") && !parentClass.getFullName().equals("android.R");
+	}
+
+	@Override
+	public void visit(MethodNode mth) throws JadxException {
+		AnnotationsAttr annotationsList = mth.get(JadxAttrType.ANNOTATION_LIST);
+		if (visitAnnotationList(annotationsList)) {
+			nonFinalResIdsFlagRequired = true;
+			return;
+		}
+
+		if (nonFinalResIdsFlagRequired || !CodeFeaturesAttr.contains(mth, CodeFeaturesAttr.CodeFeature.SWITCH)) {
+			return;
+		}
+		DepthRegionTraversal.traverseIterative(mth, this);
+	}
+
+	private boolean visitAnnotationList(AnnotationsAttr annotationsList) {
+		if (annotationsList != null) {
+			for (IAnnotation annotation : annotationsList.getAll()) {
+				if (annotation.getVisibility() == AnnotationVisibility.SYSTEM) {
+					continue;
+				}
+				for (Map.Entry<String, EncodedValue> entry : annotation.getValues().entrySet()) {
+					Object value = entry.getValue().getValue();
+					if (value instanceof IFieldInfoRef && isCustomResourceClass(((IFieldInfoRef) value).getFieldInfo().getDeclClass())) {
+						gradleInfoStorage.setNonFinalResIds(true);
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean visitRegion(MethodNode mth, IRegion region) {
+		if (nonFinalResIdsFlagRequired) {
+			return false;
+		}
+		if (region instanceof SwitchRegion) {
+			return detectSwitchOverResIds((SwitchRegion) region);
+		}
+		return false;
+	}
+
+	private boolean detectSwitchOverResIds(SwitchRegion switchRegion) {
+		for (SwitchRegion.CaseInfo caseInfo : switchRegion.getCases()) {
+			for (Object key : caseInfo.getKeys()) {
+				if (key instanceof FieldNode) {
+					ClassNode topParentClass = ((FieldNode) key).getTopParentClass();
+					if (AndroidResourcesUtils.isResourceClass(topParentClass) && !"android.R".equals(topParentClass.getFullName())) {
+						this.nonFinalResIdsFlagRequired = true;
+						gradleInfoStorage.setNonFinalResIds(true);
+						return false;
+					}
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/jadx-core/src/main/java/jadx/core/export/ExportGradleProject.java
+++ b/jadx-core/src/main/java/jadx/core/export/ExportGradleProject.java
@@ -1,7 +1,9 @@
 package jadx.core.export;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -35,8 +37,23 @@ public class ExportGradleProject {
 			saveProjectBuildGradle();
 			saveApplicationBuildGradle();
 			saveSettingsGradle();
+			saveGradleProperties();
 		} catch (Exception e) {
 			throw new JadxRuntimeException("Gradle export failed", e);
+		}
+	}
+
+	private void saveGradleProperties() throws IOException {
+		GradleInfoStorage gradleInfo = root.getGradleInfoStorage();
+		/*
+		 * For Android Gradle Plugin >=8.0.0 the property "android.nonFinalResIds=false" has to be set in
+		 * "gradle.properties" when resource identifiers are used as constant expressions.
+		 */
+		if (gradleInfo.isNonFinalResIds()) {
+			File gradlePropertiesFile = new File(projectDir, "gradle.properties");
+			try (FileOutputStream fos = new FileOutputStream(gradlePropertiesFile)) {
+				fos.write("android.nonFinalResIds=false".getBytes(StandardCharsets.UTF_8));
+			}
 		}
 	}
 

--- a/jadx-core/src/main/java/jadx/core/export/GradleInfoStorage.java
+++ b/jadx-core/src/main/java/jadx/core/export/GradleInfoStorage.java
@@ -8,6 +8,8 @@ public class GradleInfoStorage {
 
 	private boolean useApacheHttpLegacy;
 
+	private boolean nonFinalResIds;
+
 	public boolean isVectorPathData() {
 		return vectorPathData;
 	}
@@ -30,5 +32,13 @@ public class GradleInfoStorage {
 
 	public void setUseApacheHttpLegacy(boolean useApacheHttpLegacy) {
 		this.useApacheHttpLegacy = useApacheHttpLegacy;
+	}
+
+	public boolean isNonFinalResIds() {
+		return nonFinalResIds;
+	}
+
+	public void setNonFinalResIds(boolean nonFinalResIds) {
+		this.nonFinalResIds = nonFinalResIds;
 	}
 }

--- a/jadx-core/src/test/java/jadx/tests/api/ExportGradleTest.java
+++ b/jadx-core/src/test/java/jadx/tests/api/ExportGradleTest.java
@@ -67,4 +67,12 @@ public abstract class ExportGradleTest {
 	protected String getSettingsGradle() {
 		return loadFileContent(new File(exportDir, "settings.gradle"));
 	}
+
+	protected File getGradleProperiesFile() {
+		return new File(exportDir, "gradle.properties");
+	}
+
+	protected String getGradleProperies() {
+		return loadFileContent(getGradleProperiesFile());
+	}
 }

--- a/jadx-core/src/test/java/jadx/tests/export/TestNonFinalResIds.java
+++ b/jadx-core/src/test/java/jadx/tests/export/TestNonFinalResIds.java
@@ -1,0 +1,24 @@
+package jadx.tests.export;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import jadx.core.export.GradleInfoStorage;
+import jadx.tests.api.ExportGradleTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestNonFinalResIds extends ExportGradleTest {
+
+	@Test
+	void test() {
+		GradleInfoStorage gradleInfo = getRootNode().getGradleInfoStorage();
+		gradleInfo.setNonFinalResIds(false);
+		exportGradle("OptionalTargetSdkVersion.xml", "strings.xml");
+		Assertions.assertFalse(getGradleProperiesFile().exists());
+
+		gradleInfo.setNonFinalResIds(true);
+		exportGradle("OptionalTargetSdkVersion.xml", "strings.xml");
+		assertThat(getGradleProperies()).containsOne("android.nonFinalResIds=false");
+	}
+}


### PR DESCRIPTION
The android gradle plugin for jadx gradle export can't be updated to newer versions > 8.0.0 due to several issues. One issue e.g. is a compiler error when android resource identifiers are uses as constant expressions.

Example:

Decompile an app with like this, export sources to gradle, update AGP version manually (> 8.0.0) and recompile it:

```java
package` jadx.app.test;

import java.lang.annotation.Retention;
import java.lang.annotation.RetentionPolicy;

@Retention(RetentionPolicy.RUNTIME)
public @interface RequiresFinalResId {
    int value() default android.R.string.ok;
}
```

```java
package jadx.app.test;

import android.app.Activity;

@RequiresFinalResId(value=R.string.app_name) // <-- error: constant expression required
public class MainActivity extends Activity {

    @RequiresFinalResId(value=R.string.app_name) // <-- error: constant expression required
    public class Test {
    }

    @RequiresFinalResId(value=R.string.app_name) // <-- error: constant expression required
    private int i;

    @RequiresFinalResId(value=R.string.app_name) // <-- error: constant expression required
    public int test(@RequiresFinalResId(value=R.string.app_name) int i) { // <-- error: constant expression required, error introduced with https://github.com/skylot/jadx/pull/2358
        @RequiresFinalResId(value=R.string.app_name) // <-- Jadx ignores runtime annotations with variable, no error until jadx can decompile this line
        int a = i + 1;
        this.i = i;
        switch (i) {
            case R.string.app_name: // <-- error: constant expression required
                break;
            case android.R.string.ok: // <-- ok, no error
                break;
        }
        return a;
    }
}
```

With the current gradle export using a AGP version < 8.0.0 this class could be recompiled without any issues.

The solution is to set a property `android.nonFinalResIds=false` in `gradle.properties` (see https://stackoverflow.com/questions/76430646/constant-expression-required-when-trying-to-create-a-switch-case-block).

I introduced a new pass to detect these cases. For the new visitor I introduced also a new package `jadx.core.dex.visitors.gradle` for visitors only required for gradle export. For a refactored visitor for https://github.com/skylot/jadx/pull/1927 I would use the same package.

Real world example:

See switch instruction in class `de.sellfisch.android.wwr.a.k` of https://apkpure.com/who-becomes-rich/de.sellfisch.android.wwr/download/1.15.1