### PR TITLE
fix(gui): use UI thread for adding logcat messages

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/log/LogUtils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/log/LogUtils.java
@@ -9,16 +9,18 @@ import java.util.regex.Pattern;
  */
 public class LogUtils {
 
-	private static final Pattern ALFA_NUMERIC = Pattern.compile("\\w*");
+	/**
+	 * We replace everything except alphanumeric characters, underscore, dots, colon, semicolon, comma,
+	 * spaces, minus
+	 */
+	private static final Pattern REPLACE_PATTERN = Pattern.compile("[^\\w\\.:;, -]");
 
 	public static String escape(String input) {
 		if (input == null) {
 			return "null";
 		}
-		if (ALFA_NUMERIC.matcher(input).matches()) {
-			return input;
-		}
-		return input.replaceAll("\\W", ".");
+
+		return REPLACE_PATTERN.matcher(input).replaceAll(".");
 	}
 
 	public static String escape(byte[] input) {

--- a/jadx-core/src/test/java/jadx/core/utils/log/LogUtilsTest.java
+++ b/jadx-core/src/test/java/jadx/core/utils/log/LogUtilsTest.java
@@ -8,6 +8,8 @@ class LogUtilsTest {
 
 	@Test
 	void escape() {
-		assertThat(LogUtils.escape("Guest'%0AUser:'Admin")).isEqualTo("Guest..0AUser..Admin");
+		String src = "a.b,c:d;e disallowed\"a'b#c*d\te\rf\ng";
+		String out = "a.b,c:d;e disallowed.a.b.c.d.e.f.g";
+		assertThat(LogUtils.escape(src)).isEqualTo(out);
 	}
 }

--- a/jadx-gui/src/main/java/jadx/gui/ui/dialog/ADBDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/dialog/ADBDialog.java
@@ -279,6 +279,7 @@ public class ADBDialog extends JDialog implements ADB.DeviceStateListener, ADB.J
 
 	@Override
 	public void onDeviceStatusChange(List<ADBDeviceInfo> deviceInfoList) {
+		LOG.debug("onDeviceStatusChange {}", deviceInfoList);
 		List<DeviceNode> nodes = new ArrayList<>(deviceInfoList.size());
 		info_loop: for (ADBDeviceInfo info : deviceInfoList) {
 			for (DeviceNode deviceNode : deviceNodes) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/panel/LogcatPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/panel/LogcatPanel.java
@@ -208,15 +208,8 @@ public class LogcatPanel extends JPanel {
 		JScrollBar scrollbar = logcatScroll.getVerticalScrollBar();
 		boolean atBottom = isAtBottom(scrollbar);
 
-		String logString = " > " +
-				logcatInfo.getTimestamp() +
-				" [pid: " +
-				logcatInfo.getPid() +
-				"] " +
-				logcatInfo.getMsgTypeString() +
-				": " +
-				logcatInfo.getMsg() +
-				"\n";
+		String logString = " > " + logcatInfo.getTimestamp() + " [pid: " + logcatInfo.getPid() + "] "
+				+ logcatInfo.getMsgTypeString() + ": " + logcatInfo.getMsg() + "\n";
 
 		if (logcatInfo.getMsgType() == 0) {
 			return; // ignore unknown
@@ -327,11 +320,7 @@ public class LogcatPanel extends JPanel {
 		public void selectAllBut(int ind) {
 			for (int i = 0; i < combo.getItemCount(); i++) {
 				CheckComboStore ccs = combo.getItemAt(i);
-				if (i != ind) {
-					ccs.state = false;
-				} else {
-					ccs.state = true;
-				}
+				ccs.state = (i == ind);
 				switch (type) {
 					case 1: // process
 						logcatController.getFilter().togglePid(ccs.index, ccs.state);

--- a/jadx-gui/src/main/java/jadx/gui/ui/panel/LogcatPanel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/panel/LogcatPanel.java
@@ -14,6 +14,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.swing.AbstractAction;
@@ -60,6 +61,10 @@ public class LogcatPanel extends JPanel {
 	private final AttributeSet errorAset = sc.addAttribute(SimpleAttributeSet.EMPTY, StyleConstants.Foreground, Color.decode("#dc322f"));
 	private final AttributeSet fatalAset = sc.addAttribute(SimpleAttributeSet.EMPTY, StyleConstants.Foreground, Color.decode("#d33682"));
 	private final AttributeSet silentAset = sc.addAttribute(SimpleAttributeSet.EMPTY, StyleConstants.Foreground, Color.decode("#002b36"));
+
+	private final Map<Byte, AttributeSet> asetMap =
+			Map.of((byte) 1, defaultAset, (byte) 2, verboseAset, (byte) 3, debugAset, (byte) 4, infoAset, (byte) 5, warningAset,
+					(byte) 6, errorAset, (byte) 7, fatalAset, (byte) 8, silentAset);
 
 	private static final ImageIcon ICON_PAUSE = UiUtils.openSvgIcon("debugger/threadFrozen");
 	private static final ImageIcon ICON_RUN = UiUtils.openSvgIcon("debugger/execute");
@@ -199,64 +204,36 @@ public class LogcatPanel extends JPanel {
 	}
 
 	public void log(LogcatController.LogcatInfo logcatInfo) {
-		boolean atBottom = false;
-
 		int len = logcatPane.getDocument().getLength();
 		JScrollBar scrollbar = logcatScroll.getVerticalScrollBar();
-		if (isAtBottom(scrollbar)) {
-			atBottom = true;
+		boolean atBottom = isAtBottom(scrollbar);
+
+		String logString = " > " +
+				logcatInfo.getTimestamp() +
+				" [pid: " +
+				logcatInfo.getPid() +
+				"] " +
+				logcatInfo.getMsgTypeString() +
+				": " +
+				logcatInfo.getMsg() +
+				"\n";
+
+		if (logcatInfo.getMsgType() == 0) {
+			return; // ignore unknown
 		}
 
-		StringBuilder sb = new StringBuilder();
-		sb.append(" > ")
-				.append(logcatInfo.getTimestamp())
-				.append(" [pid: ")
-				.append(logcatInfo.getPid())
-				.append("] ")
-				.append(logcatInfo.getMsgTypeString())
-				.append(": ")
-				.append(logcatInfo.getMsg())
-				.append("\n");
+		AttributeSet attrSet = asetMap.get(logcatInfo.getMsgType());
 
-		try {
-			switch (logcatInfo.getMsgType()) {
-				case 0: // Unknown
-					break;
-				case 1: // Default
-					logcatPane.getDocument().insertString(len, sb.toString(), defaultAset);
-					break;
-				case 2: // Verbose
-					logcatPane.getDocument().insertString(len, sb.toString(), verboseAset);
-					break;
-				case 3: // Debug
-					logcatPane.getDocument().insertString(len, sb.toString(), debugAset);
-					break;
-				case 4: // Info
-					logcatPane.getDocument().insertString(len, sb.toString(), infoAset);
-					break;
-				case 5: // Warn
-					logcatPane.getDocument().insertString(len, sb.toString(), warningAset);
-					break;
-				case 6: // Error
-					logcatPane.getDocument().insertString(len, sb.toString(), errorAset);
-					break;
-				case 7: // Fatal
-					logcatPane.getDocument().insertString(len, sb.toString(), fatalAset);
-					break;
-				case 8: // Silent
-					logcatPane.getDocument().insertString(len, sb.toString(), silentAset);
-					break;
-				default:
-					logcatPane.getDocument().insertString(len, sb.toString(), null);
-					break;
+		UiUtils.uiRun(() -> {
+			try {
+				logcatPane.getDocument().insertString(len, logString, attrSet);
+			} catch (Exception e) {
+				LOG.error("Failed to add logcat message", e);
 			}
-		} catch (Exception e) {
-			LOG.error("Failed to write logcat message", e);
-		}
-
-		if (atBottom) {
-			EventQueue.invokeLater(() -> scrollbar.setValue(scrollbar.getMaximum()));
-		}
+			if (atBottom) {
+				EventQueue.invokeLater(() -> scrollbar.setValue(scrollbar.getMaximum()));
+			}
+		});
 	}
 
 	public void exit() {
@@ -282,7 +259,7 @@ public class LogcatPanel extends JPanel {
 		}
 
 		public void actionPerformed(ActionEvent e) {
-			JComboBox cb = (JComboBox) e.getSource();
+			JComboBox<?> cb = (JComboBox<?>) e.getSource();
 			CheckComboStore store = (CheckComboStore) cb.getSelectedItem();
 			CheckComboRenderer ccr = (CheckComboRenderer) cb.getRenderer();
 			store.state = !store.state;


### PR DESCRIPTION
The logcat messages were also added without proper UI synchronization.

I also made other improvements to adb and logcat handling like never closed sockets and never terminated executor.

Also the LogUtils.escape method was a bit restrictive what it filters out. I was very confused as this "log escaper" modified the ADB commands printed in the log. I relaxed that a bit.

As long term solution we may consider switching to `org.apache.commons.text.StringEscapeUtils.escapeJava(...)`.