### PR TITLE
fix(plugins): Fix plugin loading issue with custom jar plugins

### DIFF
--- a/jadx-plugins-tools/src/main/java/jadx/plugins/tools/JadxExternalPluginsLoader.java
+++ b/jadx-plugins-tools/src/main/java/jadx/plugins/tools/JadxExternalPluginsLoader.java
@@ -60,9 +60,24 @@ public class JadxExternalPluginsLoader implements JadxPluginLoader {
 	private void loadFromClsLoader(Map<Class<? extends JadxPlugin>, JadxPlugin> map, ClassLoader classLoader) {
 		ServiceLoader.load(JadxPlugin.class, classLoader)
 				.stream()
-				.filter(p -> p.type().getClassLoader() == classLoader)
+				.filter(p -> isClassLoaderMatch(p.type().getClassLoader(), classLoader))
 				.filter(p -> !map.containsKey(p.type()))
 				.forEach(p -> map.put(p.type(), p.get()));
+	}
+
+	private boolean isClassLoaderMatch(ClassLoader pluginClassLoader, ClassLoader targetClassLoader) {
+		if (pluginClassLoader == targetClassLoader) {
+			return true;
+		}
+		// Check if the plugin's ClassLoader is a child of the target ClassLoader
+		ClassLoader parent = pluginClassLoader;
+		while (parent != null) {
+			if (parent == targetClassLoader) {
+				return true;
+			}
+			parent = parent.getParent();
+		}
+		return false;
 	}
 
 	private void loadInstalledPlugins(Map<Class<? extends JadxPlugin>, JadxPlugin> map) {


### PR DESCRIPTION
# Fix plugin loading issue with custom jar plugins

## Problem
When loading plugins from custom jars using `loadFromJar()`, the plugins may be filtered out due to a strict ClassLoader check in `loadFromClsLoader()`. The current implementation only accepts plugins where `p.type().getClassLoader() == classLoader`, which doesn't consider the ClassLoader hierarchy.

## Solution
Added a `isClassLoaderMatch()` method to properly check the ClassLoader hierarchy relationship. This allows plugins to be loaded if their ClassLoader is either:
- The same as the target ClassLoader
- A child ClassLoader of the target ClassLoader

This change maintains the security and duplicate loading prevention of the original implementation while fixing the issue with custom jar plugin loading.

## Changes
- Added `isClassLoaderMatch()` method to check ClassLoader hierarchy
- Modified `loadFromClsLoader()` to use the new matching logic
- No changes to existing plugin loading behavior for built-in plugins

## Testing
Tested with:
- Loading built-in plugins (unchanged behavior)
- Loading custom jar plugins (now works correctly)