### PR TITLE
Minor UI fixes

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -2,6 +2,7 @@ package jadx.gui.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.DisplayMode;
 import java.awt.Font;
@@ -1297,7 +1298,13 @@ public class MainWindow extends JFrame {
 			uiWatchDog.setState(UIWatchDog.onStart());
 			help.add(uiWatchDog);
 		}
-		help.add(aboutAction);
+
+		if (SystemInfo.IS_MAC) {
+			System.setProperty("apple.laf.useScreenMenuBar", "true");
+			Desktop.getDesktop().setAboutHandler(e -> aboutAction.actionPerformed(null));
+		} else {
+			help.add(aboutAction);
+		}
 
 		menuBar = new JadxMenuBar();
 		menuBar.add(file);

--- a/jadx-gui/src/main/java/jadx/gui/ui/dialog/AboutDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/dialog/AboutDialog.java
@@ -3,7 +3,6 @@ package jadx.gui.ui.dialog;
 import java.awt.BorderLayout;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.net.URL;
 
 import javax.swing.BorderFactory;
@@ -29,21 +28,16 @@ public class AboutDialog extends JDialog {
 	}
 
 	public final void initUI() {
-		Font font = new Font("Serif", Font.BOLD, 13);
-
 		URL logoURL = getClass().getResource("/logos/jadx-logo-48px.png");
-		Icon logo = new ImageIcon(logoURL, "jadx logo");
+		Icon logo = new ImageIcon(logoURL, "JADX logo");
 
-		JLabel name = new JLabel("jadx", logo, SwingConstants.CENTER);
-		name.setFont(font);
+		JLabel name = new JLabel("JADX", logo, SwingConstants.CENTER);
 		name.setAlignmentX(0.5f);
 
 		JLabel desc = new JLabel("Dex to Java decompiler");
-		desc.setFont(font);
 		desc.setAlignmentX(0.5f);
 
-		JLabel version = new JLabel("jadx version: " + JadxDecompiler.getVersion());
-		version.setFont(font);
+		JLabel version = new JLabel("JADX version: " + JadxDecompiler.getVersion());
 		version.setAlignmentX(0.5f);
 
 		String javaVm = System.getProperty("java.vm.name");
@@ -52,12 +46,10 @@ public class AboutDialog extends JDialog {
 		javaVm = javaVm == null ? "" : javaVm;
 
 		JLabel javaVmLabel = new JLabel("Java VM: " + javaVm);
-		javaVmLabel.setFont(font);
 		javaVmLabel.setAlignmentX(0.5f);
 
 		javaVer = javaVer == null ? "" : javaVer;
 		JLabel javaVerLabel = new JLabel("Java version: " + javaVer);
-		javaVerLabel.setFont(font);
 		javaVerLabel.setAlignmentX(0.5f);
 
 		JPanel textPane = new JPanel();

--- a/jadx-gui/src/main/java/jadx/gui/ui/dialog/CommonSearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/dialog/CommonSearchDialog.java
@@ -5,6 +5,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Font;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -380,6 +381,15 @@ public abstract class CommonSearchDialog extends JFrame {
 		@Override
 		public Object getValueAt(int row, int column) {
 			return model.getValueAt(row, column);
+		}
+
+		@Override
+		public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
+			// ResultsTable only has two wide columns, the default increment is way too fast
+			if (orientation == SwingConstants.HORIZONTAL) {
+				return 30;
+			}
+			return super.getScrollableUnitIncrement(visibleRect, orientation, direction);
 		}
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/dialog/SearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/dialog/SearchDialog.java
@@ -556,7 +556,7 @@ public class SearchDialog extends CommonSearchDialog {
 					searchEmitter.getFlowable()));
 		}
 		searchDisposable = searchEvents
-				.debounce(50, TimeUnit.MILLISECONDS)
+				.debounce(100, TimeUnit.MILLISECONDS)
 				.observeOn(Schedulers.from(searchBackgroundExecutor))
 				.subscribe(t -> this.search(searchField.getText()));
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/tab/TabbedPane.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/tab/TabbedPane.java
@@ -86,12 +86,7 @@ public class TabbedPane extends JTabbedPane implements ITabStatesListener {
 			int index = getSelectedIndex();
 			int maxIndex = getTabCount() - 1;
 			index += direction;
-			// switch between first tab <-> last tab
-			if (index < 0) {
-				index = maxIndex;
-			} else if (index > maxIndex) {
-				index = 0;
-			}
+			index = Math.max(0, Math.min(maxIndex, index));
 			try {
 				setSelectedIndex(index);
 			} catch (IndexOutOfBoundsException e) {


### PR DESCRIPTION
A few minor UI tweaks and fixes.

1. Use system menu bar on macOS, there's no reason to make the user to set `apple.laf.useScreenMenuBar` manually in a custom script.
2. Everything else uses sans font so `AboutDialog` should probably do that too.
3. `GetScrollableUnitIncrement` calculates the horizontal unit increment by column size, so horizontal scrolling is way too fast if you have only a few very wide columns. Override this to a sensible value.
4. The result table has some very bad flickering with auto search enabled, I've increased the debounce timer a little without making it feel sluggish.
5. The wrap-around behavior for tab scrolling is very annoying if you have a large list of tabs open. This could be made configurable but no other text editors or web browsers with tabs does this, it's probably easier to just disable it for now.