### PR TITLE
fix: collapse ternary with the same constant in both branches

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/SimplifyVisitor.java
@@ -138,8 +138,7 @@ public class SimplifyVisitor extends AbstractVisitor {
 				simplifyIf(mth, (IfNode) insn);
 				break;
 			case TERNARY:
-				simplifyTernary(mth, (TernaryInsn) insn);
-				break;
+				return simplifyTernary(mth, (TernaryInsn) insn);
 
 			case INVOKE:
 				return convertInvoke(mth, (InvokeNode) insn);
@@ -306,13 +305,58 @@ public class SimplifyVisitor extends AbstractVisitor {
 	/**
 	 * Simplify condition in ternary operation
 	 */
-	private static void simplifyTernary(MethodNode mth, TernaryInsn insn) {
+	private static InsnNode simplifyTernary(MethodNode mth, TernaryInsn insn) {
+		if (insn.getArg(0).isSameConst(insn.getArg(1)) && canDropCondition(insn.getCondition())) {
+			// both branches yield the same constant and the condition has no side effect: 'c ? x : x' => 'x'
+			for (RegisterArg reg : insn.getCondition().getRegisterArgs()) {
+				InsnRemover.unbindArgUsage(mth, reg);
+			}
+			InsnArg valueArg = insn.getArg(0);
+			InsnNode value;
+			if (valueArg.isInsnWrap()) {
+				value = ((InsnWrapArg) valueArg).getWrapInsn().copyWithoutResult();
+			} else {
+				value = new InsnNode(InsnType.CONST, 1);
+				value.addArg(valueArg);
+			}
+			value.setResult(insn.getResult());
+			value.copyAttributesFrom(insn);
+			return value;
+		}
 		IfCondition condition = insn.getCondition();
 		if (condition.isCompare()) {
 			simplifyIf(mth, condition.getCompare().getInsn());
 		} else {
 			insn.simplifyCondition();
 		}
+		return null;
+	}
+
+	/**
+	 * A condition can be dropped only if evaluating it has no observable effect. Every condition
+	 * instruction must be in {@link InsnNode#canThrowException()}'s no-throw set (which holds only
+	 * pure insns: const/compare/move/neg), and every operand must be a parameter or a plain field
+	 * read. Anything else (a cast, invoke, array access, ...) may be the last use of a value whose
+	 * removal drops a cast/exception (e.g. the erased CHECK_CAST behind 'String s = list.get(0)').
+	 */
+	private static boolean canDropCondition(IfCondition condition) {
+		boolean[] pure = { true };
+		condition.visitInsns(insn -> {
+			if (insn.canThrowException()) {
+				pure[0] = false;
+			}
+		});
+		if (!pure[0]) {
+			return false;
+		}
+		for (RegisterArg reg : condition.getRegisterArgs()) {
+			// null assign == method argument (no producing insn to drop)
+			InsnNode assign = reg.getSVar().getAssignInsn();
+			if (assign != null && assign.getType() != InsnType.IGET && assign.getType() != InsnType.SGET) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/jadx-core/src/test/java/jadx/tests/integration/conditions/TestTernarySameResult.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/conditions/TestTernarySameResult.java
@@ -1,0 +1,31 @@
+package jadx.tests.integration.conditions;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.tests.api.RaungTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestTernarySameResult extends RaungTest {
+
+	// Uses hand-written bytecode: javac folds 'if (c) return x; else return x;', so a plain Java
+	// test can't produce the degenerate 'c ? x : x' ternary that this fix collapses.
+
+	@Test
+	public void test() {
+		assertThat(getClassNodeFromRaung())
+				.code()
+				// same constant in both branches + side-effect-free condition => collapse
+				.doesNotContain("? null : null")
+				.doesNotContain("? 7 : 7")
+				.doesNotContain("? \"x\" : \"x\"")
+				.containsOne("return null;")
+				.containsOne("return 7;")
+				.containsOne("return \"x\";")
+				// must keep the ternary: different values, a side effect in the condition,
+				// or an operand whose cast would be dropped with the condition
+				.containsOne("z ? 7 : 8")
+				.containsOne("? 5 : 5")
+				.containsOne("? 9 : 9");
+	}
+}

--- a/jadx-core/src/test/raung/conditions/TestTernarySameResult.raung
+++ b/jadx-core/src/test/raung/conditions/TestTernarySameResult.raung
@@ -1,0 +1,194 @@
+.version 65  # Java 21
+.class public super conditions/TestTernarySameResult
+.source "TestTernarySameResult.java"
+
+.field private calls I
+
+.method public <init>()V
+    .max stack 1
+    .max locals 1
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .line 2
+    aload 0
+    invokespecial java/lang/Object <init> ()V
+    return
+.end method
+
+.method public retNull(Ljava/lang/Object;)Ljava/lang/Object;
+    .max stack 1
+    .max locals 2
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .local 1 "o" Ljava/lang/Object;
+    .line 5
+    aload 1
+    ifnonnull :L1
+    aconst_null
+    areturn
+  :L1
+    .stack same
+    aconst_null
+    areturn
+.end method
+
+.method public retSame(Z)I
+    .max stack 1
+    .max locals 2
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .local 1 "z" Z
+    .line 8
+    iload 1
+    ifeq :L1
+    bipush 7
+    ireturn
+  :L1
+    .stack same
+    bipush 7
+    ireturn
+.end method
+
+.method public retStr(Z)Ljava/lang/String;
+    .max stack 1
+    .max locals 2
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .local 1 "z" Z
+    .line 11
+    iload 1
+    ifeq :L1
+    ldc "x"
+    areturn
+  :L1
+    .stack same
+    ldc "x"
+    areturn
+.end method
+
+.method public assignSame(Z)I
+    .max stack 1
+    .max locals 3
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .local 1 "z" Z
+    .line 15
+    iload 1
+    ifeq :L1
+    bipush 7
+    istore 2
+    .local 2 "r" I
+    goto :L3
+  :L1
+    .stack same
+    .end local 2 # "r"
+    bipush 7
+    istore 2
+  :L3
+    .local 2 "r" I
+    .line 16
+    .stack append
+        int
+    .end stack
+    iload 2
+    ireturn
+.end method
+
+.method public keepDiff(Z)I
+    .max stack 1
+    .max locals 3
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .local 1 "z" Z
+    .line 20
+    iload 1
+    ifeq :L1
+    bipush 7
+    istore 2
+    .local 2 "r" I
+    goto :L3
+  :L1
+    .stack same
+    .end local 2 # "r"
+    bipush 8
+    istore 2
+  :L3
+    .local 2 "r" I
+    .line 21
+    .stack append
+        int
+    .end stack
+    iload 2
+    ireturn
+.end method
+
+.method public keepEffect()I
+    .max stack 1
+    .max locals 2
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .line 25
+    aload 0
+    invokevirtual conditions/TestTernarySameResult ping ()I
+    ifle :L1
+    iconst_5
+    istore 1
+    .local 1 "r" I
+    goto :L3
+  :L1
+    .stack same
+    .end local 1 # "r"
+    iconst_5
+    istore 1
+  :L3
+    .local 1 "r" I
+    .line 26
+    .stack append
+        int
+    .end stack
+    iload 1
+    ireturn
+.end method
+
+.method public keepCast(Ljava/lang/Object;)I
+    .max stack 1
+    .max locals 3
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .local 1 "o" Ljava/lang/Object;
+    .line 29
+    aload 1
+    checkcast java/lang/Integer
+    astore 2
+    .local 2 "i" Ljava/lang/Integer;
+    .line 30
+    aload 2
+    ifnull :L2
+    bipush 9
+    goto :L3
+  :L2
+    .stack append
+        java/lang/Integer
+    .end stack
+    bipush 9
+  :L3
+    .stack same1 int
+    ireturn
+.end method
+
+.method private ping()I
+    .max stack 3
+    .max locals 1
+
+    .local 0 "this" Lconditions/TestTernarySameResult;
+    .line 32
+    aload 0
+    dup
+    getfield conditions/TestTernarySameResult calls I
+    iconst_1
+    iadd
+    putfield conditions/TestTernarySameResult calls I
+    aload 0
+    getfield conditions/TestTernarySameResult calls I
+    ireturn
+.end method


### PR DESCRIPTION
NOTE: This is what one may call "AI slop". Feel free to close this PR if it's not up to your quality standards or even if you just aren't interested in reviewing it. I use these changes downstream on an APK and thought I might as well make a PR offering to upstream them, as your CONTRIBUTING.md doesn't say anything discouraging this.

### Description

`if (c) return x; else return x;` (and the assignment form) decompiled to a redundant `c ? x : x`, a ternary with the same constant in both branches, e.g. `return apiException != null ? null : null;`. It shows on every input path (dex and java/class alike): `TernaryMod` forms the ternary without noticing the two results are equal, and nothing removes it.

`SimplifyVisitor.simplifyTernary` (which already normalizes a ternary's condition) now also collapses `c ? x : x` to `x` when both value args are the same constant (`InsnArg.isSameConst`, covering int/null/string/class constants), for both the return-wrapped and assign-result forms.

Dropping the condition is only safe when evaluating it has no observable effect, so `canDropCondition` collapses only when every condition instruction is non-throwing and every operand is a parameter or a plain field read (`IGET`/`SGET`). `foo() ? x : x` and `a[0] > 0 ? x : x` are left as-is, and a cast operand is rejected so the erased `CHECK_CAST` behind `String s = list.get(0)` (and its `ClassCastException`) is never dropped.

This is scoped to same-constant branches. A same-value ternary (`c ? v : v` with the same variable) is left as-is.

Includes an integration test.
