### PR TITLE
Option to disable the tooltip that pops up on hover

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/JadxSettings.java
@@ -69,6 +69,7 @@ public class JadxSettings extends JadxCLIArgs {
 	private Path lastSaveFilePath = USER_HOME;
 	private boolean flattenPackage = false;
 	private boolean checkForUpdates = true;
+	private boolean disableTooltipOnHover = false;
 	private List<Path> recentProjects = new ArrayList<>();
 	private String fontStr = "";
 	private String smaliFontStr = "";
@@ -242,6 +243,14 @@ public class JadxSettings extends JadxCLIArgs {
 	public void setCheckForUpdates(boolean checkForUpdates) {
 		this.checkForUpdates = checkForUpdates;
 		sync();
+	}
+
+	public boolean isDisableTooltipOnHover() {
+		return disableTooltipOnHover;
+	}
+
+	public void setDisableTooltipOnHover(boolean disableTooltipOnHover) {
+		this.disableTooltipOnHover = disableTooltipOnHover;
 	}
 
 	public List<Path> getRecentProjects() {

--- a/jadx-gui/src/main/java/jadx/gui/settings/ui/JadxSettingsWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/ui/JadxSettingsWindow.java
@@ -645,6 +645,10 @@ public class JadxSettingsWindow extends JDialog {
 		update.setSelected(settings.isCheckForUpdates());
 		update.addItemListener(e -> settings.setCheckForUpdates(e.getStateChange() == ItemEvent.SELECTED));
 
+		JCheckBox disableTooltipOnHover = new JCheckBox();
+		disableTooltipOnHover.setSelected(settings.isDisableTooltipOnHover());
+		disableTooltipOnHover.addItemListener(e -> settings.setDisableTooltipOnHover(e.getStateChange() == ItemEvent.SELECTED));
+
 		JCheckBox cfg = new JCheckBox();
 		cfg.setSelected(settings.isCfgOutput());
 		cfg.addItemListener(e -> {
@@ -684,6 +688,7 @@ public class JadxSettingsWindow extends JDialog {
 		group.addRow(NLS.str("preferences.xposed_codegen_language"), xposedCodegenLanguage);
 		group.addRow(NLS.str("preferences.check_for_updates"), update);
 		group.addRow(NLS.str("preferences.update_channel"), updateChannel);
+		group.addRow(NLS.str("preferences.disable_tooltip_on_hover"), disableTooltipOnHover);
 		return group;
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/MouseHoverHighlighter.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/MouseHoverHighlighter.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import jadx.api.JavaNode;
 import jadx.gui.treemodel.JNode;
+import jadx.gui.ui.MainWindow;
 import jadx.gui.utils.JNodeCache;
 
 class MouseHoverHighlighter extends MouseMotionAdapter {
@@ -86,11 +87,12 @@ class MouseHoverHighlighter extends MouseMotionAdapter {
 	}
 
 	private void updateToolTip(JavaNode node) {
-		if (node == null) {
+		MainWindow mainWindow = codeArea.getMainWindow();
+		if (node == null || mainWindow.getSettings().isDisableTooltipOnHover()) {
 			codeArea.setToolTipText(null);
 			return;
 		}
-		JNodeCache nodeCache = codeArea.getMainWindow().getCacheObject().getNodeCache();
+		JNodeCache nodeCache = mainWindow.getCacheObject().getNodeCache();
 		JNode jNode = nodeCache.makeFrom(node);
 		codeArea.setToolTipText(jNode.getTooltip());
 	}

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -264,6 +264,7 @@ preferences.cfg=CFG-Grafiken für Methoden generieren (im 'dot'-Format)
 preferences.raw_cfg=RAW CFG-Grafiken generieren
 preferences.xposed_codegen_language=Xposed-Code-Generierungssprache
 preferences.update_channel=Jadx-Updatekanal
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 preferences.integerFormat=Ganzzahlformat
 preferences.font=Schriftart ändern
 preferences.smali_font=Monospaced-Schriftart (Smali/Hex)

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -264,6 +264,7 @@ preferences.cfg=Generate methods CFG graphs (in 'dot' format)
 preferences.raw_cfg=Generate RAW CFG graphs
 preferences.xposed_codegen_language=Xposed code generation language
 preferences.update_channel=Jadx update channel
+preferences.disable_tooltip_on_hover=Disable tooltip on hover
 preferences.integerFormat=Integer format
 preferences.font=Editor font
 preferences.smali_font=Monospaced font (Smali/Hex)

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -264,6 +264,7 @@ preferences.cfg=Generar methods CFG graphs (in 'dot' format)
 preferences.raw_cfg=Generate RAW CFG graphs
 #preferences.xposed_codegen_language=Xposed code generation language
 #preferences.update_channel=Jadx update channel
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 #preferences.integerFormat=Integer format
 preferences.font=Fuente del editor
 #preferences.smali_font=Monospaced font (Smali/Hex)

--- a/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
@@ -264,6 +264,7 @@ preferences.cfg=Hasilkan grafik CFG metode (dalam format 'dot')
 preferences.raw_cfg=Hasilkan grafik CFG mentah
 #preferences.xposed_codegen_language=Xposed code generation language
 #preferences.update_channel=Jadx update channel
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 preferences.integerFormat=Format bilangan bulat
 preferences.font=Font editor
 preferences.smali_font=Font monospasi (Smali/Hex)

--- a/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
@@ -264,6 +264,7 @@ preferences.cfg=메소드 CFG 그래프 생성 ('dot' 포맷)
 preferences.raw_cfg=RAW CFG 그래프 생성
 #preferences.xposed_codegen_language=Xposed code generation language
 #preferences.update_channel=Jadx update channel
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 #preferences.integerFormat=Integer format
 preferences.font=에디터 글씨체
 #preferences.smali_font=Monospaced font (Smali/Hex)

--- a/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
@@ -264,6 +264,7 @@ preferences.cfg=Gera gráficos de métodos CFG no formato de pontos ('dot')
 preferences.raw_cfg=Gera gráficos CFG no formato RAW
 #preferences.xposed_codegen_language=Xposed code generation language
 #preferences.update_channel=Jadx update channel
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 #preferences.integerFormat=Integer format
 preferences.font=Fonte do editor
 #preferences.smali_font=Monospaced font (Smali/Hex)

--- a/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
@@ -264,6 +264,7 @@ preferences.cfg=Методы генерации графиков CFG (в "dot" �
 preferences.raw_cfg=Генерировать необработанные графики CFG
 preferences.xposed_codegen_language=Язык генерации Xposed хуков
 preferences.update_channel=Канал обновления Jadx
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 preferences.integerFormat=Формат чисел
 preferences.font=Шрифт редактора Java
 preferences.smali_font=Шрифт smali/HEX редактора

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -264,6 +264,7 @@ preferences.cfg=生成方法的 CFG 图（‘.dot’）
 preferences.raw_cfg=生成原始的 CFG 图
 preferences.xposed_codegen_language=Xposed代码生成语言
 preferences.update_channel=Jadx 更新通道
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 preferences.integerFormat=数值格式化
 preferences.font=编辑器字体
 preferences.smali_font=等宽字体 (Smali/Hex)

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
@@ -264,6 +264,7 @@ preferences.cfg=產生方法 CFG 圖表 ('dot' 格式)
 preferences.raw_cfg=產生 RAW CFG 圖表
 preferences.xposed_codegen_language=Xposed 程式碼產生語言
 preferences.update_channel=Jadx 更新頻道
+#preferences.disable_tooltip_on_hover=Disable tooltip on hover
 preferences.integerFormat=整數模式
 preferences.font=編輯器字型
 preferences.smali_font=等寬字型 (Smali/Hex)


### PR DESCRIPTION
This PR adds an option in the Preferences menu to disable the tooltip that pops up 
when hovering over a node.
I thought it would be nice to have because the tooltip can steal focus
away from the mouse. Anyways, let me know  what you think.
