### PR TITLE
fix(gui): use FontUtils.getCompositeFont() that supports CJK

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/report/ExceptionDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/report/ExceptionDialog.java
@@ -3,7 +3,6 @@ package jadx.gui.report;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -119,7 +118,7 @@ public class ExceptionDialog extends JDialog {
 		JTextArea messageArea = new JTextArea();
 		TextStandardActions.attach(messageArea);
 		messageArea.setEditable(false);
-		messageArea.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
+		messageArea.setFont(mainWindow.getSettings().getCodeFont().deriveFont(12f));
 		messageArea.setForeground(Color.BLACK);
 		messageArea.setBackground(Color.WHITE);
 

--- a/jadx-gui/src/main/java/jadx/gui/settings/font/FontSettings.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/font/FontSettings.java
@@ -7,6 +7,7 @@ import javax.swing.UIManager;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.fonts.inter.FlatInterFont;
 import com.formdev.flatlaf.fonts.jetbrains_mono.FlatJetBrainsMonoFont;
+import com.formdev.flatlaf.util.FontUtils;
 
 import jadx.gui.settings.JadxSettingsData;
 import jadx.gui.utils.UiUtils;
@@ -31,8 +32,8 @@ public class FontSettings {
 
 	public FontSettings() {
 		int defFontSize = 13;
-		Font defUiFont = new Font(FlatInterFont.FAMILY, Font.PLAIN, defFontSize);
-		Font defCodeFont = new Font(FlatJetBrainsMonoFont.FAMILY, Font.PLAIN, defFontSize);
+		Font defUiFont = FontUtils.getCompositeFont(FlatInterFont.FAMILY, Font.PLAIN, defFontSize);
+		Font defCodeFont = FontUtils.getCompositeFont(FlatJetBrainsMonoFont.FAMILY, Font.PLAIN, defFontSize);
 		uiFontAdapter = new FontAdapter(defUiFont);
 		codeFontAdapter = new FontAdapter(defCodeFont);
 		smaliFontAdapter = new FontAdapter(defCodeFont);

--- a/jadx-gui/src/main/java/jadx/gui/settings/ui/font/JadxFontDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/settings/ui/font/JadxFontDialog.java
@@ -15,6 +15,7 @@ import org.drjekyll.fontchooser.FontChooser;
 import org.jetbrains.annotations.Nullable;
 
 import jadx.gui.settings.JadxSettings;
+import jadx.gui.utils.FontUtils;
 import jadx.gui.utils.NLS;
 
 public class JadxFontDialog extends JDialog {
@@ -42,7 +43,7 @@ public class JadxFontDialog extends JDialog {
 		setVisible(true);
 		Font selectedFont = fontChooser.getSelectedFont();
 		if (selected && !selectedFont.equals(currentFont)) {
-			return selectedFont;
+			return FontUtils.getCompositeFont(selectedFont.getFamily(), selectedFont.getStyle(), selectedFont.getSize());
 		}
 		return null;
 	}

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -58,7 +58,6 @@ import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 import javax.swing.event.TreeExpansionEvent;
 import javax.swing.event.TreeWillExpandListener;
-import javax.swing.plaf.FontUIResource;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import javax.swing.tree.DefaultTreeModel;
@@ -1573,7 +1572,7 @@ public class MainWindow extends JFrame {
 		Font defaultUiFont = UIManager.getFont("defaultFont");
 		Font uiFont = settings.getUiFont();
 		if (!uiFont.equals(defaultUiFont)) {
-			UIManager.put("defaultFont", new FontUIResource(uiFont));
+			UIManager.put("defaultFont", uiFont);
 			setFont(uiFont);
 			needUpdateUI = true;
 		}

--- a/jadx-gui/src/main/java/jadx/gui/utils/FontUtils.java
+++ b/jadx-gui/src/main/java/jadx/gui/utils/FontUtils.java
@@ -3,8 +3,6 @@ package jadx.gui.utils;
 import java.awt.Font;
 import java.io.InputStream;
 
-import javax.swing.text.StyleContext;
-
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,8 +21,7 @@ public class FontUtils {
 		int style = parseFontStyle(parts[1]);
 		int size = Integer.parseInt(parts[2]);
 
-		StyleContext sc = StyleContext.getDefaultStyleContext();
-		Font font = sc.getFont(family, style, size);
+		Font font = FontUtils.getCompositeFont(family, style, size);
 		if (font == null) {
 			throw new JadxRuntimeException("Font not found: " + fontDesc);
 		}
@@ -93,6 +90,15 @@ public class FontUtils {
 			offset += Character.charCount(codePoint);
 		}
 		return true;
+	}
+
+	/**
+	 * https://github.com/JFormDesigner/FlatLaf/issues/923
+	 * When changing fonts, use font.deriveFont() or FontUtils.getCompositeFont
+	 * instead of new Font(), otherwise FlatLaf's CJKs support will be lost
+	 */
+	public static Font getCompositeFont(String family, int style, int size) {
+		return com.formdev.flatlaf.util.FontUtils.getCompositeFont(family, style, size);
 	}
 
 	private FontUtils() {


### PR DESCRIPTION
after commit 0c3e6e77 that introduces flatlaf fonts, some panels doesn't support CJk characters any more. e.g. left panel, and settings dialog after changing ui font. (images are below)

Thers's a related issue from FlatLaf: [Font issues with CJK](https://github.com/JFormDesigner/FlatLaf/issues/923). The solution is to use `Font.deriveFont()` or `com.formdev.flatlaf.util.FontUtils.getCompositeFont()` instead of `new Font()`.

This PR adjust some places that could lead to CJK missing problems.

currently CJK problems preview:

<img width="360" height="321" alt="image" src="https://github.com/user-attachments/assets/c38c761d-04d7-45f5-97db-310c69bf03af" />

 ![ezgif-7fb1f1638b34a447](https://github.com/user-attachments/assets/c81b4fce-a6e4-464e-acc2-8a5680606c4c) 


