### PR TITLE
Change from virtualenv to venv

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkManager.java
+++ b/jadx-gui/src/main/java/jadx/gui/plugins/quark/QuarkManager.java
@@ -132,13 +132,9 @@ public class QuarkManager {
 			}
 		}
 		List<String> cmd = new ArrayList<>();
-		if (JadxSystemInfo.IS_WINDOWS) {
-			cmd.add("python");
-			cmd.add("-m");
-			cmd.add("venv");
-		} else {
-			cmd.add("virtualenv");
-		}
+		cmd.add("python");
+		cmd.add("-m");
+		cmd.add("venv");
 		cmd.add(VENV_PATH.toString());
 		try {
 			runCommand(cmd);


### PR DESCRIPTION
## Summary

This PR changes unified virtual environment used for quark engine

## Problem
Any system other than windows use virtualenv that not guarantee installed in the system or inflict with  system-managed Python environments, 

## Solution
Change the virtual environment to python built in environment

## Test Plan

- [x] Build passes with `./gradlew dist`
- [x] Tested on Linux 7.0.9-arch1-1