### PR TITLE
fix: Error decode xml (manifest) when parsing an APK file containing …

### DIFF
--- a/jadx-plugins/jadx-aab-input/src/main/java/jadx/plugins/input/aab/factories/ProtoXmlResContainerFactory.java
+++ b/jadx-plugins/jadx-aab-input/src/main/java/jadx/plugins/input/aab/factories/ProtoXmlResContainerFactory.java
@@ -32,7 +32,7 @@ public class ProtoXmlResContainerFactory implements IResContainerFactory {
 		if (zipEntry == null) {
 			return null;
 		}
-		boolean isFromAab = zipEntry.getZipFile().getPath().contains(".aab");
+		boolean isFromAab = zipEntry.getZipFile().getPath().toLowerCase().endsWith(".aab");
 		if (!isFromAab) {
 			return null;
 		}


### PR DESCRIPTION
This PR is simple and solves the XML parsing failure issue when the APK path contains `.aab` files. The problem lies in incorrectly determining whether the file is from an aab file.
Our project converts `app.aab` to `app.aab.apks` upon build completion and then installs these APKs. However, I wanted to verify that the APK code was correct and unzipped `app.aab.apks` to the default `app.aab` folder, but encountered an XML parsing failure.

stack trace:
``` java 
Error decode manifest
com.google.protobuf.InvalidProtocolBufferException: Protocol message contained an invalid tag (zero).
	at com.google.protobuf.InvalidProtocolBufferException.invalidTag(InvalidProtocolBufferException.java:110)
	at com.google.protobuf.CodedInputStream$ArrayDecoder.readTag(CodedInputStream.java:607)
	at com.android.aapt.Resources$XmlNode$Builder.mergeFrom(Resources.java:44113)
	at com.android.aapt.Resources$XmlNode$1.parsePartialFrom(Resources.java:44594)
	at com.android.aapt.Resources$XmlNode$1.parsePartialFrom(Resources.java:44586)
	at com.google.protobuf.AbstractParser.parsePartialFrom(AbstractParser.java:135)
	at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:168)
	at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:180)
	at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:185)
	at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:25)
	at com.android.aapt.Resources$XmlNode.parseFrom(Resources.java:43897)
	at jadx.plugins.input.aab.parsers.ResXmlProtoParser.decodeProto(ResXmlProtoParser.java:219)
	at jadx.plugins.input.aab.parsers.ResXmlProtoParser.parse(ResXmlProtoParser.java:45)
	at jadx.plugins.input.aab.factories.ProtoXmlResContainerFactory.create(ProtoXmlResContainerFactory.java:38)
```