### PR TITLE
fix: back to the old correct resource ID calculation

### DIFF
--- a/jadx-core/src/main/java/jadx/core/xmlgen/entry/ResourceEntry.java
+++ b/jadx-core/src/main/java/jadx/core/xmlgen/entry/ResourceEntry.java
@@ -36,6 +36,19 @@ public final class ResourceEntry {
 		return copy(String.format("%s_res_0x%08x", resName, id));
 	}
 
+	/**
+	 * 32 bit resource ID as defined in AOSP.
+	 *
+	 * <ol>
+	 * <li>Package ID (8 bit)</li>
+	 * <li>Type ID (8 bit)</li>
+	 * <li>Entry ID (16 bit)</li>
+	 * </ol>
+	 *
+	 * See <code>make_resid()</code> in ResourceUtils.h
+	 *
+	 * @return resource ID
+	 */
 	public int getId() {
 		return id;
 	}


### PR DESCRIPTION
This PR reverts some of the changes introduced by #2777 regarding the resource ID calculation.

As described in #2786 the resource ID is important for constant replacement. 

This PR also includes changes regarding the protection system to protect us against duplicate resource entry and the renaming cascade and memory problem as described in #2775, it now bases on the index, not on the offset.

fixes #2786