### PR TITLE
test: cover class generation scenarios

### DIFF
--- a/jadx-core/src/test/java/jadx/tests/integration/others/TestClassGen.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/others/TestClassGen.java
@@ -19,6 +19,28 @@ public class TestClassGen extends IntegrationTest {
 		}
 	}
 
+	public static class GenericCls<T extends Number & Comparable<T>> {
+		private final T value;
+
+		public GenericCls(T value) {
+			this.value = value;
+		}
+
+		public <R extends Runnable> R get(R runnable) {
+			return runnable;
+		}
+	}
+
+	public static class MultiInterfaceCls implements Runnable, AutoCloseable {
+		@Override
+		public void run() {
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+
 	@Test
 	public void test() {
 		JadxAssertions.assertThat(getClassNode(TestCls.class))
@@ -29,5 +51,24 @@ public class TestClassGen extends IntegrationTest {
 				.contains(indent(2) + "int test3();")
 				.contains("public static abstract class A {")
 				.contains(indent(2) + "public abstract int test2();");
+	}
+
+	@Test
+	public void testGenericBounds() {
+		JadxAssertions.assertThat(getClassNode(GenericCls.class))
+				.code()
+				.contains("public class TestClassGen$GenericCls<T extends Number & Comparable<T>> {")
+				.contains("private final T value;")
+				.contains("public TestClassGen$GenericCls(T value) {")
+				.contains("public <R extends Runnable> R get(R runnable) {");
+	}
+
+	@Test
+	public void testMultipleInterfaces() {
+		JadxAssertions.assertThat(getClassNode(MultiInterfaceCls.class))
+				.code()
+				.contains("public class TestClassGen$MultiInterfaceCls implements Runnable, AutoCloseable {")
+				.contains("public void run() {")
+				.contains("public void close() {");
 	}
 }


### PR DESCRIPTION
Hi,

I added two focused integration tests for class generation output that was not covered by the existing test. They keep generic bounds and multiple-interface class declarations covered through the normal decompiler assertions.

Impact on coverage:

* Covers class header generation for generic bounds and multiple implemented interfaces, including [ClassGen.java:195-218](https://github.com/amirdeljouyi/jadx/blob/6b973d32cf161ebf1f10ebdf9c72eb4eba8f7399/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java#L195-L218) and [ClassGen.java:226-264](https://github.com/amirdeljouyi/jadx/blob/6b973d32cf161ebf1f10ebdf9c72eb4eba8f7399/jadx-core/src/main/java/jadx/core/codegen/ClassGen.java#L226-L264)
* Line coverage for `ClassGen` increases by 27%.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir