### PR TITLE
Handle empty string in Utils.cleanObjectName and cutObject

### DIFF
--- a/jadx-core/src/main/java/jadx/core/utils/Utils.java
+++ b/jadx-core/src/main/java/jadx/core/utils/Utils.java
@@ -41,6 +41,9 @@ public class Utils {
 	}
 
 	public static String cleanObjectName(String obj) {
+		if (obj.isEmpty()) {
+			return obj;
+		}
 		if (obj.charAt(0) == 'L') {
 			int last = obj.length() - 1;
 			if (obj.charAt(last) == ';') {
@@ -51,6 +54,9 @@ public class Utils {
 	}
 
 	public static String cutObject(String obj) {
+		if (obj.isEmpty()) {
+			return obj;
+		}
 		if (obj.charAt(0) == 'L') {
 			return obj.substring(1, obj.length() - 1);
 		}

--- a/jadx-core/src/test/java/jadx/core/utils/UtilsEmptyStringTest.java
+++ b/jadx-core/src/test/java/jadx/core/utils/UtilsEmptyStringTest.java
@@ -1,0 +1,35 @@
+package jadx.core.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class UtilsEmptyStringTest {
+
+	@Test
+	public void cleanObjectNameEmptyString() {
+		// cleanObjectName should handle empty string gracefully (return it unchanged),
+		// not throw StringIndexOutOfBoundsException on charAt(0)
+		assertDoesNotThrow(() -> Utils.cleanObjectName(""));
+		assertEquals("", Utils.cleanObjectName(""));
+	}
+
+	@Test
+	public void cutObjectEmptyString() {
+		// cutObject should handle empty string gracefully (return it unchanged),
+		// not throw StringIndexOutOfBoundsException on charAt(0)
+		assertDoesNotThrow(() -> Utils.cutObject(""));
+		assertEquals("", Utils.cutObject(""));
+	}
+
+	@Test
+	public void cleanObjectNameNormalCase() {
+		assertEquals("java.lang.String", Utils.cleanObjectName("Ljava/lang/String;"));
+	}
+
+	@Test
+	public void cutObjectNormalCase() {
+		assertEquals("java/lang/String", Utils.cutObject("Ljava/lang/String;"));
+	}
+}


### PR DESCRIPTION
## Problem

`Utils.cleanObjectName` and `Utils.cutObject` both start by calling `obj.charAt(0)`:

```java
public static String cleanObjectName(String obj) {
    if (obj.charAt(0) == \x27L\x27) { ... }
}
```

Passing an empty string throws `StringIndexOutOfBoundsException: Index 0 out of bounds for length 0`.

## Fix

Return the empty string unchanged when the input is empty, in both methods.

## Test

Adds `UtilsEmptyStringTest` covering `cleanObjectName("")` and `cutObject("")` (plus normal cases). The empty-string cases fail on `master` (`StringIndexOutOfBoundsException`) and pass with this change.