### PR TITLE
feat(gui): programmatic open/close project + init plugins with no project open

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/JadxWrapper.java
@@ -87,6 +87,31 @@ public class JadxWrapper {
 		}
 	}
 
+	public void initPluginsForEmptyWorkspace() {
+		synchronized (DECOMPILER_UPDATE_SYNC) {
+			if (decompiler != null) {
+				return; // a project (or a previous empty init) is already active
+			}
+			try {
+				JadxArgs jadxArgs = getSettings().toJadxArgs();
+				jadxArgs.setPluginLoader(new JadxExternalPluginsLoader());
+				jadxArgs.setFilesGetter(JadxFilesGetter.INSTANCE);
+				JadxAppCommon.applyEnvVars(jadxArgs);
+
+				JadxDecompiler dc = new JadxDecompiler(jadxArgs);
+				CommonGuiPluginsContext ctx = initGuiPluginsContext(dc, mainWindow);
+				dc.setEventsImpl(mainWindow.events());
+				// Plugin init only: no input validation, no class loading.
+				dc.getPluginManager().load(jadxArgs.getPluginLoader());
+				dc.getPluginManager().initResolved();
+				decompiler = dc;
+				guiPluginsContext = ctx;
+			} catch (Exception e) {
+				LOG.error("Jadx empty-workspace plugin init error", e);
+			}
+		}
+	}
+
 	// TODO: check and move into core package
 	public void unloadClasses() {
 		getCurrentDecompiler().ifPresent(decompiler -> {

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -377,6 +377,41 @@ public class MainWindow extends JFrame {
 		});
 	}
 
+	public void closeProject(boolean save, @Nullable Runnable onFinish) {
+		UiUtils.bgRun(() -> {
+			try {
+				if (save) {
+					UiUtils.uiRunAndWait(() -> {
+						saveAll();
+						persistProjectSilently();
+					});
+				}
+				closeAll();
+				updateProject(new JadxProject(this));
+			} catch (Exception e) {
+				LOG.error("Programmatic closeProject error", e);
+			} finally {
+				if (onFinish != null) {
+					onFinish.run();
+				}
+			}
+		});
+	}
+
+	private void persistProjectSilently() {
+		if (project.isInitial() || project.getFilePaths().isEmpty()) {
+			return;
+		}
+		if (project.isSaveFileSelected()) {
+			project.save();
+		} else {
+			Path defaultPath = getProjectPathForFile(project.getFilePaths().get(0));
+			project.saveAs(defaultPath);
+			settings.addRecentProject(defaultPath);
+		}
+		settings.sync();
+	}
+
 	private void saveProject() {
 		saveOpenTabs();
 		if (!project.isSaveFileSelected()) {

--- a/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/MainWindow.java
@@ -293,9 +293,20 @@ public class MainWindow extends JFrame {
 	private void processCommandLineArgs() {
 		if (settings.getFiles().isEmpty()) {
 			tabsController.selectTab(new StartPageNode());
+			initGuiPluginsForEmptyWorkspace();
 		} else {
 			open(FileUtils.fileNamesToPaths(settings.getFiles()), this::handleSelectClassOption);
 		}
+	}
+
+	private void initGuiPluginsForEmptyWorkspace() {
+		UiUtils.bgRun(() -> {
+			try {
+				wrapper.initPluginsForEmptyWorkspace();
+			} catch (Exception e) {
+				LOG.warn("Failed to initialize GUI plugins for empty workspace", e);
+			}
+		});
 	}
 
 	private void handleSelectClassOption() {
@@ -502,6 +513,16 @@ public class MainWindow extends JFrame {
 
 	public void open(List<Path> paths) {
 		open(paths, UiUtils.EMPTY_RUNNABLE);
+	}
+
+	/**
+	 * Programmatically open the given input files (e.g an APK) as a new project without any GUI
+	 * dialog, replacing the current project. Intended for automation and AI, mirroring
+	 * {@link #closeProject(boolean, Runnable)}: {@code onFinish} runs once the new project has
+	 * finished loading (it is not invoked on load failure), so callers can wait for readiness.
+	 */
+	public void openProject(List<Path> paths, @Nullable Runnable onFinish) {
+		UiUtils.uiRun(() -> open(paths, onFinish == null ? UiUtils.EMPTY_RUNNABLE : onFinish));
 	}
 
 	private void open(List<Path> paths, Runnable onFinish) {


### PR DESCRIPTION
### Description

closes: #2913.

I have been running jadx-gui with an MCP plugin that exposes a small local HTTP endpoint so i can control it from another tool. The workflow is: open an APK, analyze it, close it, then open the next one, without using the GUI. This PR adds support for that.

For the Open/close projects programmatically, MainWindow already has the logic to open and close projects but only through the GUI. What i did is basically add two methods that do the same thing without showing dialogs:

* `closeProject(boolean save, Runnable onFinish)` close the current project, optionally saving it first, then call `onFinish`.
* `openProject(List<Path> paths, Runnable onFinish)` opens the given files as a new project and calls `onFinish` after loading finishes.

Both use the already existing open/close code just without the file chooser and save prompts.

Now i made it possible to initialize plugins before the first project, GUI plugins are currently started only after a project is loaded so a plugin can't do anything before the first APK is opened.

If jadx starts without a project, it now starts plugins against an empty workspace. `JadxWrapper.initPluginsForEmptyWorkspace()` runs the plugin initialization part of `open()` but skips input validation since there are no files yet. Opening a real project later works the same as before.

No changes to existing behaviors done.