### PR TITLE
fix go to main activity and application class

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/android/ApplicationParams.java
+++ b/jadx-core/src/main/java/jadx/core/utils/android/ApplicationParams.java
@@ -55,7 +55,7 @@ public class ApplicationParams {
 	}
 
 	public JavaClass getMainActivityJavaClass(JadxDecompiler decompiler) {
-		return decompiler.searchJavaClassByOrigFullName(mainActivity);
+		return decompiler.searchJavaClassByAliasFullName(mainActivity);
 	}
 
 	public String getApplication() {
@@ -63,6 +63,6 @@ public class ApplicationParams {
 	}
 
 	public JavaClass getApplicationJavaClass(JadxDecompiler decompiler) {
-		return decompiler.searchJavaClassByOrigFullName(application);
+		return decompiler.searchJavaClassByAliasFullName(application);
 	}
 }


### PR DESCRIPTION
fix(gui): go to main activity and application class when class name was renamed by deobfuscator

fixes #2632 

description see [https://github.com/skylot/jadx/issues/2632#issuecomment-3867072438](https://github.com/skylot/jadx/issues/2632#issuecomment-3867072438)