### PR TITLE
fix: don't re-invert a shared 'if' condition in a duplicated block

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/regions/maker/IfRegionMaker.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/regions/maker/IfRegionMaker.java
@@ -68,17 +68,15 @@ final class IfRegionMaker {
 		IfInfo mergedIf = mergeNestedIfNodes(currentIf);
 		if (mergedIf != null) {
 			currentIf = mergedIf;
-		} else {
+		} else if (!block.contains(AFlag.DONT_INVERT)) {
 			// invert simple condition (compiler often do it)
-			// ensure that we only ever invert once, because if multiple regions contain this block
-			// we'll change the block after it's already been included in a region, which can cause
-			// other regions containing the block to believe the condition has been flipped when it
-			// has not, or vice versa.
-			if (!block.contains(AFlag.DONT_INVERT)) {
-				currentIf = IfInfo.invert(currentIf);
-				block.add(AFlag.DONT_INVERT);
-			}
+			currentIf = IfInfo.invert(currentIf);
 		}
+		// Guard the simple inversion above from being applied again on a later region-head pass over
+		// this shared block (see AFlag.DUPLICATED): its 'if' instruction is inverted in place, so a
+		// second inversion would flip an operand of the condition already built here. Set the flag
+		// after a merge too, since that branch skips the simple inversion above.
+		block.add(AFlag.DONT_INVERT);
 		IfInfo modifiedIf = restructureIf(block, currentIf);
 		if (modifiedIf != null) {
 			currentIf = modifiedIf;

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestDuplicatedBlockCondition.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestDuplicatedBlockCondition.java
@@ -1,0 +1,19 @@
+package jadx.tests.integration.conditions;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.RaungTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestDuplicatedBlockCondition extends RaungTest {
+
+	@Test
+	public void test() {
+		allowWarnInCode(); // block is duplicated, see TestConditions22
+		assertThat(getClassNodeFromRaung())
+				.code()
+				.containsOne("if (z3 || z4) {")
+				.doesNotContain("!z3 || z4");
+	}
+}

--- a/jadx-core/src/test/raung/conditions/TestDuplicatedBlockCondition.raung
+++ b/jadx-core/src/test/raung/conditions/TestDuplicatedBlockCondition.raung
@@ -1,0 +1,41 @@
+.version 50
+.class public super conditions/TestDuplicatedBlockCondition
+.super java/lang/Object
+.auto frames
+
+# Java equivalent:
+#   static int test(boolean a, boolean b, boolean x, boolean y) {
+#       int r = 2;
+#       if (a || b) {         # 'if' body is a block with two predecessors -> DUPLICATED
+#           r = (x || y) ? 1 : 0;
+#       }
+#       return r;
+#   }
+#
+# The '(x || y)' block heads a merged short-circuit condition and is also reached from
+# two predecessors, so it is processed as a region head twice. The second (standalone)
+# pass must not invert its shared 'if' instruction again, otherwise the first operand of
+# the already built condition gets flipped ('x || y' -> '!x || y').
+
+.method public static test(ZZZZ)I
+    iload 0
+    ifne :L_body
+    iconst_2
+    istore 4
+    iload 1
+    ifeq :L_return
+  :L_body
+    iload 2
+    ifne :L_one
+    iload 3
+    ifne :L_one
+    iconst_0
+    istore 4
+    goto :L_return
+  :L_one
+    iconst_1
+    istore 4
+  :L_return
+    iload 4
+    ireturn
+.end method


### PR DESCRIPTION
NOTE: This is what one may call "AI slop". Feel free to close this PR if it's not up to your quality standards or even if you just aren't interested in reviewing it. I use these changes downstream on an APK and thought I might as well make a PR offering to upstream them, as your CONTRIBUTING.md doesn't say anything discouraging this.

### Description

Demonstrated on the java/class input path. A condition that heads a block belonging to more than one region is inverted one extra time, flipping its first operand. For

```java
static int test(boolean a, boolean b, boolean x, boolean y) {
    int r = 2;
    if (a || b) {
        r = (x || y) ? 1 : 0;
    }
    return r;
}
```

the inner `(x || y)` decompiled as `(!x || y)`: the first operand picked up a spurious negation.

`IfRegionMaker.process` inverts a simple condition in place: `IfInfo.invert` (via `IfCondition.invert`) calls `Compare.invert`, which mutates the block's shared `IfNode` in place. The `(x || y)` block heads a merged short-circuit condition and is also reached from two predecessors (`AFlag.DUPLICATED`), so it is processed as a region head more than once. The `DONT_INVERT` guard that prevents a second in-place inversion was only set on the simple-invert path, not when the condition was built by `mergeNestedIfNodes`, so the later standalone pass inverted the already-built condition again and flipped its first operand.

Set `AFlag.DONT_INVERT` after both the merge and the simple-invert branches, so a shared block's condition is inverted at most once regardless of how it was built.

Includes an integration test.
