### PR TITLE
fix: inner class parent is wrong when name formatted as Class$method$xxx

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/RootNode.java
@@ -290,7 +290,7 @@ public class RootNode {
 		List<ClassNode> updated = new ArrayList<>();
 		for (ClassNode cls : inner) {
 			ClassInfo clsInfo = cls.getClassInfo();
-			ClassNode parent = resolveClass(clsInfo.getParentClass());
+			ClassNode parent = resolveParentClass(clsInfo);
 			if (parent == null) {
 				clsMap.remove(clsInfo);
 				clsInfo.notInner(this);
@@ -480,6 +480,33 @@ public class RootNode {
 	@Nullable
 	public ClassNode resolveRawClass(String rawFullName) {
 		return rawClsMap.get(rawFullName);
+	}
+
+	/**
+	 * Find and correct the parent of an inner class.
+	 * <br>
+	 * Sometimes inner ClassInfo generated wrong parent info.
+	 * e.g. inner is `Cls$mth$1`, current parent = `Cls$mth`, real parent = `Cls`
+	 */
+	@Nullable
+	public ClassNode resolveParentClass(ClassInfo clsInfo) {
+		ClassInfo parentInfo = clsInfo.getParentClass();
+		ClassNode parentNode = resolveClass(parentInfo);
+		if (parentNode == null && parentInfo != null) {
+			String parClsName = parentInfo.getFullName();
+			// strip last part as method name
+			int sep = parClsName.lastIndexOf('.');
+			if (sep > 0 && sep != parClsName.length() - 1) {
+				String mthName = parClsName.substring(sep + 1);
+				String upperParClsName = parClsName.substring(0, sep);
+				ClassNode tmpParent = resolveClass(upperParClsName);
+				if (tmpParent != null && tmpParent.searchMethodByShortName(mthName) != null) {
+					parentNode = tmpParent;
+					clsInfo.convertToInner(parentNode);
+				}
+			}
+		}
+		return parentNode;
 	}
 
 	/**


### PR DESCRIPTION
inner class name format can be `Class1$InnerClass1`. but it can also be `Class1$method1$InnerClass1` ([example](https://github.com/skylot/jadx/blob/master/jadx-core/src/test/smali/inline/TestSyntheticInline3/TestSyntheticInline3%24onCreate%241.smali)). In [ClassInfo.splitAndApplyNames()](https://github.com/skylot/jadx/blob/47f2e516e54be4e91eee1fc56dd260ee634d0cfd/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java#L161), only the former situation is considered. 

This pr is trying to cover the latter situation. If the inner class ClassInfo see its parent class as `Class1$method1`, parent classNode will not be found. In this case `resolveParentClass()` will try to split it again, into `Class1` and `method1`, make sure `Class1` exists and contains method `method1`, then set `Class1` as inner class's parent.


