### PR TITLE
fix: harden XML parser in FileTypeDetector against XML bomb DoS

### DIFF
--- a/jadx-core/src/main/java/jadx/core/deobf/FileTypeDetector.java
+++ b/jadx-core/src/main/java/jadx/core/deobf/FileTypeDetector.java
@@ -83,9 +83,12 @@ public class FileTypeDetector {
 		try {
 			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 			factory.setNamespaceAware(true);
+			factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 			factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 			factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
 			factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			factory.setXIncludeAware(false);
+			factory.setExpandEntityReferences(false);
 
 			DocumentBuilder builder = factory.newDocumentBuilder();
 			Document doc = builder.parse(new java.io.ByteArrayInputStream(data));


### PR DESCRIPTION
:exclamation: Please review the [guidelines for contributing](https://github.com/skylot/jadx/blob/master/CONTRIBUTING.md#Pull-Request-Process)

### Description

A crafted APK containing a resource with nested entity expansion (Billion Laughs) could cause excessive memory consumption and crash jadx during file type detection.