### PR TITLE
Change let to var in Frida script

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/action/FridaAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/action/FridaAction.java
@@ -136,7 +136,7 @@ public final class FridaAction extends JNodeAction {
 		JavaClass javaClass = jc.getCls();
 		String rawClassName = StringEscapeUtils.escapeEcmaScript(javaClass.getRawName());
 		String shortClassName = javaClass.getName();
-		return String.format("let %s = Java.use(\"%s\");", shortClassName, rawClassName);
+		return String.format("var %s = Java.use(\"%s\");", shortClassName, rawClassName);
 	}
 
 	private void showMethodSelectionDialog(JClass jc) {


### PR DESCRIPTION
### Description

When generating Frida hooks, the generated scripts use 'let' for the class reference. Since you're typically prototyping different hooks and copy/pasting the hooks into your script, these let statements clash. Using `var` instead of `let` for the class definition fixes this.

Alternatively we could wrap the generated code in a code block, but this var approach makes more sense to me.
