### PR TITLE
feat: add "copy reference" to context menu

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/action/ActionModel.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/action/ActionModel.java
@@ -107,6 +107,8 @@ public enum ActionModel {
 			Shortcut.keyboard(KeyEvent.VK_F)),
 	XPOSED_COPY(CODE_AREA, "popup.xposed", "popup.xposed", null,
 			Shortcut.keyboard(KeyEvent.VK_Y)),
+	COPY_REFERENCE(CODE_AREA, "popup.copy_reference", "popup.copy_reference", null,
+			Shortcut.keyboard(KeyEvent.VK_R)),
 	JSON_PRETTIFY(CODE_AREA, "popup.json_prettify", "popup.json_prettify", null,
 			Shortcut.none()),
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/action/CopyReferenceAction.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/action/CopyReferenceAction.java
@@ -1,0 +1,46 @@
+package jadx.gui.ui.action;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jadx.api.JavaClass;
+import jadx.api.JavaField;
+import jadx.api.JavaMethod;
+import jadx.api.JavaNode;
+import jadx.gui.treemodel.JClass;
+import jadx.gui.treemodel.JField;
+import jadx.gui.treemodel.JMethod;
+import jadx.gui.treemodel.JNode;
+import jadx.gui.ui.codearea.CodeArea;
+import jadx.gui.utils.UiUtils;
+
+public final class CopyReferenceAction extends JNodeAction {
+	private static final Logger LOG = LoggerFactory.getLogger(CopyReferenceAction.class);
+	private static final long serialVersionUID = -8816072267744391424L;
+
+	public CopyReferenceAction(CodeArea codeArea) {
+		super(ActionModel.COPY_REFERENCE, codeArea);
+	}
+
+	@Override
+	public void runAction(JNode node) {
+		JavaNode javaNode = node.getJavaNode();
+		String ref;
+		if (javaNode instanceof JavaClass) {
+			ref = javaNode.getFullName();
+		} else if (javaNode instanceof JavaMethod) {
+			ref = ((JavaMethod) javaNode).getDeclaringClass().getFullName() + '.' + javaNode.getName();
+		} else if (javaNode instanceof JavaField) {
+			ref = ((JavaField) javaNode).getDeclaringClass().getFullName() + '.' + javaNode.getName();
+		} else {
+			LOG.warn("Copy reference not supported for node type: {}", node.getClass());
+			return;
+		}
+		UiUtils.copyToClipboard(ref);
+	}
+
+	@Override
+	public boolean isActionEnabled(JNode node) {
+		return node instanceof JMethod || node instanceof JClass || node instanceof JField;
+	}
+}

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -35,6 +35,7 @@ import jadx.gui.treemodel.JNode;
 import jadx.gui.treemodel.JResource;
 import jadx.gui.ui.MainWindow;
 import jadx.gui.ui.action.CommentSearchAction;
+import jadx.gui.ui.action.CopyReferenceAction;
 import jadx.gui.ui.action.FindUsageAction;
 import jadx.gui.ui.action.FridaAction;
 import jadx.gui.ui.action.GoToDeclarationAction;
@@ -191,6 +192,7 @@ public final class CodeArea extends AbstractCodeArea implements CodePanelSyncerA
 		popup.add(new CommentAction(this));
 		popup.add(new CommentSearchAction(this));
 		popup.add(new RenameAction(this));
+		popup.add(new CopyReferenceAction(this));
 		popup.addSeparator();
 		popup.add(new FridaAction(this));
 		popup.add(new XposedAction(this));

--- a/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_de_DE.properties
@@ -393,6 +393,7 @@ popup.add_comment=Kommentar
 popup.update_comment=Kommentar aktualisieren
 popup.search_comment=Kommentar suchen
 popup.rename=Umbennen
+#popup.copy_reference=Copy Reference
 popup.search=Suche "%s"
 popup.search_global=Globale Suche "%s"
 popup.remove=Entfernen

--- a/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_en_US.properties
@@ -393,6 +393,7 @@ popup.add_comment=Comment
 popup.update_comment=Update comment
 popup.search_comment=Search comments
 popup.rename=Rename
+popup.copy_reference=Copy Reference
 popup.search=Search "%s"
 popup.search_global=Global Search "%s"
 popup.remove=Remove

--- a/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_es_ES.properties
@@ -393,6 +393,7 @@ popup.xposed=Copiar como fragmento de xposed
 #popup.update_comment=Update comment
 #popup.search_comment=Search comments
 popup.rename=Renombrar
+#popup.copy_reference=Copy Reference
 #popup.search=Search "%s"
 #popup.search_global=Global Search "%s"
 #popup.remove=Remove

--- a/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_id_ID.properties
@@ -393,6 +393,7 @@ popup.add_comment=Komentar
 #popup.update_comment=Update comment
 popup.search_comment=Cari komentar
 popup.rename=Ganti nama
+#popup.copy_reference=Copy Reference
 popup.search=Cari "%s"
 popup.search_global=Cari Global "%s"
 popup.remove=Hapus

--- a/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ko_KR.properties
@@ -393,6 +393,7 @@ popup.add_comment=주석
 #popup.update_comment=Update comment
 popup.search_comment=주석 검색
 popup.rename=이름 바꾸기
+#popup.copy_reference=Copy Reference
 popup.search="%s" 검색
 popup.search_global="%s" 전역 검색
 #popup.remove=Remove

--- a/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_pt_BR.properties
@@ -393,6 +393,7 @@ popup.add_comment=Comentar
 #popup.update_comment=Update comment
 popup.search_comment=Buscar comentários
 popup.rename=Renomear
+#popup.copy_reference=Copy Reference
 popup.search=Buscar "%s"
 popup.search_global=Busca global "%s"
 #popup.remove=Remove

--- a/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_ru_RU.properties
@@ -393,6 +393,7 @@ popup.add_comment=Комментарий
 #popup.update_comment=Update comment
 popup.search_comment=Поиск комментариев
 popup.rename=Переименовать
+#popup.copy_reference=Copy Reference
 popup.search=Найти "%s"
 popup.search_global=Глобальный поиск "%s"
 popup.remove=Удалить

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_CN.properties
@@ -393,6 +393,7 @@ popup.add_comment=添加注释
 popup.update_comment=更新注释
 popup.search_comment=搜索注释
 popup.rename=重命名
+popup.copy_reference=复制引用
 popup.search=搜索 “%s”
 popup.search_global=全局搜索 “%s”
 popup.remove=移除

--- a/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
+++ b/jadx-gui/src/main/resources/i18n/Messages_zh_TW.properties
@@ -393,6 +393,7 @@ popup.add_comment=註解
 popup.update_comment=更新註解
 popup.search_comment=搜尋註解
 popup.rename=重新命名
+popup.copy_reference=複製引用
 popup.search=搜尋 "%s"
 popup.search_global=全域搜尋 "%s"
 popup.remove=移除


### PR DESCRIPTION
### Description

Added "Copy Reference" to the context menu, same as in IDEA — copies `com.example.Class.method` to clipboard. Works on classes, methods, and fields

Shortcut: `R` (open to suggestions if anything else fits better)


### Motivation

When reverse engineering, it's common for people to copy reference for writing scripts (frida/xposed or else), writing documents, etc. 

Currently when copying code reference, we can hover and copy from popup. But this is slow and inconvenient (and the popup widget easily loses focus, even thought I pressed `F2`）

I think it would be very helpful to have an menu option to do this :)


### Preview

<img width="1188" height="672" alt="image" src="https://github.com/user-attachments/assets/e3fc9f67-1491-45cd-bb5a-5ab9cab6578c" />

- class: `com.example.MyClass`
- method: `com.example.MyClass.onCreate`
- field: `com.example.MyClass.TAG`
- method of inner class: `com.example.Outer$Inner.doSomething`