### PR TITLE
Update README with Linux HiDPI workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Command line and GUI tools for producing Java source code from Android Dex and A
 - deobfuscator included
 
 **jadx-gui features:**
+
+> [!WARNING]
+> On Linux HiDPI systems, jadx may not scale correctly.<br>
+> As a workaround, start jadx with the environment variable `GDK_SCALE=2`.
+
 - view decompiled code with highlighted syntax
 - jump to declaration
 - find usage


### PR DESCRIPTION
Added warning for Linux HiDPI scaling issues happening on 4k displays.

This workaround was suggested in [this](https://github.com/skylot/jadx/issues/143#issuecomment-476587071) issue and has been verified by me on a Fedora machine with dual 4K displays.