### PR TITLE
fix(gui): fix token type error leading to disables right-click context menu rename button

### DIFF
--- a/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
@@ -122,17 +122,18 @@ public class ClassGen {
 	private void addImports(ICodeWriter clsCode) {
 		int importsCount = imports.size();
 		if (importsCount != 0) {
-			List<ClassInfo> sortedImports = new ArrayList<>(imports);
-			sortedImports.sort(Comparator.comparing(ClassInfo::getAliasFullName));
-			sortedImports.forEach(classInfo -> {
-				clsCode.startLine("import ");
-				ClassNode classNode = cls.root().resolveClass(classInfo);
-				if (classNode != null) {
-					clsCode.attachAnnotation(classNode);
-				}
-				clsCode.add(classInfo.getAliasFullName());
-				clsCode.add(';');
-			});
+			imports.stream()
+					.filter(classInfo -> !classInfo.getPackage().equals("java.lang") || classInfo.isInner())
+					.sorted(Comparator.comparing(ClassInfo::getAliasFullName))
+					.forEach(classInfo -> {
+						clsCode.startLine("import ");
+						ClassNode classNode = cls.root().resolveClass(classInfo);
+						if (classNode != null) {
+							clsCode.attachAnnotation(classNode);
+						}
+						clsCode.add(classInfo.getAliasFullName());
+						clsCode.add(';');
+					});
 			clsCode.newLine();
 			imports.clear();
 		}
@@ -697,10 +698,6 @@ public class ClassGen {
 			return fullName;
 		}
 		if (isBothClassesInOneTopClass(useCls, extClsInfo)) {
-			return shortName;
-		}
-		// don't add import for top classes from 'java.lang' package (subpackages excluded)
-		if (extClsInfo.getPackage().equals("java.lang") && extClsInfo.getParentClass() == null) {
 			return shortName;
 		}
 		// don't add import if this class from same package

--- a/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
+++ b/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java
@@ -123,7 +123,6 @@ public class ClassGen {
 		int importsCount = imports.size();
 		if (importsCount != 0) {
 			imports.stream()
-					.filter(classInfo -> !classInfo.getPackage().equals("java.lang") || classInfo.isInner())
 					.sorted(Comparator.comparing(ClassInfo::getAliasFullName))
 					.forEach(classInfo -> {
 						clsCode.startLine("import ");
@@ -700,11 +699,15 @@ public class ClassGen {
 		if (isBothClassesInOneTopClass(useCls, extClsInfo)) {
 			return shortName;
 		}
-		// don't add import if this class from same package
-		if (extClsInfo.getPackage().equals(useCls.getPackage()) && !extClsInfo.isInner()) {
+		// don't add import for top classes from 'java.lang' package (subpackages excluded)
+		if (extClsInfo.getPackage().equals("java.lang") && extClsInfo.getParentClass() == null) {
 			return shortName;
 		}
 		if (extClsInfo.getAliasPkg().equals(useCls.getAliasPkg())) {
+			if (!extClsInfo.isInner()) {
+				// don't add import if this class from same package
+				return shortName;
+			}
 			fullName = extClsInfo.getAliasNameWithoutPackage();
 		}
 		for (ClassInfo importCls : getImports()) {
@@ -737,7 +740,16 @@ public class ClassGen {
 		}
 		Collections.reverse(clsList);
 		if (addImport) {
-			addImport(clsList.get(0));
+			ClassInfo top = clsList.get(0);
+			if (top != extClsInfo) {
+				String usedName = useClassInternal(useCls, top);
+				if (!usedName.equals(top.getAliasShortName())) {
+					// short top name can't be used, use full name as fallback
+					return extClsInfo.getAliasFullName();
+				}
+			} else {
+				addImport(top);
+			}
 		}
 		return Utils.listToString(clsList, ".", ClassInfo::getAliasShortName);
 	}

--- a/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
@@ -256,11 +256,17 @@ public final class ClassInfo implements Comparable<ClassInfo> {
 		return parentClass.getAliasNameWithoutPackage() + '.' + getAliasShortName();
 	}
 
+	/**
+	 * Return the outer class of the class represented by this ClassInfo instead of the parent class.
+	 */
 	@Nullable
 	public ClassInfo getParentClass() {
 		return parentClass;
 	}
 
+	/**
+	 * Return the top outer class of the class represented by this ClassInfo instead of the parent class.
+	 */
 	public ClassInfo getTopParentClass() {
 		if (parentClass != null) {
 			ClassInfo topCls = parentClass.getTopParentClass();

--- a/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
+++ b/jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java
@@ -257,17 +257,16 @@ public final class ClassInfo implements Comparable<ClassInfo> {
 	}
 
 	/**
-	 * Return the outer class of the class represented by this ClassInfo instead of the parent class.
+	 * Return the outer class of the class represented by this ClassInfo
 	 */
-	@Nullable
-	public ClassInfo getParentClass() {
+	public @Nullable ClassInfo getParentClass() {
 		return parentClass;
 	}
 
 	/**
-	 * Return the top outer class of the class represented by this ClassInfo instead of the parent class.
+	 * Return the top outer class of the class represented by this ClassInfo
 	 */
-	public ClassInfo getTopParentClass() {
+	public @Nullable ClassInfo getTopParentClass() {
 		if (parentClass != null) {
 			ClassInfo topCls = parentClass.getTopParentClass();
 			return topCls != null ? topCls : parentClass;

--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestImports.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestImports.java
@@ -1,0 +1,53 @@
+package jadx.tests.integration.others;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+@SuppressWarnings("DataFlowIssue")
+public class TestImports extends IntegrationTest {
+
+	public static class TestCls1 {
+		public Character.UnicodeBlock test1() {
+			return null;
+		}
+
+		public Character test2() {
+			return 'a';
+		}
+	}
+
+	public static class TestCls2 {
+		public static final class Character {
+		}
+
+		public Character test1() {
+			return new Character();
+		}
+
+		public java.lang.Character test2() {
+			return 'c';
+		}
+
+		public java.lang.Character.UnicodeBlock test3() {
+			return null;
+		}
+	}
+
+	@Test
+	public void test1() {
+		noDebugInfo();
+		assertThat(getClassNode(TestCls1.class))
+				.code()
+				.doesNotContain("import java.lang.Character;"); // import not needed
+	}
+
+	@Test
+	public void test2() {
+		noDebugInfo();
+		assertThat(getClassNode(TestCls2.class))
+				.code();
+	}
+}

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -392,6 +392,23 @@ public final class CodeArea extends AbstractCodeArea implements CodeAreaSyncerAb
 		}
 	}
 
+	public @Nullable JavaNode getJavaIdentifierIfAtPos(int pos) {
+		try {
+			ICodeInfo codeInfo = getCodeInfo();
+			if (!codeInfo.hasMetadata()) {
+				return null;
+			}
+			ICodeAnnotation ann = codeInfo.getCodeMetadata().getAt(pos);
+			if (ann == null) {
+				return null;
+			}
+			return getJadxWrapper().getDecompiler().getJavaNodeByCodeAnnotation(codeInfo, ann);
+		} catch (Exception e) {
+			LOG.error("Can't get java node by offset: {}", pos, e);
+			return null;
+		}
+	}
+
 	public void refreshClass() {
 		refreshClass(false);
 	}

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java
@@ -392,23 +392,6 @@ public final class CodeArea extends AbstractCodeArea implements CodeAreaSyncerAb
 		}
 	}
 
-	public @Nullable JavaNode getJavaIdentifierIfAtPos(int pos) {
-		try {
-			ICodeInfo codeInfo = getCodeInfo();
-			if (!codeInfo.hasMetadata()) {
-				return null;
-			}
-			ICodeAnnotation ann = codeInfo.getCodeMetadata().getAt(pos);
-			if (ann == null) {
-				return null;
-			}
-			return getJadxWrapper().getDecompiler().getJavaNodeByCodeAnnotation(codeInfo, ann);
-		} catch (Exception e) {
-			LOG.error("Can't get java node by offset: {}", pos, e);
-			return null;
-		}
-	}
-
 	public void refreshClass() {
 		refreshClass(false);
 	}

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/JadxTokenMaker.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/JadxTokenMaker.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 import javax.swing.text.Segment;
 
-import jadx.api.JavaMethod;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
 import org.fife.ui.rsyntaxtextarea.TokenTypes;
@@ -15,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jadx.api.JavaClass;
+import jadx.api.JavaMethod;
 import jadx.api.JavaNode;
 
 import static jadx.api.plugins.utils.Utils.constSet;
@@ -85,7 +85,7 @@ public final class JadxTokenMaker extends JavaTokenMaker {
 	}
 
 	private void fixIdentifierWithTheSameNameAsJavaLangClass(Token token) {
-		JavaNode identifier = codeArea.getJavaIdentifierIfAtPos(token.getTextOffset());
+		JavaNode identifier = codeArea.getJavaNodeAtOffset(token.getTextOffset());
 		if (identifier == null) {
 			return;
 		}
@@ -94,12 +94,11 @@ public final class JadxTokenMaker extends JavaTokenMaker {
 			token.setType(TokenTypes.IDENTIFIER);
 			return;
 		}
-		if (!(identifier instanceof JavaMethod)) {
-			return;
-		}
-		JavaClass javaCls = identifier.getDeclaringClass();
-		if (lexeme.equals(javaCls.getName())) {
-			token.setType(TokenTypes.IDENTIFIER);
+		if (identifier instanceof JavaMethod) {
+			JavaClass javaCls = identifier.getDeclaringClass();
+			if (lexeme.equals(javaCls.getName())) {
+				token.setType(TokenTypes.IDENTIFIER);
+			}
 		}
 	}
 

--- a/jadx-gui/src/main/java/jadx/gui/ui/codearea/JadxTokenMaker.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/codearea/JadxTokenMaker.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import javax.swing.text.Segment;
 
+import jadx.api.JavaMethod;
 import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rsyntaxtextarea.TokenImpl;
 import org.fife.ui.rsyntaxtextarea.TokenTypes;
@@ -54,6 +55,10 @@ public final class JadxTokenMaker extends JavaTokenMaker {
 						fixContextualKeyword(current);
 						break;
 
+					case TokenTypes.FUNCTION:
+						fixIdentifierWithTheSameNameAsJavaLangClass(current);
+						break;
+
 					case TokenTypes.IDENTIFIER:
 						current = mergeLongClassNames(prev, current, false);
 						break;
@@ -75,6 +80,25 @@ public final class JadxTokenMaker extends JavaTokenMaker {
 	private static void fixContextualKeyword(Token token) {
 		String lexeme = token.getLexeme(); // TODO: create new string every call, better to avoid
 		if (lexeme != null && CONTEXTUAL_KEYWORDS.contains(lexeme)) {
+			token.setType(TokenTypes.IDENTIFIER);
+		}
+	}
+
+	private void fixIdentifierWithTheSameNameAsJavaLangClass(Token token) {
+		JavaNode identifier = codeArea.getJavaIdentifierIfAtPos(token.getTextOffset());
+		if (identifier == null) {
+			return;
+		}
+		String lexeme = token.getLexeme();
+		if (lexeme.equals(identifier.getName())) {
+			token.setType(TokenTypes.IDENTIFIER);
+			return;
+		}
+		if (!(identifier instanceof JavaMethod)) {
+			return;
+		}
+		JavaClass javaCls = identifier.getDeclaringClass();
+		if (lexeme.equals(javaCls.getName())) {
 			token.setType(TokenTypes.IDENTIFIER);
 		}
 	}


### PR DESCRIPTION
### Problem
RSyntaxTextArea marks all tokens whose lexemes match class names under `java.lang`, `java.io`, and `java.util` as `TokenTypes.FUNCTION`. This happens even when the token is not a corresponding class identifier — such as a method, field, or local variable identifier. This problem not only causes incorrect syntax highlighting but also disables the rename button in the right-click context menu.
### Solution
Refer to the `mergeLongClassNames()` in `JadxTokenMaker`, look up metadata and correct the token types accordingly.
### Figures
<img width="3820" height="1110" alt="result1" src="https://github.com/user-attachments/assets/518f7e65-55f6-48d8-a503-f0b044d7da79" />
<img width="3598" height="650" alt="result2" src="https://github.com/user-attachments/assets/c299c89f-f1f4-446b-b04d-13d3883001ee" />

### Changed Files
| File | Change |
| --- | --- |
| jadx-gui/src/main/java/jadx/gui/ui/codearea/JadxTokenMaker.java | Correct token types based on metadata. |
| jadx-gui/src/main/java/jadx/gui/ui/codearea/CodeArea.java | Added a modified version of `getJavaClassIfAtPos()` to retrieve metadata other than just class. |
| jadx-core/src/main/java/jadx/core/codegen/ClassGen.java | Fixed an import conflict where `plasion.data.Object` would be redundantly imported after `java.lang.Object` was already imported (see Figure 1). |
| jadx-core/src/main/java/jadx/core/dex/info/ClassInfo.java | Add doc for `getParentClass()` and `getTopParentClass()`. The naming of `getParentClass()` cost me a lot of reading code time. I hope other developers won’t run into the same confusion. |