### PR TITLE
Use length in header for checksum, fix error in Dex v41

### DIFF
--- a/jadx-plugins/jadx-dex-input/src/main/java/jadx/plugins/input/dex/utils/DexCheckSum.java
+++ b/jadx-plugins/jadx-dex-input/src/main/java/jadx/plugins/input/dex/utils/DexCheckSum.java
@@ -1,20 +1,20 @@
 package jadx.plugins.input.dex.utils;
 
-import java.nio.ByteBuffer;
 import java.util.zip.Adler32;
 
 import jadx.plugins.input.dex.DexException;
 
-import static java.nio.ByteOrder.LITTLE_ENDIAN;
-
 public class DexCheckSum {
 
 	public static void verify(String fileName, byte[] content, int offset) {
-		int len = ByteBuffer.wrap(content, offset + 32, 4).order(LITTLE_ENDIAN).getInt();
+		if (offset + 32 + 4 > content.length) {
+			throw new DexException("Dex file truncated, can't read file length, file: " + fileName);
+		}
+		int len = DataReader.readU4(content, offset + 32);
 		if (offset + len > content.length) {
 			throw new DexException("Dex file truncated, length in header: " + len + ", file: " + fileName);
 		}
-		int checksum = ByteBuffer.wrap(content, offset + 8, 4).order(LITTLE_ENDIAN).getInt();
+		int checksum = DataReader.readU4(content, offset + 8);
 		Adler32 adler32 = new Adler32();
 		adler32.update(content, offset + 12, len - 12);
 		int fileChecksum = (int) adler32.getValue();


### PR DESCRIPTION
Dex v41 (#2128) allows storing multiple dex files inside  a single container. Currently the checksum verification uses the whole file for calculation, which fails if there are multiple files inside a single dex, as the checksum only covers the dex entry that is immediately following the header, not the whole file which is actually 2 or more dex files. This leads to JADX failing to load services.jar in various Android 16 ROMs.

This passes all currently available tests, but I don't know if it will fail on ill-formed dex files out there, one can always disable checksum checking tho.

Example file (taking from Samsung OneUI 8.0): 
[services.zip](https://github.com/user-attachments/files/23840771/services.zip)
