### PR TITLE
feat(gui): open the summary tab automatically when the project is opened

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -54,7 +54,7 @@ public class JadxSettings extends JadxCLIArgs {
 
 	private static final Path USER_HOME = Paths.get(System.getProperty("user.home"));
 	private static final int RECENT_PROJECTS_COUNT = 30;
-	private static final int CURRENT_SETTINGS_VERSION = 22;
+	private static final int CURRENT_SETTINGS_VERSION = 23;
 
 	private static final Font DEFAULT_FONT = new RSyntaxTextArea().getFont();
 
@@ -127,6 +127,7 @@ public class JadxSettings extends JadxCLIArgs {
 	private @Nullable String cacheDir = null; // null - default (system), "." - at project dir, other - custom
 
 	private boolean jumpOnDoubleClick = true;
+	private boolean showSummaryOnOpen = true;
 
 	private XposedCodegenLanguage xposedCodegenLanguage = XposedCodegenLanguage.JAVA;
 	private JadxUpdateChannel jadxUpdateChannel = JadxUpdateChannel.STABLE;
@@ -759,6 +760,14 @@ public class JadxSettings extends JadxCLIArgs {
 		this.jumpOnDoubleClick = jumpOnDoubleClick;
 	}
 
+	public boolean isShowSummaryOnOpen() {
+		return showSummaryOnOpen;
+	}
+
+	public void setShowSummaryOnOpen(boolean showSummaryOnOpen) {
+		this.showSummaryOnOpen = showSummaryOnOpen;
+	}
+
 	public boolean isDockLogViewer() {
 		return dockLogViewer;
 	}
@@ -852,6 +861,10 @@ public class JadxSettings extends JadxCLIArgs {
 		}
 		if (fromVersion == 21) {
 			migrateUseSourceNameAsClassNameAlias();
+			fromVersion++;
+		}
+		if (fromVersion == 22) {
+			showSummaryOnOpen = true;
 			fromVersion++;
 		}
 		if (fromVersion != CURRENT_SETTINGS_VERSION) {

--- a/jadx-gui/src/main/java/jadx/gui/settings/ui/JadxSettingsWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/ui/JadxSettingsWindow.java
@@ -629,6 +629,10 @@ public class JadxSettingsWindow extends JDialog {
 		jumpOnDoubleClick.setSelected(settings.isJumpOnDoubleClick());
 		jumpOnDoubleClick.addItemListener(e -> settings.setJumpOnDoubleClick(e.getStateChange() == ItemEvent.SELECTED));
 
+		JCheckBox showSummaryOnOpen = new JCheckBox();
+		showSummaryOnOpen.setSelected(settings.isShowSummaryOnOpen());
+		showSummaryOnOpen.addItemListener(e -> settings.setShowSummaryOnOpen(e.getStateChange() == ItemEvent.SELECTED));
+
 		JCheckBox useAltFileDialog = new JCheckBox();
 		useAltFileDialog.setSelected(settings.isUseAlternativeFileDialog());
 		useAltFileDialog.addItemListener(e -> settings.setUseAlternativeFileDialog(e.getStateChange() == ItemEvent.SELECTED));
@@ -670,6 +674,7 @@ public class JadxSettingsWindow extends JDialog {
 		SettingsGroup group = new SettingsGroup(NLS.str("preferences.other"));
 		group.addRow(NLS.str("preferences.lineNumbersMode"), lineNumbersMode);
 		group.addRow(NLS.str("preferences.jumpOnDoubleClick"), jumpOnDoubleClick);
+		group.addRow(NLS.str("preferences.showSummaryOnOpen"), showSummaryOnOpen);
 		group.addRow(NLS.str("preferences.useAlternativeFileDialog"), useAltFileDialog);
 		group.addRow(NLS.str("preferences.cfg"), cfg);
 		group.addRow(NLS.str("preferences.raw_cfg"), rawCfg);

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -656,6 +656,9 @@ public class MainWindow extends JFrame {
 		BreakpointManager.init(project.getFilePaths().get(0).toAbsolutePath().getParent());
 		treeExpansionService.load(project.getTreeExpansions());
 		List<EditorViewState> openTabs = project.getOpenTabs(this);
+		if (openTabs.isEmpty() && settings.isShowSummaryOnOpen()) {
+			openSummaryTab();
+		}
 		backgroundExecutor.execute(NLS.str("progress.load"),
 				() -> preLoadOpenTabs(openTabs),
 				status -> {
@@ -1550,6 +1553,15 @@ public class MainWindow extends JFrame {
 
 		dispose();
 		System.exit(0);
+	}
+
+	private void openSummaryTab() {
+		for (JNode node : treeRoot.getCustomNodes()) {
+			if (node.getClass() == SummaryNode.class) {
+				tabsController.codeJump(node);
+				break;
+			}
+		}
 	}
 
 	private void saveOpenTabs() {

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -204,6 +204,7 @@ preferences.other=Andere
 preferences.language=Sprache
 preferences.lineNumbersMode=Editor Zeilennummern-Modus
 preferences.jumpOnDoubleClick=Sprung bei Doppelklick aktivieren
+#preferences.showSummaryOnOpen=Show summary on open
 #preferences.useAlternativeFileDialog=Use alternative file dialog
 preferences.check_for_updates=Nach Updates beim Start suchen
 preferences.useDx=dx/d8 zur Konvertierung von Java Bytecode verwenden

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -204,6 +204,7 @@ preferences.other=Other
 preferences.language=Language
 preferences.lineNumbersMode=Editor line numbers mode
 preferences.jumpOnDoubleClick=Enable jump on double click
+preferences.showSummaryOnOpen=Show summary on open
 preferences.useAlternativeFileDialog=Use alternative file dialog
 preferences.check_for_updates=Check for updates on startup
 preferences.useDx=Use dx/d8 to convert java bytecode

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -204,6 +204,7 @@ preferences.other=Otros
 preferences.language=Idioma
 #preferences.lineNumbersMode=Editor line numbers mode
 #preferences.jumpOnDoubleClick=Enable jump on double click
+#preferences.showSummaryOnOpen=Show summary on open
 #preferences.useAlternativeFileDialog=Use alternative file dialog
 preferences.check_for_updates=Buscar actualizaciones al iniciar
 #preferences.useDx=Use dx/d8 to convert java bytecode

--- a/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
@@ -204,6 +204,7 @@ preferences.other=Lainnya
 preferences.language=Bahasa
 preferences.lineNumbersMode=Mode nomor baris editor
 preferences.jumpOnDoubleClick=Aktifkan lompat saat dua kali klik
+#preferences.showSummaryOnOpen=Show summary on open
 preferences.useAlternativeFileDialog=Gunakan dialog berkas alternatif
 preferences.check_for_updates=Periksa pembaruan saat memulai
 preferences.useDx=Gunakan dx/d8 untuk mengonversi bytecode Java

--- a/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
@@ -204,6 +204,7 @@ preferences.other=기타
 preferences.language=언어
 preferences.lineNumbersMode=편집기 줄 번호 모드
 preferences.jumpOnDoubleClick=더블 클릭 시 점프 활성화
+#preferences.showSummaryOnOpen=Show summary on open
 #preferences.useAlternativeFileDialog=Use alternative file dialog
 preferences.check_for_updates=시작시 업데이트 확인
 preferences.useDx=dx/d8을 사용하여 Java 바이트 코드 변환

--- a/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
@@ -204,6 +204,7 @@ preferences.other=Outro
 preferences.language=Idioma
 preferences.lineNumbersMode=Modo do contador de linhas do editor
 preferences.jumpOnDoubleClick=Ativar salto no duplo clique
+#preferences.showSummaryOnOpen=Show summary on open
 #preferences.useAlternativeFileDialog=Use alternative file dialog
 preferences.check_for_updates=Verificar por atualizações ao inicializar
 preferences.useDx=Usar dx/d8 para converter bytecode Java

--- a/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
@@ -204,6 +204,7 @@ preferences.other=Прочее
 preferences.language=Язык
 preferences.lineNumbersMode=Тип переноса строк
 preferences.jumpOnDoubleClick=Переход по двойному клику
+#preferences.showSummaryOnOpen=Show summary on open
 preferences.useAlternativeFileDialog=Использовать альтернативный файлпикер
 preferences.check_for_updates=Проверять наличие новых версий
 preferences.useDx=DX/D8 для конвертации java байткода

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -204,6 +204,7 @@ preferences.other=其他
 preferences.language=语言
 preferences.lineNumbersMode=编辑器行号模式
 preferences.jumpOnDoubleClick=启用双击跳转
+#preferences.showSummaryOnOpen=Show summary on open
 preferences.useAlternativeFileDialog=使用选择文件对话框
 preferences.check_for_updates=启动时检查更新
 preferences.useDx=使用 dx/d8 来转换java字节码

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
@@ -204,6 +204,7 @@ preferences.other=其他
 preferences.language=語言
 preferences.lineNumbersMode=編輯器行號模式
 preferences.jumpOnDoubleClick=啟用點擊兩下時跳躍
+#preferences.showSummaryOnOpen=Show summary on open
 preferences.useAlternativeFileDialog=使用替代檔案對話框
 preferences.check_for_updates=啟動時檢查更新
 preferences.useDx=使用 dx/d8 來轉換 Java 位元組碼


### PR DESCRIPTION
### Description

This feature will, as the title says, automatically open the "Summary" tab when a project is opened if the following conditions are met:
1. The feature is enabled in settings (default: true).
2. No previous tabs were opened (when using tab restoration).

The feature is in preparation of a next one that will provide an overhaul of the "summary" tab (or maybe a new tab) that will show more app information (I'll open a new issue for it to be discussed) and will make the summary tab more useful, especially for malware analysis.

