### PR TITLE
fix: keep cast that changes operand arithmetic type in arith instructions

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
@@ -28,6 +28,7 @@ import jadx.core.dex.instructions.args.ArgType;
 import jadx.core.dex.instructions.args.InsnArg;
 import jadx.core.dex.instructions.args.InsnWrapArg;
 import jadx.core.dex.instructions.args.LiteralArg;
+import jadx.core.dex.instructions.args.PrimitiveType;
 import jadx.core.dex.instructions.args.RegisterArg;
 import jadx.core.dex.instructions.args.SSAVar;
 import jadx.core.dex.instructions.mods.ConstructorInsn;
@@ -231,7 +232,7 @@ public class SimplifyVisitor extends AbstractVisitor {
 		}
 
 		ArgType castToType = (ArgType) castInsn.getIndex();
-		if (isArithWideUpCast(parentInsn, argType, castToType)) {
+		if (isArithTypeChangingCast(parentInsn, argType, castToType)) {
 			return null;
 		}
 		if (!ArgType.isCastNeeded(mth.root(), argType, castToType)
@@ -247,18 +248,36 @@ public class SimplifyVisitor extends AbstractVisitor {
 	}
 
 	/**
-	 * Keep cast to wide types in arith instructions,
+	 * Keep cast that changes the operand arithmetic type in arith instructions,
 	 * because arguments type determine instruction used in result bytecode.
-	 * Example: (long) i << 32 - without 'long' cast will be used 'int shift' instruction and result
-	 * will be incorrect
+	 * Examples:
+	 * (long) i << 32 - without 'long' cast will be used 'int shift' instruction and result
+	 * will be incorrect;
+	 * (float) i / (float) j - without 'float' casts will be used 'int division' instruction.
 	 */
-	private static boolean isArithWideUpCast(@Nullable InsnNode parentInsn, ArgType argType, ArgType castToType) {
+	private static boolean isArithTypeChangingCast(@Nullable InsnNode parentInsn, ArgType argType, ArgType castToType) {
 		if (parentInsn != null
 				&& parentInsn.getType() == InsnType.ARITH
 				&& argType.isPrimitive() && castToType.isPrimitive()) {
-			return castToType.getRegCount() > argType.getRegCount();
+			return getArithPrimitiveType(argType) != getArithPrimitiveType(castToType);
 		}
 		return false;
+	}
+
+	/**
+	 * Arithmetic type used by bytecode arith instructions: int, long, float or double.
+	 * Types narrower than int (boolean, byte, char and short) are treated as int.
+	 */
+	private static PrimitiveType getArithPrimitiveType(ArgType type) {
+		PrimitiveType primitiveType = type.getPrimitiveType();
+		switch (primitiveType) {
+			case LONG:
+			case FLOAT:
+			case DOUBLE:
+				return primitiveType;
+			default:
+				return PrimitiveType.INT;
+		}
 	}
 
 	private static boolean isCastDuplicate(IndexInsnNode castInsn) {

--- a/jadx-core/src/test/java/jadx/tests/integration/arith/TestCastInArith.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/arith/TestCastInArith.java
@@ -1,0 +1,43 @@
+package jadx.tests.integration.arith;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.IntegrationTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestCastInArith extends IntegrationTest {
+
+	public static class TestCls {
+		public float floatDiv(int a, int b) {
+			return (float) a / (float) b;
+		}
+
+		public double doubleDiv(long a, long b) {
+			return (double) a / (double) b;
+		}
+
+		public void check() {
+			assertThat(floatDiv(1, 2)).isEqualTo(0.5f);
+			assertThat(doubleDiv(1, 2)).isEqualTo(0.5);
+		}
+	}
+
+	@Test
+	public void test() {
+		assertThat(getClassNode(TestCls.class))
+				.code()
+				.containsOneOf("return (float) a / (float) b;", "return ((float) a) / ((float) b);")
+				.containsOneOf("return (double) a / (double) b;", "return ((double) a) / ((double) b);");
+	}
+
+	@Test
+	public void testNoDebug() {
+		noDebugInfo();
+		assertThat(getClassNode(TestCls.class))
+				.code()
+				.containsOneOf("(float) i / (float) i2", "((float) i) / ((float) i2)")
+				.containsOneOf("(double) j / (double) j2", "((double) j) / ((double) j2)");
+	}
+}


### PR DESCRIPTION
NOTE: This is what one may call "AI slop". Feel free to close this PR if it's not up to your quality standards or even if you just aren't interested in reviewing it. I use these changes downstream on an APK and thought I might as well make a PR offering to upstream them, as your CONTRIBUTING.md doesn't say anything discouraging this.

### Description

`(float) a / (float) b` with `int` operands decompiled to `a / b`, an integer division, so the result was truncated: `floatDiv(1, 2)` returned `0.0f` instead of `0.5f`. It reproduces on both the dex and java/class paths, since the cast is dropped in `SimplifyVisitor`, which is shared by all inputs.

`SimplifyVisitor.processCast` drops a primitive cast feeding an `ARITH` insn when `isArithWideUpCast` reports it as unnecessary. That helper only kept casts that grow the operand register count (`castToType.getRegCount() > argType.getRegCount()`). `int` and `float` share a register count, so the `int`->`float` cast was dropped and jadx emitted an integer division, then relied on a widening at the result that does not happen (the division is already done in `int`).

Keep any cast that changes the operand arithmetic type (`int`/`long`/`float`/`double`), because operand types select the arith instruction in the result bytecode. Types narrower than `int` are treated as `int`. The `(long) i << 32` case the old check handled stays covered, since it is also a type change.

Includes an integration test.
