### PR TITLE
fix: erase unresolved generic field type to its bound in field-get assign

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/typeinference/TypeBoundFieldGetAssign.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/typeinference/TypeBoundFieldGetAssign.java
@@ -1,5 +1,7 @@
 package jadx.core.dex.visitors.typeinference;
 
+import java.util.List;
+
 import jadx.core.dex.info.FieldInfo;
 import jadx.core.dex.instructions.IndexInsnNode;
 import jadx.core.dex.instructions.args.ArgType;
@@ -44,7 +46,38 @@ public final class TypeBoundFieldGetAssign implements ITypeBoundDynamic {
 		if (resultGeneric != null && !resultGeneric.isWildcard()) {
 			return resultGeneric;
 		}
-		return initType; // TODO: check if this type is allowed in current scope
+		if (initType.isGenericType() || initType.isArray()) {
+			// type variable unresolvable from the (raw) instance type: erase it (arrays element-wise)
+			// to its leftmost bound, like javac, so the result type is valid in the current scope
+			return eraseTypeVar(initType);
+		}
+		return initType;
+	}
+
+	private static ArgType eraseTypeVar(ArgType type) {
+		if (type.isArray()) {
+			// erase element, keep rank (T[] -> Object[])
+			return ArgType.array(eraseTypeVar(type.getArrayElement()));
+		}
+		if (type.isGenericType()) {
+			List<ArgType> bounds = type.getExtendTypes();
+			if (bounds.isEmpty()) {
+				return ArgType.OBJECT;
+			}
+			ArgType bound = bounds.get(0);
+			if (bound.isGenericType()) {
+				// bound is itself a type variable (<S extends T>)
+				return ArgType.OBJECT;
+			}
+			// drop type args so we don't reintroduce an out-of-scope variable (Comparable<T> -> Comparable)
+			return bound.isGeneric() ? ArgType.object(bound.getObject()) : bound;
+		}
+		if (type.isGeneric()) {
+			// parameterized element (List<T>[]) -> raw
+			return ArgType.object(type.getObject());
+		}
+		// already concrete (array element)
+		return type;
 	}
 
 	private InsnArg getInstanceArg() {

--- a/jadx-core/src/test/java/jadx/tests/integration/generics/TestRawGenericFieldNullCompare.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/generics/TestRawGenericFieldNullCompare.java
@@ -1,0 +1,58 @@
+package jadx.tests.integration.generics;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestRawGenericFieldNullCompare extends IntegrationTest {
+
+	public static class TestCls {
+		public static class NumBox<T extends Number> {
+			public T value;
+		}
+
+		public static class MultiBox<T extends Number & Comparable<T>> {
+			public T value;
+		}
+
+		public static class CompBox<T extends Comparable<T>> {
+			public T value;
+		}
+
+		public static class ArrBox<T extends Number> {
+			public T[] values;
+		}
+
+		public static boolean isNull(NumBox box) {
+			return box.value == null;
+		}
+
+		public static int useMulti(MultiBox box) {
+			if (box.value == null) {
+				return -1;
+			}
+			return box.value.intValue();
+		}
+
+		public static boolean compNull(CompBox box) {
+			return box.value == null;
+		}
+
+		public static boolean arrNull(ArrBox box) {
+			return box.values == null;
+		}
+	}
+
+	@Test
+	public void test() {
+		useJavaInput();
+		noDebugInfo();
+		assertThat(getClassNode(TestCls.class))
+				.code()
+				.contains("== null")
+				.doesNotContain("== 0")
+				.doesNotContain("Type inference failed");
+	}
+}


### PR DESCRIPTION
NOTE: This is what one may call "AI slop". Feel free to close this PR if it's not up to your quality standards or even if you just aren't interested in reviewing it. I use these changes downstream on an APK and thought I might as well make a PR offering to upstream them, as your CONTRIBUTING.md doesn't say anything discouraging this.

### Description

Reading a generic field through a raw instance type and null-checking it emitted `== 0` instead of `== null` (with a `type inference failed` warning), for both a type-variable field (`T`) and arrays of one (`T[]`).

When the field's type variable can't be resolved from the raw instance type, `getResultType` returned it unchanged, leaving an out-of-scope type variable that type propagation rejects, so the compared `0` literal kept its unknown type. Erase the unresolved variable to its leftmost bound (like javac), arrays element-wise, falling back to `Object` when unbounded or when the bound is itself a type variable. This mirrors the extend-type handling in `FixTypesVisitor`, rather than the straight-to-`Object` erasure in `checkRawType`, so a `T extends Number` field stays usable as a `Number`.

Includes an integration test.

Fixes #2886
