### PR TITLE
Fix potential resource leak in JadxExternalPluginsLoader.close()

### DIFF
--- a/jadx-plugins-tools/src/main/java/jadx/plugins/tools/JadxExternalPluginsLoader.java
+++ b/jadx-plugins-tools/src/main/java/jadx/plugins/tools/JadxExternalPluginsLoader.java
@@ -123,16 +123,19 @@ public class JadxExternalPluginsLoader implements JadxPluginLoader {
 
 	@Override
 	public void close() {
+		List<URLClassLoader> failed = new ArrayList<>();
 		try {
 			for (URLClassLoader classLoader : classLoaders) {
 				try {
 					classLoader.close();
 				} catch (Exception e) {
-					// ignore
+					LOG.warn("Failed to close plugin class loader: {}", classLoader.getName(), e);
+					failed.add(classLoader);
 				}
 			}
 		} finally {
 			classLoaders.clear();
+			classLoaders.addAll(failed);
 		}
 	}
 }


### PR DESCRIPTION
### Problem:
`JadxExternalPluginsLoader.close()` clears classLoaders even if some `URLClassLoader.close()` calls fail, which drops references to loaders that may still hold open resources and prevents retry/diagnosis. If a close fails, the underlying resources (e.g., jar file handles) can remain open and leak.

### Fix:
Track classloaders that fail to close, log the failure, and keep only those loaders in classLoaders so a later `close()` can retry cleanup.

### Test:
```java
./gradlew build
```