### PR TITLE
Provide direct InputStream of ZIP entries

### DIFF
--- a/jadx-commons/jadx-zip/src/main/java/jadx/zip/fallback/FallbackZipParser.java
+++ b/jadx-commons/jadx-zip/src/main/java/jadx/zip/fallback/FallbackZipParser.java
@@ -17,8 +17,8 @@ import jadx.zip.IZipEntry;
 import jadx.zip.IZipParser;
 import jadx.zip.ZipContent;
 import jadx.zip.ZipReaderOptions;
+import jadx.zip.io.LimitedInputStream;
 import jadx.zip.security.IJadxZipSecurity;
-import jadx.zip.security.LimitedInputStream;
 
 public class FallbackZipParser implements IZipParser {
 	private static final Logger LOG = LoggerFactory.getLogger(FallbackZipParser.class);

--- a/jadx-commons/jadx-zip/src/main/java/jadx/zip/io/ByteBufferBackedInputStream.java
+++ b/jadx-commons/jadx-zip/src/main/java/jadx/zip/io/ByteBufferBackedInputStream.java
@@ -1,0 +1,50 @@
+package jadx.zip.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import org.jetbrains.annotations.NotNull;
+
+public class ByteBufferBackedInputStream extends InputStream {
+
+	private final ByteBuffer buf;
+	private int markedPosition = 0;
+
+	public ByteBufferBackedInputStream(ByteBuffer buf) {
+		this.buf = buf;
+	}
+
+	public int read() throws IOException {
+		if (!buf.hasRemaining()) {
+			return -1;
+		}
+		return buf.get() & 0xFF;
+	}
+
+	public int read(byte @NotNull [] bytes, int off, int len)
+			throws IOException {
+		if (!buf.hasRemaining()) {
+			return -1;
+		}
+
+		len = Math.min(len, buf.remaining());
+		buf.get(bytes, off, len);
+		return len;
+	}
+
+	@Override
+	public boolean markSupported() {
+		return true;
+	}
+
+	@Override
+	public synchronized void mark(int unused) {
+		markedPosition = buf.position();
+	}
+
+	@Override
+	public synchronized void reset() {
+		buf.position(markedPosition);
+	}
+}

--- a/jadx-commons/jadx-zip/src/main/java/jadx/zip/io/ByteBufferBackedInputStream.java
+++ b/jadx-commons/jadx-zip/src/main/java/jadx/zip/io/ByteBufferBackedInputStream.java
@@ -4,10 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import org.jetbrains.annotations.NotNull;
-
 public class ByteBufferBackedInputStream extends InputStream {
-
 	private final ByteBuffer buf;
 	private int markedPosition = 0;
 
@@ -22,15 +19,14 @@ public class ByteBufferBackedInputStream extends InputStream {
 		return buf.get() & 0xFF;
 	}
 
-	public int read(byte @NotNull [] bytes, int off, int len)
-			throws IOException {
+	@SuppressWarnings("NullableProblems")
+	public int read(byte[] bytes, int off, int len) throws IOException {
 		if (!buf.hasRemaining()) {
 			return -1;
 		}
-
-		len = Math.min(len, buf.remaining());
-		buf.get(bytes, off, len);
-		return len;
+		int readLen = Math.min(len, buf.remaining());
+		buf.get(bytes, off, readLen);
+		return readLen;
 	}
 
 	@Override

--- a/jadx-commons/jadx-zip/src/main/java/jadx/zip/io/LimitedInputStream.java
+++ b/jadx-commons/jadx-zip/src/main/java/jadx/zip/io/LimitedInputStream.java
@@ -1,4 +1,4 @@
-package jadx.zip.security;
+package jadx.zip.io;
 
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -8,6 +8,7 @@ public class LimitedInputStream extends FilterInputStream {
 	private final long maxSize;
 
 	private long currentPos;
+	private long markPos;
 
 	public LimitedInputStream(InputStream in, long maxSize) {
 		super(in);
@@ -50,7 +51,14 @@ public class LimitedInputStream extends FilterInputStream {
 	}
 
 	@Override
-	public boolean markSupported() {
-		return false;
+	public void mark(int readLimit) {
+		super.mark(readLimit);
+		markPos = currentPos;
+	}
+
+	@Override
+	public void reset() throws IOException {
+		super.reset();
+		currentPos = markPos;
 	}
 }

--- a/jadx-commons/jadx-zip/src/main/java/jadx/zip/parser/ZipDeflate.java
+++ b/jadx-commons/jadx-zip/src/main/java/jadx/zip/parser/ZipDeflate.java
@@ -1,8 +1,12 @@
 package jadx.zip.parser;
 
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+import jadx.zip.io.ByteBufferBackedInputStream;
 
 final class ZipDeflate {
 
@@ -21,4 +25,13 @@ final class ZipDeflate {
 		inflater.end();
 		return out;
 	}
+
+	static InputStream decompressEntryToStream(ByteBuffer buf, JadxZipEntry entry) {
+		buf.position(entry.getDataStart());
+		ByteBuffer entryBuf = buf.slice();
+		entryBuf.limit((int) entry.getCompressedSize());
+		Inflater inflater = new Inflater(true);
+		return new InflaterInputStream(new ByteBufferBackedInputStream(entryBuf), inflater);
+	}
+
 }

--- a/jadx-commons/jadx-zip/src/main/java/jadx/zip/security/JadxZipSecurity.java
+++ b/jadx-commons/jadx-zip/src/main/java/jadx/zip/security/JadxZipSecurity.java
@@ -27,6 +27,8 @@ public class JadxZipSecurity implements IJadxZipSecurity {
 
 	private int maxEntriesCount = 100_000;
 
+	private boolean useLimitedDataStream = true;
+
 	@Override
 	public boolean isValidEntry(IZipEntry entry) {
 		return isValidEntryName(entry.getName()) && !isZipBomb(entry);
@@ -34,7 +36,7 @@ public class JadxZipSecurity implements IJadxZipSecurity {
 
 	@Override
 	public boolean useLimitedDataStream() {
-		return false;
+		return useLimitedDataStream;
 	}
 
 	@Override
@@ -113,6 +115,10 @@ public class JadxZipSecurity implements IJadxZipSecurity {
 
 	public void setZipBombMinUncompressedSize(int zipBombMinUncompressedSize) {
 		this.zipBombMinUncompressedSize = zipBombMinUncompressedSize;
+	}
+
+	public void setUseLimitedDataStream(boolean useLimitedDataStream) {
+		this.useLimitedDataStream = useLimitedDataStream;
 	}
 
 	private static File getCWD() {

--- a/jadx-core/src/main/java/jadx/api/plugins/utils/ZipSecurity.java
+++ b/jadx-core/src/main/java/jadx/api/plugins/utils/ZipSecurity.java
@@ -16,10 +16,10 @@ import jadx.api.plugins.JadxPluginContext;
 import jadx.core.utils.Utils;
 import jadx.zip.IZipEntry;
 import jadx.zip.ZipReader;
+import jadx.zip.io.LimitedInputStream;
 import jadx.zip.security.DisabledZipSecurity;
 import jadx.zip.security.IJadxZipSecurity;
 import jadx.zip.security.JadxZipSecurity;
-import jadx.zip.security.LimitedInputStream;
 
 /**
  * Deprecated, migrate to {@link ZipReader}. <br>

--- a/jadx-core/src/main/java/jadx/core/xmlgen/ParserStream.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/ParserStream.java
@@ -1,5 +1,6 @@
 package jadx.core.xmlgen;
 
+import java.io.BufferedInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,7 +22,7 @@ public class ParserStream {
 	private long markPos = 0;
 
 	public ParserStream(@NotNull InputStream inputStream) {
-		this.input = inputStream;
+		this.input = inputStream.markSupported() ? inputStream : new BufferedInputStream(inputStream);
 	}
 
 	public long getPos() {


### PR DESCRIPTION
As mentioned recently there was no direct way of getting an InputStream of a ZIP entry without having to extract the full entry data to a byte array in memory. 

This PR provides a way to directly get an InputStream for compressed and uncompressed data in a ZIP file.
Only in one case the only way of reading everything to memory is still present: when using the FallbackZipParser.