### PR TITLE
fix: avoid more false positive throws

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/MethodThrowsVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/MethodThrowsVisitor.java
@@ -1,7 +1,6 @@
 package jadx.core.dex.visitors;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -180,7 +179,9 @@ public class MethodThrowsVisitor extends AbstractVisitor {
 				MethodThrowsAttr cAttr = cMth.get(AType.METHOD_THROWS);
 				MethodThrowsAttr attr = mth.get(AType.METHOD_THROWS);
 				if (attr != null && cAttr != null && !cAttr.getList().isEmpty()) {
-					attr.getList().addAll(filterExceptions(cAttr.getList(), excludedExceptions));
+					for (String argTypeStr : cAttr.getList()) {
+						visitThrows(mth, ArgType.object(argTypeStr), excludedExceptions);
+					}
 				}
 			} else {
 				ClspClass clsDetails = root.getClsp().getClsDetails(classInfo.getType());
@@ -189,7 +190,9 @@ public class MethodThrowsVisitor extends AbstractVisitor {
 					if (cMth != null && cMth.getThrows() != null && !cMth.getThrows().isEmpty()) {
 						MethodThrowsAttr attr = mth.get(AType.METHOD_THROWS);
 						if (attr != null) {
-							attr.getList().addAll(filterExceptions(cMth.getThrows(), excludedExceptions));
+							for (ArgType argType : cMth.getThrows()) {
+								visitThrows(mth, argType, excludedExceptions);
+							}
 						}
 					}
 				}
@@ -249,41 +252,6 @@ public class MethodThrowsVisitor extends AbstractVisitor {
 			return true;
 		}
 		return root.getClsp().isImplements(type.getObject(), baseType.getObject());
-	}
-
-	private Collection<String> filterExceptions(Set<String> exceptions, Set<String> excludedExceptions) {
-		Set<String> filteredExceptions = new HashSet<>();
-		for (String exception : exceptions) {
-			boolean filtered = false;
-			for (String excluded : excludedExceptions) {
-				filtered = isBaseException(exception, excluded);
-				if (filtered) {
-					break;
-				}
-			}
-			if (!filtered) {
-				filteredExceptions.add(exception);
-			}
-		}
-		return filteredExceptions;
-	}
-
-	private Collection<String> filterExceptions(Collection<ArgType> exceptionArgTypes, Set<String> excludedExceptions) {
-		Set<String> filteredExceptions = new HashSet<>();
-		for (ArgType exceptionArgType : exceptionArgTypes) {
-			boolean filtered = false;
-			String exception = exceptionArgType.getObject();
-			for (String excluded : excludedExceptions) {
-				filtered = isBaseException(exception, excluded);
-				if (filtered) {
-					break;
-				}
-			}
-			if (!filtered) {
-				filteredExceptions.add(exception);
-			}
-		}
-		return filteredExceptions;
 	}
 
 	private @Nullable MethodNode searchOverriddenMethod(ClassNode cls, MethodInfo mth, String signature) {

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestThrows.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestThrows.java
@@ -74,6 +74,13 @@ public class TestThrows extends IntegrationTest {
 			}
 		}
 
+		public int doSomething3(int i) throws IllegalArgumentException {
+			if (i < 0) {
+				throw new IllegalArgumentException();
+			}
+			return 1;
+		}
+
 		public void noThrownExceptions1(InputStream i1) {
 			try {
 				i1.close();
@@ -86,6 +93,11 @@ public class TestThrows extends IntegrationTest {
 				throw new FileNotFoundException("");
 			} catch (IOException ignore) {
 			}
+		}
+
+		public void noThrownExceptions3() {
+			int i = doSomething3(0);
+			System.out.print(i);
 		}
 	}
 
@@ -104,7 +116,7 @@ public class TestThrows extends IntegrationTest {
 				.containsOne("mergeThrownExceptions() throws IOException {")
 				.containsOne("rethrowThrowable() {")
 				.containsOne("noThrownExceptions1(InputStream i1) {")
-				.containsOne("noThrownExceptions2() {");
-
+				.containsOne("noThrownExceptions2() {")
+				.containsOne("noThrownExceptions3() {");
 	}
 }


### PR DESCRIPTION
This pr avoids more false positive throws in MethodThrowsVisitor.
In `MethodThrowsVisitor.checkInsn()`, there are two places that call `visitThrows()` to add throws, and the other two places that call `filterExceptions()` to add throws.

Only `visitThrows()` calls `isThrowsRequired()` to ignore runtime exceptions, so sometimes `filterExceptions()` adds redundant throws.

`visitThrows()` and `filterExceptions()` are very similar, the only difference is that the former has two more conditions: `excType.isTypeKnown() && isThrowsRequired(mth, excType)`. So I think it's safe to replace the latter with the former. 

A small reproducible example is added.  
```
    public void noThrownExceptions3() {
		// This line leads to false positive throws.
		// 1. assignment 2. invoked method throws runtime exception
        int i = doSomething3(0);
        System.out.print(i);
    }
    public int doSomething3(int i) throws IllegalArgumentException {
        if (i < 0) {
            throw new IllegalArgumentException();
        }
        return 1;
    }
```
