### PR TITLE
fix: use proper newlines when generating cfg from backup

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/DotGraphVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/DotGraphVisitor.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 import jadx.api.ICodeWriter;
 import jadx.api.impl.SimpleCodeWriter;
@@ -30,6 +31,7 @@ import static jadx.core.codegen.MethodGen.FallbackOption.BLOCK_DUMP;
 public class DotGraphVisitor extends AbstractVisitor {
 
 	private static final String NL = "\\l";
+	private static final String NLQR = Matcher.quoteReplacement(NL);
 	private static final boolean PRINT_DOMINATORS = false;
 	private static final boolean PRINT_DOMINATORS_INFO = false;
 
@@ -324,7 +326,7 @@ public class DotGraphVisitor extends AbstractVisitor {
 					.replace("\"", "\\\"")
 					.replace("-", "\\-")
 					.replace("|", "\\|")
-					.replaceAll("\\R", NL);
+					.replaceAll("\\R", NLQR);
 		}
 	}
 }


### PR DESCRIPTION
As described in #2588 there is an issue when generating the CFG. This PR fixes that issue by using `Matcher.quoteReplacement()` as suggested in the Java documentation.

I also noticed a bug where there is a missing space between "CFG for" and the function path in the title. I wasn't sure whether I should put that in a separate pull request.

I'm quite new to contributing to OSS, so I apologize if I don't know the proper procedures for all this.
