### PR TITLE
fix: better package-info support

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
@@ -176,8 +176,7 @@ public class ClassNode extends NotificationAttrNode
 
 	private static void processSpecialClasses(ClassNode cls) {
 		AccessInfo flags = cls.getAccessFlags();
-		if (flags.isSynthetic() && flags.isInterface() && flags.isAbstract()
-				&& cls.getName().equals("package-info")) {
+		if (flags.isInterface() && cls.getName().equals("package-info")) {
 			cls.add(AFlag.PACKAGE_INFO);
 			cls.add(AFlag.DONT_RENAME);
 		}

--- a/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/ClassNode.java
@@ -175,8 +175,7 @@ public class ClassNode extends NotificationAttrNode
 	}
 
 	private static void processSpecialClasses(ClassNode cls) {
-		AccessInfo flags = cls.getAccessFlags();
-		if (flags.isInterface() && cls.getName().equals("package-info")) {
+		if (cls.getName().equals("package-info") && cls.getFields().isEmpty() && cls.getMethods().isEmpty()) {
 			cls.add(AFlag.PACKAGE_INFO);
 			cls.add(AFlag.DONT_RENAME);
 		}

--- a/jadx-core/src/test/java/jadx/tests/integration/special/TestPackageInfoSupport.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/special/TestPackageInfoSupport.java
@@ -28,5 +28,7 @@ public class TestPackageInfoSupport extends SmaliTest {
 						"package special.pkg2;",
 						"",
 						"import org.jetbrains.annotations.ApiStatus;");
+		assertThat(searchCls(classes, "special.pkg3.package-info"))
+				.code().isEqualTo("\npackage special.pkg3;\n");
 	}
 }

--- a/jadx-core/src/test/smali/special/TestPackageInfoSupport/pkg3.smali
+++ b/jadx-core/src/test/smali/special/TestPackageInfoSupport/pkg3.smali
@@ -1,0 +1,2 @@
+.class interface Lspecial/pkg3/package-info;
+.super Ljava/lang/Object;


### PR DESCRIPTION
When I filed https://github.com/skylot/jadx/issues/1967 I had only one sample app. With https://apkpure.com/who-becomes-rich/de.sellfisch.android.wwr/download/1.15.1 I found another app with package-infos e.g. `javax.annotation.package-info`. This time a package-info is just an interface, nothing else. I removed some checks to support this case too.