### PR TITLE
fix: avoid false positive throws (regression of PR #2475)

### DIFF
--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestThrows.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestThrows.java
@@ -2,6 +2,7 @@ package jadx.tests.integration.others;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
 
@@ -72,6 +73,20 @@ public class TestThrows extends IntegrationTest {
 				doSomething1(i);
 			}
 		}
+
+		public void noThrownExceptions1(InputStream i1) {
+			try {
+				i1.close();
+			} catch (IOException ignore) {
+			}
+		}
+
+		public void noThrownExceptions2() {
+			try {
+				throw new FileNotFoundException("");
+			} catch (IOException ignore) {
+			}
+		}
 	}
 
 	@Test
@@ -87,6 +102,9 @@ public class TestThrows extends IntegrationTest {
 				.containsOne("throwThrowable() throws Throwable {")
 				.containsOne("exceptionSource() throws FileNotFoundException {")
 				.containsOne("mergeThrownExceptions() throws IOException {")
-				.containsOne("rethrowThrowable() {");
+				.containsOne("rethrowThrowable() {")
+				.containsOne("noThrownExceptions1(InputStream i1) {")
+				.containsOne("noThrownExceptions2() {");
+
 	}
 }


### PR DESCRIPTION
I'd like to fix a regression I introduced with PR #2475. In two cases a check for excluded exceptions was missing. This may cause compiler errors in overridden methods.

## Steps to reproduce

Recompile the app https://saper-minesweeper.apk.gold/

There are errors in `LionheartGames.Saper.SaperActivity` due to thrown exceptions (false positives).

### Detailed instructions:

Download apk from https://apk.gold/download?file_id=263903/saper-minesweeper

Recompile with:

```sh
jadx -e Saper-1.4.apk 
cd Saper-1.4
# Workaround for R-file conflicts, R files should not be generated in recompilation mode. 
# This should be fixed for a better out-of-the box experience.
mv app/src/main/java/LionheartGames/Saper/R.java app/src/main/java/LionheartGames/Saper/R.java.bak
gradle wrapper --gradle-version 8.13
./gradlew assembleDebug
```

After applying the PR this app can be recompiled and installed without errors. Recompiled game is playable.

