### PR TITLE
fix: inline anonymous class wrongly handles field as Classname.this

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/ClassModifier.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/ClassModifier.java
@@ -86,8 +86,11 @@ public class ClassModifier extends AbstractVisitor {
 					ClassInfo clsInfo = ClassInfo.fromType(cls.root(), fldType);
 					ClassNode fieldsCls = cls.root().resolveClass(clsInfo);
 					ClassInfo parentClass = cls.getClassInfo().getParentClass();
-					if (fieldsCls != null
-							&& (inline || Objects.equals(parentClass, fieldsCls.getClassInfo()))) {
+					if (fieldsCls == null) {
+						continue;
+					}
+					boolean isParentInst = Objects.equals(parentClass, fieldsCls.getClassInfo());
+					if (inline || isParentInst) {
 						int found = 0;
 						for (MethodNode mth : cls.getMethods()) {
 							if (removeFieldUsageFromConstructor(mth, field, fieldsCls)) {
@@ -95,7 +98,9 @@ public class ClassModifier extends AbstractVisitor {
 							}
 						}
 						if (found != 0) {
-							field.addAttr(new FieldReplaceAttr(fieldsCls.getClassInfo()));
+							if (isParentInst) {
+								field.addAttr(new FieldReplaceAttr(fieldsCls.getClassInfo()));
+							}
 							field.add(AFlag.DONT_GENERATE);
 						}
 					}

--- a/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass22.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/inner/TestAnonymousClass22.java
@@ -1,0 +1,40 @@
+package jadx.tests.integration.inner;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestAnonymousClass22 extends IntegrationTest {
+
+	public static class TestCls {
+
+		public static class Parent {
+			public static Parent test(Class<?> cls) {
+				final AnotherClass another = new AnotherClass();
+				return new Parent() {
+					@Override
+					public String func() {
+						return another.toString();
+					}
+				};
+			}
+
+			public String func() {
+				return "";
+			}
+		}
+
+		public static class AnotherClass {
+		}
+	}
+
+	@Test
+	public void test() {
+		assertThat(getClassNode(TestCls.class))
+				.code()
+				.containsOne("return another.toString();")
+				.doesNotContain("AnotherClass.this");
+	}
+}


### PR DESCRIPTION
If option "inline anonymous class" is checked, sometimes the field of the anonymous class is wrongly recoginized as the instance of its parent class, which actually is instance of a random class. This leads to the field being added `CLASS_INSTANCE` type `FieldReplaceAttr` and displayed as `FieldClassName.this` rather than its normal name.

[example dex](https://github.com/user-attachments/files/18104562/classes.dex.zip)
decompiled code: notice that `another` is displayed as `AnotherClass.this`
```java
public class Parent {
    public static Parent test(Class<?> cls) {
        final AnotherClass another = new AnotherClass();
        return new Parent() { // from class: jadxtest.Parent.1
            @Override // jadxtest.Parent
            public String func() {
                return AnotherClass.this.toString();
            }
        };
    }

    public String func() {
        return "";
    }
}
```

this pr extracts `Objects.equals(parentClass, fieldsCls.getClassInfo())`, and only add CLASS_INSTANCE replace attr if it is true.