### PR TITLE
gui: Copy full code snippet when copy all search results

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/dialog/CommonSearchDialog.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/dialog/CommonSearchDialog.java
@@ -190,7 +190,12 @@ public abstract class CommonSearchDialog extends JFrame {
 			if (javaNode != null) {
 				String codeNodeRef = javaNode.getCodeNodeRef().toString();
 				if (uniqueRefs.add(codeNodeRef)) {
-					sb.append(codeNodeRef).append("\n");
+					sb.append(codeNodeRef);
+					if (node.hasDescString()) {
+						String code = node.makeDescString();
+						sb.append("		").append(code);
+					}
+					sb.append("\n");
 				}
 			}
 		}


### PR DESCRIPTION
### Changes
Modify `CommonSearchDialog#copyAllSearchResults` to also copy matched code snippet from search table, format each output line as:
`[node ref]   code line`

1. Append matched code snippet after node CodeNodeRef when using the Copy button