### PR TITLE
Fix ImmutableList.lastIndexOf skipping index 0

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/ImmutableList.java
+++ b/jadx-core/src/main/java/jadx/core/utils/ImmutableList.java
@@ -60,7 +60,7 @@ public final class ImmutableList<E> implements List<E>, RandomAccess {
 
 	@Override
 	public int lastIndexOf(Object o) {
-		for (int i = arr.length - 1; i > 0; i--) {
+		for (int i = arr.length - 1; i >= 0; i--) {
 			E e = arr[i];
 			if (Objects.equals(e, o)) {
 				return i;

--- a/jadx-core/src/test/java/jadx/core/utils/ImmutableListTest.java
+++ b/jadx-core/src/test/java/jadx/core/utils/ImmutableListTest.java
@@ -1,0 +1,38 @@
+package jadx.core.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class ImmutableListTest {
+
+	@Test
+	public void lastIndexOfElementOnlyAtIndex0() {
+		String[] arr = new String[] { "a", "b", "c" };
+		ImmutableList<String> list = new ImmutableList<>(arr);
+		// "a" is at index 0 only; lastIndexOf should return 0
+		assertEquals(0, list.lastIndexOf("a"));
+	}
+
+	@Test
+	public void lastIndexOfElementAtIndex0AndLater() {
+		String[] arr = new String[] { "a", "b", "a" };
+		ImmutableList<String> list = new ImmutableList<>(arr);
+		// "a" is at index 0 and 2; lastIndexOf should return 2
+		assertEquals(2, list.lastIndexOf("a"));
+	}
+
+	@Test
+	public void lastIndexOfElementNotPresent() {
+		String[] arr = new String[] { "a", "b", "c" };
+		ImmutableList<String> list = new ImmutableList<>(arr);
+		assertEquals(-1, list.lastIndexOf("z"));
+	}
+
+	@Test
+	public void lastIndexOfSingleElementList() {
+		String[] arr = new String[] { "only" };
+		ImmutableList<String> list = new ImmutableList<>(arr);
+		assertEquals(0, list.lastIndexOf("only"));
+	}
+}

--- a/jadx-core/src/test/java/jadx/core/utils/ImmutableListTest.java
+++ b/jadx-core/src/test/java/jadx/core/utils/ImmutableListTest.java
@@ -1,8 +1,8 @@
 package jadx.core.utils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ImmutableListTest {
 


### PR DESCRIPTION
## Problem

`ImmutableList.lastIndexOf` scans the backing array backwards but uses `i > 0` as the loop condition:

```java
for (int i = arr.length - 1; i > 0; i--) {
    if (obj.equals(arr[i])) {
        return i;
    }
}
return -1;
```

Because the loop stops before `i == 0`, index 0 is never examined. An element that exists only at index 0 — including any single-element list — returns `-1` instead of `0`.

## Fix

Use `i >= 0` so index 0 is checked.

## Test

Adds `ImmutableListTest` covering `lastIndexOf`, including an element only at index 0 and a single-element list. The index-0 cases fail before the change (`expected: <0> but was: <-1>`) and pass after.