### PR TITLE
chore(gui): update obsolete issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/jadx-gui-issue.yml
+++ b/.github/ISSUE_TEMPLATE/jadx-gui-issue.yml
@@ -23,14 +23,14 @@ body:
     id: jadx-version
     attributes:
       label: Jadx version
-      placeholder: check `Help->About`
+      placeholder: check `JadxGUI->About JadxGUI`
     validations:
       required: true
   - type: input
     id: java-version
     attributes:
       label: Java version
-      placeholder: check `Help->About`
+      placeholder: check `JadxGUI->About JadxGUI`
     validations:
       required: true
   - type: checkboxes


### PR DESCRIPTION
### Description

While drafting some issue reports, I noticed that the Jadx GUI issue template is obsolete.
