### PR TITLE
Add missing `ExpiringTargetSdkVersion` in #2533

### DIFF
--- a/jadx-core/src/main/resources/export/android/app.build.gradle.tmpl
+++ b/jadx-core/src/main/resources/export/android/app.build.gradle.tmpl
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId '{{applicationId}}'
         minSdkVersion {{minSdkVersion}}
-        //noinspection ExpiredTargetSdkVersion
+        //noinspection ExpiringTargetSdkVersion,ExpiredTargetSdkVersion
         targetSdkVersion {{targetSdkVersion}}
         versionCode {{versionCode}}
         versionName "{{versionName}}"


### PR DESCRIPTION
:exclamation: Please review the [guidelines for contributing](https://github.com/skylot/jadx/blob/master/CONTRIBUTING.md#Pull-Request-Process)

### Description
- Extended the existing lint suppression for `ExpiredTargetSdkVersion` to also include `ExpiringTargetSdkVersion`.
- This ensures that both current and near-future target SDK deprecation warnings are suppressed during builds.
- Keeps the project clean from unnecessary lint noise while maintaining control over SDK updates.