### PR TITLE
chore: disable targetSDKVersion checks in AndroidStudio

### DIFF
--- a/jadx-core/src/main/resources/export/android/app.build.gradle.tmpl
+++ b/jadx-core/src/main/resources/export/android/app.build.gradle.tmpl
@@ -9,6 +9,7 @@ android {
     defaultConfig {
         applicationId '{{applicationId}}'
         minSdkVersion {{minSdkVersion}}
+        //noinspection ExpiredTargetSdkVersion
         targetSdkVersion {{targetSdkVersion}}
         versionCode {{versionCode}}
         versionName "{{versionName}}"


### PR DESCRIPTION
Android Studio is pretty picky regarding the targetSDKVersion of a loaded project as Google accepts only recent versions when publishing in PlayStore. For older targetSDKVersions AndroidStudio even refuses to load/build a project. 

As PlayStore publishing is usually not a target when using a Jadx exported project, it is better to disable this targetSDKVersion check as shown in this Stackoverflow post: https://stackoverflow.com/q/55260233/150978.

It is a bit strange that a comment is used for that, but who cares if it works ;)