### PR TITLE
fix: add more checks to better find handler's end

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/regions/maker/ExcHandlersRegionMaker.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/regions/maker/ExcHandlersRegionMaker.java
@@ -132,8 +132,18 @@ public class ExcHandlersRegionMaker {
 		if (dom.contains(AFlag.REMOVE)) {
 			return;
 		}
-		BitSet domFrontier = dom.getDomFrontier();
-		List<BlockNode> handlerExits = BlockUtils.bitSetToBlocks(mth, domFrontier);
+		List<BlockNode> handlerExits = new ArrayList<>();
+
+		BlockNode handlerOutBlock = BlockUtils.getTryAndHandlerCrossBlock(mth, handler);
+		if (handlerOutBlock != null) {
+			// ensure frontier's other predecessors comes from try end
+			handlerExits.add(handlerOutBlock);
+		} else {
+			// fallback to simple frontier
+			BitSet domFrontier = dom.getDomFrontier();
+			handlerExits.addAll(BlockUtils.bitSetToBlocks(mth, domFrontier));
+		}
+
 		boolean inLoop = mth.getLoopForBlock(start) != null;
 		for (BlockNode exit : handlerExits) {
 			if ((!inLoop || BlockUtils.isPathExists(start, exit))

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestIfInTryCatch.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestIfInTryCatch.java
@@ -1,0 +1,41 @@
+package jadx.tests.integration.trycatch;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+import jadx.tests.api.utils.assertj.JadxAssertions;
+
+public class TestIfInTryCatch extends IntegrationTest {
+	public static class TestCls {
+		private void test() {
+			/*
+			 * 1. if in try
+			 * 2. then branch is return
+			 * 3. after if, there's more blocks inside try
+			 * 4. after try, there's more blocks
+			 * this will result in if block and below moved out of try
+			 */
+			try {
+				if (getDouble() > 0.5) {
+					return;
+				}
+				System.out.println("after if");
+			} catch (Exception e) {
+				System.out.println("exception");
+			}
+			System.out.println("after try");
+		}
+
+		private static double getDouble() throws InterruptedException {
+			Thread.sleep(50L);
+			return Math.random();
+		}
+	}
+
+	@Test
+	public void test() {
+		// if ifBlock is moved out of try, there will be uncaught exception
+		JadxAssertions.assertThat(getClassNode(TestCls.class))
+				.code();
+	}
+}

--- a/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchInIf2.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/trycatch/TestTryCatchInIf2.java
@@ -1,0 +1,32 @@
+package jadx.tests.integration.trycatch;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+import jadx.tests.api.utils.assertj.JadxAssertions;
+
+// #2384
+public class TestTryCatchInIf2 extends IntegrationTest {
+	public static class TestCls {
+		public void test(Class<?> cls) {
+			Object obj = null;
+			if (cls != null) {
+				try {
+					obj = cls.getDeclaredConstructor().newInstance();
+				} catch (Exception e) {
+					System.out.println("error");
+				}
+			}
+			System.out.println("obj = " + obj);
+		}
+	}
+
+	@Test
+	public void test() {
+		// happens only without debug info and java version >= 10
+		noDebugInfo();
+		useTargetJavaVersion(10);
+		JadxAssertions.assertThat(getClassNode(TestCls.class))
+				.code();
+	}
+}


### PR DESCRIPTION
This pr add a method  BlockUtils.getTryAndHandlerCrossBlock(). It traverse domFrontier start from handler block, find the first frontier whose predecessor is try end.

This method is used in
- IfRegionMaker. If the IfRegion is inside try blocks, then its branches must end if they reach try end. In This case, next block of try end, which is the cross of try and handler, will be the if's outBlock. A Test (TestIfInTryCatch) is added.
- ExcHandlersRegionMaker, to try to find proper handler end. 
    - Related issue #2384. 
    - A mininal reproducible example Test (TestTryCatchInIf2) is added. 
    - <details><summary>cfg</summary> <img width="2457" height="1620" alt="1" src="https://github.com/user-attachments/assets/2c48259a-e3f0-4ec5-832c-2c2822d817a0" /></details>
    - in the smali, part of the handler region and else region use  a same block (B:7:0x0017). When finding handler region's end, [handler's domFrontier](https://github.com/skylot/jadx/blob/b725dd18b6ea7466fed47a6495a8491219cf0f21/jadx-core/src/main/java/jadx/core/dex/visitors/regions/maker/ExcHandlersRegionMaker.java#L135) (B:7:0x0017) is in the half of handler region, instead of the end. This pr uses BlockUtils.getTryAndHandlerCrossBlock() to go further to find the real end (B:8:0x0018).


