### PR TITLE
fix(gui): Xposed snippet argument types corrected (#2454)

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.kt
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/XposedAction.kt
@@ -48,16 +48,17 @@ class XposedAction(codeArea: CodeArea) : JNodeAction(ActionModel.XPOSED_COPY, co
 	private fun generateMethodSnippet(jMethod: JMethod): String {
 		val javaMethod = jMethod.javaMethod
 		val methodNode = javaMethod.methodNode
+		val methodInfo = methodNode.methodInfo
 
 		val xposedMethod: String
-		var args = methodNode.argTypes.map(::fixTypeContent)
+		var args = methodInfo.argumentsTypes.map(::fixTypeContent)
 		val rawClassName = javaMethod.declaringClass.rawName
 
 		if (methodNode.isConstructor) {
 			xposedMethod = "findAndHookConstructor"
 		} else {
 			xposedMethod = "findAndHookMethod"
-			args = listOf("\"${methodNode.methodInfo.name}\"") + args
+			args = listOf("\"${methodInfo.name}\"") + args
 		}
 
 		val template = when (language) {


### PR DESCRIPTION
fixes #2454

The correct argument type as mentioned in the issue is present in `methodNode.methodInfo.argumentsTypes` (the original source was `methodNode.argTypes`). 

`methodNode.methodInfo.argumentsTypes` is also the source where the Frida code snippet gets the used argument types from. 