### PR TITLE
New search options to search in text or binary resources

### DIFF
--- a/jadx-core/src/main/java/jadx/api/ResourceType.java
+++ b/jadx-core/src/main/java/jadx/api/ResourceType.java
@@ -4,29 +4,40 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import jadx.api.resources.ResourceContentType;
 import jadx.core.utils.exceptions.JadxRuntimeException;
 
-public enum ResourceType {
-	CODE(".dex", ".jar", ".class"),
-	XML(".xml"),
-	ARSC(".arsc"),
-	APK(".apk", ".apkm", ".apks"),
-	FONT(".ttf", ".ttc", ".otf"),
-	IMG(".png", ".gif", ".jpg", ".webp", ".bmp", ".tiff"),
-	ARCHIVE(".zip", ".rar", ".7zip", ".7z", ".arj", ".tar", ".gzip", ".bzip", ".bzip2", ".cab", ".cpio", ".ar", ".gz", ".tgz", ".bz2"),
-	VIDEOS(".mp4", ".mkv", ".webm", ".avi", ".flv", ".3gp"),
-	SOUNDS(".aac", ".ogg", ".opus", ".mp3", ".wav", ".wma", ".mid", ".midi"),
-	JSON(".json"),
-	TEXT(".txt", ".ini", ".conf", ".yaml", ".properties", ".js"),
-	HTML(".html"),
-	LIB(".so"),
-	MANIFEST,
-	UNKNOWN;
+import static jadx.api.resources.ResourceContentType.CONTENT_BINARY;
+import static jadx.api.resources.ResourceContentType.CONTENT_TEXT;
 
+public enum ResourceType {
+	CODE(CONTENT_BINARY, ".dex", ".jar", ".class"),
+	XML(CONTENT_TEXT, ".xml"),
+	ARSC(CONTENT_BINARY, ".arsc"),
+	APK(CONTENT_BINARY, ".apk", ".apkm", ".apks"),
+	FONT(CONTENT_BINARY, ".ttf", ".ttc", ".otf"),
+	IMG(CONTENT_BINARY, ".png", ".gif", ".jpg", ".webp", ".bmp", ".tiff"),
+	ARCHIVE(CONTENT_BINARY, ".zip", ".rar", ".7zip", ".7z", ".arj", ".tar", ".gzip", ".bzip", ".bzip2", ".cab", ".cpio", ".ar", ".gz",
+			".tgz", ".bz2"),
+	VIDEOS(CONTENT_BINARY, ".mp4", ".mkv", ".webm", ".avi", ".flv", ".3gp"),
+	SOUNDS(CONTENT_BINARY, ".aac", ".ogg", ".opus", ".mp3", ".wav", ".wma", ".mid", ".midi"),
+	JSON(CONTENT_TEXT, ".json"),
+	TEXT(CONTENT_TEXT, ".txt", ".ini", ".conf", ".yaml", ".properties", ".js"),
+	HTML(CONTENT_TEXT, ".html"),
+	LIB(CONTENT_BINARY, ".so"),
+	MANIFEST(CONTENT_TEXT),
+	UNKNOWN(CONTENT_TEXT);
+
+	private final ResourceContentType contentType;
 	private final String[] exts;
 
-	ResourceType(String... exts) {
+	ResourceType(ResourceContentType contentType, String... exts) {
+		this.contentType = contentType;
 		this.exts = exts;
+	}
+
+	public ResourceContentType getContentType() {
+		return contentType;
 	}
 
 	public String[] getExts() {

--- a/jadx-core/src/main/java/jadx/api/ResourcesLoader.java
+++ b/jadx-core/src/main/java/jadx/api/ResourcesLoader.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -229,9 +230,13 @@ public final class ResourcesLoader implements IResourcesLoader {
 	}
 
 	public static ICodeInfo loadToCodeWriter(InputStream is) throws IOException {
+		return loadToCodeWriter(is, StandardCharsets.UTF_8);
+	}
+
+	public static ICodeInfo loadToCodeWriter(InputStream is, Charset charset) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream(READ_BUFFER_SIZE);
 		copyStream(is, baos);
-		return new SimpleCodeInfo(baos.toString(StandardCharsets.UTF_8));
+		return new SimpleCodeInfo(baos.toString(charset));
 	}
 
 	private synchronized BinaryXMLParser loadBinaryXmlParser() {

--- a/jadx-core/src/main/java/jadx/api/resources/ResourceContentType.java
+++ b/jadx-core/src/main/java/jadx/api/resources/ResourceContentType.java
@@ -1,0 +1,7 @@
+package jadx.api.resources;
+
+public enum ResourceContentType {
+	CONTENT_TEXT,
+	CONTENT_BINARY,
+	CONTENT_NONE,
+}

--- a/jadx-gui/src/main/java/jadx/gui/search/SearchSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/search/SearchSettings.java
@@ -8,6 +8,8 @@ import jadx.api.JadxDecompiler;
 import jadx.api.JavaClass;
 import jadx.api.JavaPackage;
 import jadx.core.dex.nodes.PackageNode;
+import jadx.core.utils.exceptions.InvalidDataException;
+import jadx.gui.search.providers.ResourceFilter;
 import jadx.gui.treemodel.JClass;
 import jadx.gui.treemodel.JResource;
 import jadx.gui.ui.MainWindow;
@@ -26,6 +28,7 @@ public class SearchSettings {
 	private Pattern regexPattern;
 	private ISearchMethod searchMethod;
 	private JavaPackage searchPackage;
+	private ResourceFilter resourceFilter;
 
 	public SearchSettings(String searchString) {
 		this.searchString = searchString;
@@ -49,6 +52,11 @@ public class SearchSettings {
 			searchPackage = pkg.getJavaNode();
 		}
 		searchMethod = ISearchMethod.build(this);
+		try {
+			resourceFilter = ResourceFilter.parse(resFilterStr);
+		} catch (InvalidDataException e) {
+			return "Invalid resource file filter: " + e.getMessage();
+		}
 		return null;
 	}
 
@@ -112,12 +120,12 @@ public class SearchSettings {
 		return searchMethod;
 	}
 
-	public String getResFilterStr() {
-		return resFilterStr;
-	}
-
 	public void setResFilterStr(String resFilterStr) {
 		this.resFilterStr = resFilterStr;
+	}
+
+	public ResourceFilter getResourceFilter() {
+		return resourceFilter;
 	}
 
 	public int getResSizeLimit() {

--- a/jadx-gui/src/main/java/jadx/gui/search/providers/ResourceFilter.java
+++ b/jadx-gui/src/main/java/jadx/gui/search/providers/ResourceFilter.java
@@ -1,0 +1,102 @@
+package jadx.gui.search.providers;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import jadx.api.resources.ResourceContentType;
+import jadx.core.utils.Utils;
+import jadx.core.utils.exceptions.InvalidDataException;
+
+import static jadx.api.resources.ResourceContentType.CONTENT_BINARY;
+import static jadx.api.resources.ResourceContentType.CONTENT_TEXT;
+
+public class ResourceFilter {
+
+	private static final ResourceFilter ANY = new ResourceFilter(Set.of(), Set.of());
+
+	private static final String VAR_TEXT = "$TEXT";
+	private static final String VAR_BIN = "$BIN";
+
+	public static final String DEFAULT_STR = VAR_TEXT;
+
+	public static ResourceFilter parse(String filterStr) {
+		String str = filterStr.trim();
+		if (str.isEmpty() || str.equals("*")) {
+			return ANY;
+		}
+		Set<ResourceContentType> contentTypes = EnumSet.noneOf(ResourceContentType.class);
+		Set<String> extSet = new LinkedHashSet<>();
+		String[] parts = filterStr.split("[|, ]");
+		for (String part : parts) {
+			if (part.isEmpty()) {
+				continue;
+			}
+			if (part.startsWith("$")) {
+				switch (part) {
+					case VAR_TEXT:
+						contentTypes.add(CONTENT_TEXT);
+						break;
+					case VAR_BIN:
+						contentTypes.add(CONTENT_BINARY);
+						break;
+					default:
+						throw new InvalidDataException("Unknown var name: " + part);
+				}
+			} else {
+				extSet.add(part);
+			}
+		}
+		return new ResourceFilter(contentTypes, extSet);
+	}
+
+	public static String format(ResourceFilter filter) {
+		if (filter.isAnyFile()) {
+			return "*";
+		}
+		List<String> list = new ArrayList<>();
+		Set<ResourceContentType> types = filter.getContentTypes();
+		if (types.contains(CONTENT_TEXT)) {
+			list.add(VAR_TEXT);
+		}
+		if (types.contains(CONTENT_BINARY)) {
+			list.add(VAR_BIN);
+		}
+		list.addAll(filter.getExtSet());
+		return Utils.listToString(list, "|");
+	}
+
+	public static String withContentType(String filterStr, Set<ResourceContentType> contentTypes) {
+		ResourceFilter filter = parse(filterStr);
+		return format(new ResourceFilter(contentTypes, filter.getExtSet()));
+	}
+
+	private final boolean anyFile;
+	private final Set<ResourceContentType> contentTypes;
+	private final Set<String> extSet;
+
+	private ResourceFilter(Set<ResourceContentType> contentTypes, Set<String> extSet) {
+		this.anyFile = contentTypes.isEmpty() && extSet.isEmpty();
+		this.contentTypes = contentTypes.isEmpty() ? Set.of() : contentTypes;
+		this.extSet = extSet.isEmpty() ? Set.of() : extSet;
+	}
+
+	public boolean isAnyFile() {
+		return anyFile;
+	}
+
+	public Set<ResourceContentType> getContentTypes() {
+		return contentTypes;
+	}
+
+	public Set<String> getExtSet() {
+		return extSet;
+	}
+
+	@Override
+	public String toString() {
+		return format(this);
+	}
+}

--- a/jadx-gui/src/main/java/jadx/gui/search/providers/ResourceSearchProvider.java
+++ b/jadx-gui/src/main/java/jadx/gui/search/providers/ResourceSearchProvider.java
@@ -4,8 +4,6 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.Set;
 
 import javax.swing.tree.TreeNode;
 
@@ -16,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import jadx.api.ResourceFile;
 import jadx.api.ResourceType;
 import jadx.api.plugins.utils.CommonFileUtils;
+import jadx.api.resources.ResourceContentType;
 import jadx.api.utils.CodeUtils;
 import jadx.gui.jobs.Cancelable;
 import jadx.gui.search.ISearchProvider;
@@ -32,10 +31,9 @@ public class ResourceSearchProvider implements ISearchProvider {
 	private static final Logger LOG = LoggerFactory.getLogger(ResourceSearchProvider.class);
 
 	private final SearchSettings searchSettings;
-	private final Set<String> extSet;
 	private final SearchDialog searchDialog;
+	private final ResourceFilter resourceFilter;
 	private final int sizeLimit;
-	private boolean anyExt;
 
 	/**
 	 * Resources queue for process. Using UI nodes to reuse loading cache
@@ -48,7 +46,7 @@ public class ResourceSearchProvider implements ISearchProvider {
 
 	public ResourceSearchProvider(MainWindow mw, SearchSettings searchSettings, SearchDialog searchDialog) {
 		this.searchSettings = searchSettings;
-		this.extSet = buildAllowedFilesExtensions(searchSettings.getResFilterStr());
+		this.resourceFilter = searchSettings.getResourceFilter();
 		this.sizeLimit = searchSettings.getResSizeLimit() * 1024 * 1024;
 		this.searchDialog = searchDialog;
 		JResource activeResource = searchSettings.getActiveResource();
@@ -95,12 +93,20 @@ public class ResourceSearchProvider implements ISearchProvider {
 		if (newPos == -1) {
 			return null;
 		}
-		int lineStart = 1 + CodeUtils.getNewLinePosBefore(content, newPos);
-		int lineEnd = CodeUtils.getNewLinePosAfter(content, newPos);
-		int end = lineEnd == -1 ? content.length() : lineEnd;
-		String line = content.substring(lineStart, end);
-		this.pos = end;
-		return new JResSearchNode(resNode, line.trim(), newPos);
+		if (resNode.getContentType() == ResourceContentType.CONTENT_TEXT) {
+			int lineStart = 1 + CodeUtils.getNewLinePosBefore(content, newPos);
+			int lineEnd = CodeUtils.getNewLinePosAfter(content, newPos);
+			int end = lineEnd == -1 ? content.length() : lineEnd;
+			String line = content.substring(lineStart, end);
+			this.pos = end;
+			return new JResSearchNode(resNode, line.trim(), newPos);
+		} else {
+			int start = Math.max(0, newPos - 30);
+			int end = Math.min(newPos + 50, content.length());
+			String line = content.substring(start, end);
+			this.pos = newPos + searchString.length() + 1;
+			return new JResSearchNode(resNode, line, newPos);
+		}
 	}
 
 	private @Nullable JResource getNextResFile(Cancelable cancelable) {
@@ -167,39 +173,23 @@ public class ResourceSearchProvider implements ISearchProvider {
 		return deque;
 	}
 
-	private Set<String> buildAllowedFilesExtensions(String srhResourceFileExt) {
-		String str = srhResourceFileExt.trim();
-		if (str.isEmpty() || str.equals("*")) {
-			anyExt = true;
-			return Collections.emptySet();
-		}
-		Set<String> set = new HashSet<>();
-		for (String extStr : str.split("[|.]")) {
-			String ext = extStr.trim();
-			if (!ext.isEmpty()) {
-				anyExt = ext.equals("*");
-				if (anyExt) {
-					break;
-				}
-				set.add(ext);
-			}
-		}
-		return set;
-	}
-
 	private boolean shouldProcess(JResource resNode) {
 		ResourceFile resFile = resNode.getResFile();
 		if (resFile.getType() == ResourceType.ARSC) {
 			// don't check size of generated resource table, it will also skip all sub files
-			return anyExt || extSet.contains("xml");
+			return resourceFilter.isAnyFile() || resourceFilter.getExtSet().contains("xml");
 		}
-		if (!anyExt) {
-			String fileExt = CommonFileUtils.getFileExtension(resFile.getOriginalName());
-			if (fileExt == null) {
-				return false;
-			}
-			if (!extSet.contains(fileExt)) {
-				return false;
+		if (!resourceFilter.isAnyFile()) {
+			if (resourceFilter.getContentTypes().contains(resNode.getContentType())) {
+				// accept
+			} else {
+				String fileExt = CommonFileUtils.getFileExtension(resFile.getOriginalName());
+				if (fileExt == null) {
+					return false;
+				}
+				if (!resourceFilter.getExtSet().contains(fileExt)) {
+					return false;
+				}
 			}
 		}
 		if (sizeLimit <= 0) {

--- a/jadx-gui/src/main/java/jadx/gui/settings/data/ProjectData.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/data/ProjectData.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import org.jetbrains.annotations.Nullable;
 
 import jadx.api.data.impl.JadxCodeData;
+import jadx.gui.search.providers.ResourceFilter;
 
 public class ProjectData {
 	private int projectVersion = 2;
@@ -22,7 +23,7 @@ public class ProjectData {
 	private @Nullable String cacheDir; // don't use relative path adapter
 	private boolean enableLiveReload = false;
 	private List<String> searchHistory = new ArrayList<>();
-	private String searchResourcesFilter = "*";
+	private String searchResourcesFilter = ResourceFilter.DEFAULT_STR;
 	private int searchResourcesSizeLimit = 0; // in MB
 
 	protected Map<String, String> pluginOptions = new HashMap<>();

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JNode.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JNode.java
@@ -17,6 +17,7 @@ import jadx.api.ICodeInfo;
 import jadx.api.JavaNode;
 import jadx.api.gui.tree.ITreeNode;
 import jadx.api.metadata.ICodeNodeRef;
+import jadx.api.resources.ResourceContentType;
 import jadx.core.utils.ListUtils;
 import jadx.gui.ui.MainWindow;
 import jadx.gui.ui.panel.ContentPanel;
@@ -54,6 +55,10 @@ public abstract class JNode extends DefaultMutableTreeNode implements ITreeNode,
 
 	public ICodeInfo getCodeInfo() {
 		return ICodeInfo.EMPTY;
+	}
+
+	public ResourceContentType getContentType() {
+		return ResourceContentType.CONTENT_TEXT;
 	}
 
 	public boolean isEditable() {

--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
@@ -1,5 +1,7 @@
 package jadx.gui.treemodel;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -17,6 +19,7 @@ import jadx.api.ResourceFile;
 import jadx.api.ResourceType;
 import jadx.api.ResourcesLoader;
 import jadx.api.impl.SimpleCodeInfo;
+import jadx.api.resources.ResourceContentType;
 import jadx.core.utils.ListUtils;
 import jadx.core.utils.Utils;
 import jadx.core.xmlgen.ResContainer;
@@ -185,11 +188,16 @@ public class JResource extends JLoadableNode {
 		return codeInfo;
 	}
 
+	@Override
+	public ResourceContentType getContentType() {
+		if (type == JResType.FILE) {
+			return resFile.getType().getContentType();
+		}
+		return ResourceContentType.CONTENT_NONE;
+	}
+
 	private ICodeInfo loadContent() {
 		if (resFile == null || type != JResType.FILE) {
-			return ICodeInfo.EMPTY;
-		}
-		if (!isSupportedForView(resFile.getType())) {
 			return ICodeInfo.EMPTY;
 		}
 		ResContainer rc = resFile.loadContent();
@@ -216,11 +224,20 @@ public class JResource extends JLoadableNode {
 
 			case RES_LINK:
 				try {
-					return ResourcesLoader.decodeStream(rc.getResLink(), (size, is) -> {
+					ResourceFile resourceFile = rc.getResLink();
+					return ResourcesLoader.decodeStream(resourceFile, (size, is) -> {
+						// TODO: check size before loading
 						if (size > 10 * 1024 * 1024L) {
 							return new SimpleCodeInfo("File too large for view");
 						}
-						return ResourcesLoader.loadToCodeWriter(is);
+						Charset charset;
+						if (resourceFile.getType().getContentType() == ResourceContentType.CONTENT_BINARY) {
+							// force one byte charset for binary data to have the same offsets as in a byte array
+							charset = StandardCharsets.US_ASCII;
+						} else {
+							charset = StandardCharsets.UTF_8;
+						}
+						return ResourcesLoader.loadToCodeWriter(is, charset);
 					});
 				} catch (Exception e) {
 					return new SimpleCodeInfo("Failed to load resource file:\n" + Utils.getStackTrace(e));

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -990,13 +990,15 @@ public class MainWindow extends JFrame {
 		ContentPanel panel = tabbedPane.getSelectedContentPanel();
 		if (panel instanceof AbstractCodeContentPanel) {
 			AbstractCodeArea codeArea = ((AbstractCodeContentPanel) panel).getCodeArea();
-			String preferText = codeArea.getSelectedText();
-			if (StringUtils.isEmpty(preferText)) {
-				preferText = codeArea.getWordUnderCaret();
-			}
-			if (!StringUtils.isEmpty(preferText)) {
-				SearchDialog.searchText(MainWindow.this, preferText);
-				return;
+			if (codeArea != null) {
+				String preferText = codeArea.getSelectedText();
+				if (StringUtils.isEmpty(preferText)) {
+					preferText = codeArea.getWordUnderCaret();
+				}
+				if (!StringUtils.isEmpty(preferText)) {
+					SearchDialog.searchText(MainWindow.this, preferText);
+					return;
+				}
 			}
 		}
 		SearchDialog.search(MainWindow.this, SearchDialog.SearchPreset.TEXT);

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeContentPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/AbstractCodeContentPanel.java
@@ -2,6 +2,8 @@ package jadx.gui.ui.codearea;
 
 import java.awt.Component;
 
+import org.jetbrains.annotations.Nullable;
+
 import jadx.gui.treemodel.JNode;
 import jadx.gui.ui.panel.ContentPanel;
 import jadx.gui.ui.tab.TabbedPane;
@@ -16,7 +18,15 @@ public abstract class AbstractCodeContentPanel extends ContentPanel {
 		super(panel, jnode);
 	}
 
-	public abstract AbstractCodeArea getCodeArea();
+	public abstract @Nullable AbstractCodeArea getCodeArea();
 
 	public abstract Component getChildrenComponent();
+
+	public void scrollToPos(int pos) {
+		AbstractCodeArea codeArea = getCodeArea();
+		if (codeArea != null) {
+			codeArea.requestFocus();
+			codeArea.scrollToPos(pos);
+		}
+	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/BinaryContentPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/BinaryContentPanel.java
@@ -115,6 +115,16 @@ public class BinaryContentPanel extends AbstractCodeContentPanel {
 	}
 
 	@Override
+	public void scrollToPos(int pos) {
+		Component codePanel = getSelectedPanel();
+		if (codePanel instanceof CodeArea) {
+			textCodePanel.getCodeArea().scrollToPos(pos);
+		} else {
+			hexPreviewPanel.scrollToOffset(pos);
+		}
+	}
+
+	@Override
 	public Component getChildrenComponent() {
 		return getSelectedPanel();
 	}

--- a/jadx-gui/src/main/java/jadx/gui/ui/hexviewer/HexPreviewPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/hexviewer/HexPreviewPanel.java
@@ -135,6 +135,12 @@ public class HexPreviewPanel extends JPanel {
 		}
 	}
 
+	public void scrollToOffset(int pos) {
+		hexCodeArea.setSelection(pos, pos + 1);
+		hexCodeArea.setActiveCaretPosition(pos);
+		hexCodeArea.centerOnPosition(hexCodeArea.getActiveCaretPosition());
+	}
+
 	public void enableUpdate() {
 		CodeAreaCaretListener caretMovedListener = (CodeAreaCaretPosition caretPosition) -> updateValues();
 		hexCodeArea.addCaretMovedListener(caretMovedListener);

--- a/jadx-gui/src/main/java/jadx/gui/ui/panel/ContentPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/panel/ContentPanel.java
@@ -41,6 +41,9 @@ public abstract class ContentPanel extends JPanel {
 		return node;
 	}
 
+	public void scrollToPos(int pos) {
+	}
+
 	/**
 	 * Allows to show a tool tip on the tab e.g. for displaying a long path of the
 	 * selected entry inside the APK file.

--- a/jadx-gui/src/main/java/jadx/gui/ui/tab/TabbedPane.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/tab/TabbedPane.java
@@ -238,11 +238,7 @@ public class TabbedPane extends JTabbedPane implements ITabStatesListener {
 			LOG.warn("Ignore zero jump!", new JadxRuntimeException());
 			return;
 		}
-		if (contentPanel instanceof AbstractCodeContentPanel) {
-			AbstractCodeArea codeArea = ((AbstractCodeContentPanel) contentPanel).getCodeArea();
-			codeArea.requestFocus();
-			codeArea.scrollToPos(pos);
-		}
+		contentPanel.scrollToPos(pos);
 	}
 
 	public void selectTab(ContentPanel contentPanel) {
@@ -259,7 +255,7 @@ public class TabbedPane extends JTabbedPane implements ITabStatesListener {
 		} else {
 			selectTab(panel);
 		}
-		ClassCodeContentPanel codePane = ((ClassCodeContentPanel) panel);
+		ClassCodeContentPanel codePane = (ClassCodeContentPanel) panel;
 		codePane.showSmaliPane();
 		SmaliArea smaliArea = (SmaliArea) codePane.getSmaliCodeArea();
 		if (debugMode) {
@@ -272,7 +268,10 @@ public class TabbedPane extends JTabbedPane implements ITabStatesListener {
 	public @Nullable JumpPosition getCurrentPosition() {
 		ContentPanel selectedCodePanel = getSelectedContentPanel();
 		if (selectedCodePanel instanceof AbstractCodeContentPanel) {
-			return ((AbstractCodeContentPanel) selectedCodePanel).getCodeArea().getCurrentPosition();
+			AbstractCodeArea codeArea = ((AbstractCodeContentPanel) selectedCodePanel).getCodeArea();
+			if (codeArea != null) {
+				return codeArea.getCurrentPosition();
+			}
 		}
 		return null;
 	}

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -179,6 +179,8 @@ search_dialog.resource=Ressource
 search_dialog.keep_open=Offen halten
 search_dialog.tip_searching=Suchen…
 search_dialog.limit_package=Begrenzung auf Paket:
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 search_dialog.package_not_found=Kein passendes Paket gefunden
 search_dialog.copy=alles kopieren
 

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -179,6 +179,8 @@ search_dialog.resource=Resource
 search_dialog.keep_open=Keep open
 search_dialog.tip_searching=Searching
 search_dialog.limit_package=Limit to package:
+search_dialog.res_text=Text
+search_dialog.res_binary=Binary
 search_dialog.package_not_found=No matching package found
 search_dialog.copy=Copy All
 

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -179,6 +179,8 @@ search_dialog.regex=Regex
 #search_dialog.keep_open=Keep open
 #search_dialog.tip_searching=Searching
 #search_dialog.limit_package=Limit to package:
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 #search_dialog.package_not_found=No matching package found
 search_dialog.copy=copiar todo
 

--- a/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
@@ -179,6 +179,8 @@ search_dialog.resource=Sumber daya
 search_dialog.keep_open=Tetap terbuka
 search_dialog.tip_searching=Mencari
 #search_dialog.limit_package=Limit to package:
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 #search_dialog.package_not_found=No matching package found
 search_dialog.copy=salin semua
 

--- a/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
@@ -179,6 +179,8 @@ search_dialog.resource=리소스
 search_dialog.keep_open=열어 두기
 search_dialog.tip_searching=검색 중...
 #search_dialog.limit_package=Limit to package:
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 #search_dialog.package_not_found=No matching package found
 search_dialog.copy=모두 복사
 

--- a/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
@@ -179,6 +179,8 @@ search_dialog.resource=Recursos
 search_dialog.keep_open=Manter aberto
 search_dialog.tip_searching=Buscando
 #search_dialog.limit_package=Limit to package:
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 #search_dialog.package_not_found=No matching package found
 search_dialog.copy=skopiuj wszystko
 

--- a/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
@@ -179,6 +179,8 @@ search_dialog.resource=Ресурсы
 search_dialog.keep_open=Оставлять поиск открытым
 search_dialog.tip_searching=Поиск...
 #search_dialog.limit_package=Limit to package:
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 #search_dialog.package_not_found=No matching package found
 search_dialog.copy=скопировать все
 

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -179,6 +179,8 @@ search_dialog.resource=资源
 search_dialog.keep_open=保持窗口
 search_dialog.tip_searching=搜索中…
 search_dialog.limit_package=限制package：
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 search_dialog.package_not_found=没有找到匹配的package
 search_dialog.copy=复制全部
 

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
@@ -179,6 +179,8 @@ search_dialog.resource=資源
 search_dialog.keep_open=保持開啟
 search_dialog.tip_searching=正在搜尋
 search_dialog.limit_package=限制至套件：
+#search_dialog.res_text=Text
+#search_dialog.res_binary=Binary
 search_dialog.package_not_found=找不到符合的套件
 search_dialog.copy=複製全部
 


### PR DESCRIPTION
New checkboxes to add a `variable` into resource file filter field.
`$TEXT` for text files, `$BIN` for binary. Content type field added to `ResourceType` enum.
Filter field can be edited manually, checkboxes will add/remove variables without resetting current values.
`$TEXT` now a default filter string for resources.

![screenshot_2025-06-04-004442](https://github.com/user-attachments/assets/bf34f64f-ed73-4c40-bb02-f22bdfd1d126)

Also, some improvement and fixes done to allow search in binary files:
- scroll to position in hex viewer
- using one byte charset to binary files to match offsets in byte array (and hex viewer)

Resolves issues from #2522