### PR TITLE
Invalid cast for overloaded method

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/nodes/utils/TypeUtils.java
+++ b/jadx-core/src/main/java/jadx/core/dex/nodes/utils/TypeUtils.java
@@ -242,9 +242,9 @@ public class TypeUtils {
 		}
 		Map<ArgType, ArgType> map = new HashMap<>(1 + invokeInsn.getArgsCount());
 		addTypeVarMapping(map, mthDetails.getReturnType(), invokeInsn.getResult());
-		int argCount = Math.min(mthDetails.getArgTypes().size(), invokeInsn.getArgsCount());
+		int argCount = Math.min(mthDetails.getArgTypes().size(), invokeInsn.getArgsCount() - invokeInsn.getFirstArgOffset());
 		for (int i = 0; i < argCount; i++) {
-			addTypeVarMapping(map, mthDetails.getArgTypes().get(i), invokeInsn.getArg(i));
+			addTypeVarMapping(map, mthDetails.getArgTypes().get(i), invokeInsn.getArg(i + invokeInsn.getFirstArgOffset()));
 		}
 		return map;
 	}

--- a/jadx-core/src/test/java/jadx/tests/integration/invoke/TestOverloadedMethodInvoke2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/invoke/TestOverloadedMethodInvoke2.java
@@ -1,0 +1,36 @@
+package jadx.tests.integration.invoke;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+import jadx.tests.api.utils.assertj.JadxAssertions;
+
+public class TestOverloadedMethodInvoke2 extends IntegrationTest {
+
+	public static class AbstractItem {
+
+		public void doSomething(Container c, Item i) {
+			c.add(i);
+		}
+
+		public static class Container {
+
+			public <T extends AbstractItem> int add(T t) {
+				return 0;
+			}
+
+			public void add(AbstractItem... item) {
+			}
+		}
+
+		public static class Item extends AbstractItem {
+		}
+	}
+
+	@Test
+	public void test() {
+		JadxAssertions.assertThat(getClassNode(TestOverloadedMethodInvoke2.AbstractItem.class))
+				.code().containsOne("c.add(i);")
+				.doesNotContain("(Container)");
+	}
+}


### PR DESCRIPTION
The latest git version of jadx decompiles this class (compiled with openjdk8)

```java

public class AbstractItem {

	public void doSomething(Container c, Item i) {
		c.add(i);
	}

	public static class Container {

		public <T extends AbstractItem> int add(T t) {
			return 0;
		}

		public void add(AbstractItem... item) {
		}
	}

	public static class Item extends AbstractItem {
	}
}

```

to

```java
public class AbstractItem {

	public void doSomething(Container c, Item i) {
		c.add((Container)i); // <-- invalid cast
	}

	public static class Container {

		public <T extends AbstractItem> int add(T t) {
			return 0;
		}

		public void add(AbstractItem... item) {
		}
	}

	public static class Item extends AbstractItem {
	}
}
```

It seems the arg offsets were not respected in `TypeUtils.getTypeVarMappingForInvoke()`. After adding the arg offset the cast was gone.