### PR TITLE
chore: add .desktop file for gui

### DIFF
--- a/contrib/jadx-gui.desktop
+++ b/contrib/jadx-gui.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=JADX GUI
+Comment=Dex to Java compiler
+Icon=jadx
+Exec=jadx-gui %f
+Terminal=false
+Type=Application
+Categories=Development;Java;
+Keywords=Java;Decompiler;


### PR DESCRIPTION
### Description
This pull request adds a `.desktop` file for the GUI which can be copied to `/usr/share/application` on Linux to have a desktop entry to start the program using an application launcher/menu instead of starting it via the terminal via `jadx-gui`. I'm not sure if there's a better place for it, I placed it in a newly created `contrib` folder now as that's what most projects do.

This PR is for having a desktop file entry at Void Linux due to https://github.com/void-linux/void-packages/pull/53772#discussion_r1900208774, as we'd like to upstream desktop files and not vendor them ourselves.

If there are suggestions for improvements, feedback is always welcome! Thanks.