### PR TITLE
fix: keep all dimensions for anewarray of an array element type

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
+++ b/jadx-core/src/main/java/jadx/core/dex/instructions/InsnDecoder.java
@@ -528,18 +528,10 @@ public class InsnDecoder {
 
 	private InsnNode makeNewArray(InsnData insn) {
 		ArgType indexType = ArgType.parse(insn.getIndexAsType());
+		// NEW_ARRAY literal = dimensions to wrap the operand by: 0 if it is already the full array type
+		// (dalvik new-array, java multianewarray), 1 for newarray/anewarray (operand is the element type)
 		int dim = (int) insn.getLiteral();
-		ArgType arrType;
-		if (dim == 0) {
-			arrType = indexType;
-		} else {
-			if (indexType.isArray()) {
-				// java bytecode can pass array as a base type
-				arrType = indexType;
-			} else {
-				arrType = ArgType.array(indexType, dim);
-			}
-		}
+		ArgType arrType = dim == 0 ? indexType : ArgType.array(indexType, dim);
 		int regsCount = insn.getRegsCount();
 		NewArrayNode newArr = new NewArrayNode(arrType, regsCount - 1);
 		newArr.setResult(InsnArg.reg(insn, 0, arrType));

--- a/jadx-core/src/test/java/jadx/tests/integration/arrays/TestNewArrayOfArrays.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arrays/TestNewArrayOfArrays.java
@@ -1,0 +1,39 @@
+package jadx.tests.integration.arrays;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestNewArrayOfArrays extends IntegrationTest {
+
+	public static class TestCls {
+		public static long[][] anewarrayOfArray(int n) {
+			return new long[n][]; // anewarray [J
+		}
+
+		public static String[][] anewarrayOfObjectArray(int n) {
+			return new String[n][]; // anewarray [Ljava/lang/String;
+		}
+
+		public static int[][][] anewarrayDeep(int n) {
+			return new int[n][][]; // anewarray [[I
+		}
+
+		public static int[][] multiAnewarray(int a, int b) {
+			return new int[a][b]; // multianewarray [[I
+		}
+	}
+
+	@Test
+	public void test() {
+		useJavaInput();
+		assertThat(getClassNode(TestCls.class))
+				.code()
+				.containsOne("new long[n][]")
+				.containsOne("new String[n][]")
+				.containsOne("new int[n][][]")
+				.containsOne("new int[a][b]");
+	}
+}

--- a/jadx-plugins/jadx-java-input/src/main/java/jadx/plugins/input/java/data/code/JavaInsnsRegister.java
+++ b/jadx-plugins/jadx-java-input/src/main/java/jadx/plugins/input/java/data/code/JavaInsnsRegister.java
@@ -342,7 +342,9 @@ public class JavaInsnsRegister {
 			s.idx(s.u2());
 			int dim = s.u1();
 			JavaInsnData insn = s.insn();
-			insn.setLiteral(dim);
+			// operand is already the full array type (like new-array): literal 0 = no wrapping; the
+			// dimension count is carried by regsCount
+			insn.setLiteral(0);
 			insn.setRegsCount(dim + 1);
 			for (int i = dim; i > 0; i--) {
 				s.pop(i);


### PR DESCRIPTION
NOTE: This is what one may call "AI slop". Feel free to close this PR if it's not up to your quality standards or even if you just aren't interested in reviewing it. I use these changes downstream on an APK and thought I might as well make a PR offering to upstream them, as your CONTRIBUTING.md doesn't say anything discouraging this.

### Description

On the java/class input path, `anewarray` of an array element (e.g. `new long[n][]`) lost its outer dimension and decompiled to `new long[n]`, with a spurious `Type inference failed` warning.

`makeNewArray` is shared by all inputs and wraps the operand type by the NEW_ARRAY literal. `anewarray`/`newarray` already pass the element type with literal 1, and dalvik `new-array` passes the full array type with literal 0. `multianewarray` also passes the full array type, but was setting the literal to its dimension count, so `makeNewArray` relied on an `indexType.isArray()` shortcut to avoid double-wrapping it. That shortcut also caught `anewarray` whose element is itself an array, dropping the outer dimension.

Set the `multianewarray` literal to 0 (the operand is already the full type, like `new-array`; the dimension count comes from regsCount) and drop the now-redundant `isArray()` shortcut, so `makeNewArray` just wraps by the literal. The dex path is unaffected.

Includes an integration test.

Fixes #2885
