### PR TITLE
fix(core): restore enum initialized with external SGET field (#2618)

### DIFF
--- a/jadx-core/src/main/java/jadx/core/dex/visitors/EnumVisitor.java
+++ b/jadx-core/src/main/java/jadx/core/dex/visitors/EnumVisitor.java
@@ -512,17 +512,33 @@ public class EnumVisitor extends AbstractVisitor {
 		List<RegisterArg> regs = new ArrayList<>();
 		resCo.getRegisterArgs(regs);
 		for (RegisterArg reg : regs) {
+			InsnNode enumUse;
 			FieldInfo enumField = checkExternalRegUsage(data, reg);
-			if (enumField == null) {
-				return null;
+			if (enumField != null) {
+				enumUse = new IndexInsnNode(InsnType.SGET, enumField, 0);
+			} else {
+				// enum field can also be initialized from an external static value read (SGET),
+				// e.g. a constant of another enum reused across several fields (issue #2618)
+				enumUse = inlineExternalSget(reg);
+				if (enumUse == null) {
+					return null;
+				}
 			}
-			InsnNode enumUse = new IndexInsnNode(InsnType.SGET, enumField, 0);
 			boolean replaced = resCo.replaceArg(reg, InsnArg.wrapArg(enumUse));
 			if (!replaced) {
 				return null;
 			}
 		}
 		return resCo;
+	}
+
+	private static @Nullable InsnNode inlineExternalSget(RegisterArg reg) {
+		InsnNode assignInsn = checkInsnType(reg.getSVar().getAssignInsn(), InsnType.SGET);
+		if (assignInsn == null) {
+			return null;
+		}
+		FieldInfo fieldInfo = (FieldInfo) ((IndexInsnNode) assignInsn).getIndex();
+		return new IndexInsnNode(InsnType.SGET, fieldInfo, 0);
 	}
 
 	private static FieldInfo checkExternalRegUsage(EnumData data, RegisterArg reg) {

--- a/jadx-core/src/test/java/jadx/tests/integration/enums/TestEnumExternalSget.java
+++ b/jadx-core/src/test/java/jadx/tests/integration/enums/TestEnumExternalSget.java
@@ -1,0 +1,32 @@
+package jadx.tests.integration.enums;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import jadx.core.dex.nodes.ClassNode;
+import jadx.tests.api.SmaliTest;
+
+import static jadx.tests.api.utils.assertj.JadxAssertions.assertThat;
+
+public class TestEnumExternalSget extends SmaliTest {
+
+	/**
+	 * Enum constant constructors take an argument whose value is a static-field
+	 * read (SGET) of an external enum constant (ExtEnum.FIRST/SECOND). The value
+	 * is reused across constants, so R8 keeps it in a register instead of
+	 * inlining it. Previously EnumVisitor failed to restore the enum with
+	 * "Init of enum field '...' uses external variables" (see issue #2618).
+	 */
+	@Test
+	public void test() {
+		disableCompilation();
+		List<ClassNode> classNodes = loadFromSmaliFiles();
+		assertThat(searchCls(classNodes, "TestEnumExternalSget"))
+				.code()
+				.containsOne("enum TestEnumExternalSget")
+				.containsOne("A(ExtEnum.FIRST)")
+				.containsOne("B(ExtEnum.FIRST)")
+				.containsOne("C(ExtEnum.SECOND)");
+	}
+}

--- a/jadx-core/src/test/smali/enums/TestEnumExternalSget/ExtEnum.smali
+++ b/jadx-core/src/test/smali/enums/TestEnumExternalSget/ExtEnum.smali
@@ -1,0 +1,95 @@
+.class public final enum Lenums/ExtEnum;
+.super Ljava/lang/Enum;
+.source ""
+
+.annotation system Ldalvik/annotation/Signature;
+    value = {
+        "Ljava/lang/Enum<",
+        "Lenums/ExtEnum;",
+        ">;"
+    }
+.end annotation
+
+
+.field public static final enum FIRST:Lenums/ExtEnum;
+
+.field public static final enum SECOND:Lenums/ExtEnum;
+
+.field private static final synthetic $VALUES:[Lenums/ExtEnum;
+
+
+.method static constructor <clinit>()V
+    .registers 4
+
+    new-instance v0, Lenums/ExtEnum;
+
+    const-string v1, "FIRST"
+
+    const/4 v2, 0x0
+
+    invoke-direct {v0, v1, v2}, Lenums/ExtEnum;-><init>(Ljava/lang/String;I)V
+
+    sput-object v0, Lenums/ExtEnum;->FIRST:Lenums/ExtEnum;
+
+    new-instance v1, Lenums/ExtEnum;
+
+    const-string v2, "SECOND"
+
+    const/4 v3, 0x1
+
+    invoke-direct {v1, v2, v3}, Lenums/ExtEnum;-><init>(Ljava/lang/String;I)V
+
+    sput-object v1, Lenums/ExtEnum;->SECOND:Lenums/ExtEnum;
+
+    const/4 v2, 0x2
+
+    new-array v2, v2, [Lenums/ExtEnum;
+
+    const/4 v3, 0x0
+
+    aput-object v0, v2, v3
+
+    const/4 v0, 0x1
+
+    aput-object v1, v2, v0
+
+    sput-object v2, Lenums/ExtEnum;->$VALUES:[Lenums/ExtEnum;
+
+    return-void
+.end method
+
+.method private constructor <init>(Ljava/lang/String;I)V
+    .registers 3
+
+    invoke-direct {p0, p1, p2}, Ljava/lang/Enum;-><init>(Ljava/lang/String;I)V
+
+    return-void
+.end method
+
+.method public static valueOf(Ljava/lang/String;)Lenums/ExtEnum;
+    .registers 2
+
+    const-class v0, Lenums/ExtEnum;
+
+    invoke-static {v0, p0}, Ljava/lang/Enum;->valueOf(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
+
+    move-result-object p0
+
+    check-cast p0, Lenums/ExtEnum;
+
+    return-object p0
+.end method
+
+.method public static values()[Lenums/ExtEnum;
+    .registers 1
+
+    sget-object v0, Lenums/ExtEnum;->$VALUES:[Lenums/ExtEnum;
+
+    invoke-virtual {v0}, [Lenums/ExtEnum;->clone()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, [Lenums/ExtEnum;
+
+    return-object v0
+.end method

--- a/jadx-core/src/test/smali/enums/TestEnumExternalSget/TestEnumExternalSget.smali
+++ b/jadx-core/src/test/smali/enums/TestEnumExternalSget/TestEnumExternalSget.smali
@@ -1,0 +1,131 @@
+.class public final enum Lenums/TestEnumExternalSget;
+.super Ljava/lang/Enum;
+.source ""
+
+.annotation system Ldalvik/annotation/Signature;
+    value = {
+        "Ljava/lang/Enum<",
+        "Lenums/TestEnumExternalSget;",
+        ">;"
+    }
+.end annotation
+
+
+.field public static final enum A:Lenums/TestEnumExternalSget;
+
+.field public static final enum B:Lenums/TestEnumExternalSget;
+
+.field public static final enum C:Lenums/TestEnumExternalSget;
+
+.field private static final synthetic $VALUES:[Lenums/TestEnumExternalSget;
+
+
+# instance fields
+.field public final ext:Lenums/ExtEnum;
+
+
+.method static constructor <clinit>()V
+    .registers 10
+
+    # External enum constant reused across two enum fields, so it stays in a
+    # register (not inlined) and reaches the enum constructor as a register arg.
+    sget-object v0, Lenums/ExtEnum;->FIRST:Lenums/ExtEnum;
+
+    new-instance v1, Lenums/TestEnumExternalSget;
+
+    const-string v5, "A"
+
+    const/4 v6, 0x0
+
+    invoke-direct {v1, v5, v6, v0}, Lenums/TestEnumExternalSget;-><init>(Ljava/lang/String;ILenums/ExtEnum;)V
+
+    sput-object v1, Lenums/TestEnumExternalSget;->A:Lenums/TestEnumExternalSget;
+
+    new-instance v2, Lenums/TestEnumExternalSget;
+
+    const-string v5, "B"
+
+    const/4 v6, 0x1
+
+    invoke-direct {v2, v5, v6, v0}, Lenums/TestEnumExternalSget;-><init>(Ljava/lang/String;ILenums/ExtEnum;)V
+
+    sput-object v2, Lenums/TestEnumExternalSget;->B:Lenums/TestEnumExternalSget;
+
+    new-instance v3, Lenums/TestEnumExternalSget;
+
+    sget-object v4, Lenums/ExtEnum;->SECOND:Lenums/ExtEnum;
+
+    const-string v5, "C"
+
+    const/4 v6, 0x2
+
+    invoke-direct {v3, v5, v6, v4}, Lenums/TestEnumExternalSget;-><init>(Ljava/lang/String;ILenums/ExtEnum;)V
+
+    sput-object v3, Lenums/TestEnumExternalSget;->C:Lenums/TestEnumExternalSget;
+
+    const/4 v5, 0x3
+
+    new-array v5, v5, [Lenums/TestEnumExternalSget;
+
+    const/4 v6, 0x0
+
+    aput-object v1, v5, v6
+
+    const/4 v6, 0x1
+
+    aput-object v2, v5, v6
+
+    const/4 v6, 0x2
+
+    aput-object v3, v5, v6
+
+    sput-object v5, Lenums/TestEnumExternalSget;->$VALUES:[Lenums/TestEnumExternalSget;
+
+    return-void
+.end method
+
+.method private constructor <init>(Ljava/lang/String;ILenums/ExtEnum;)V
+    .registers 4
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "(",
+            "Ljava/lang/String;",
+            "Lenums/ExtEnum;",
+            ")V"
+        }
+    .end annotation
+
+    invoke-direct {p0, p1, p2}, Ljava/lang/Enum;-><init>(Ljava/lang/String;I)V
+
+    iput-object p3, p0, Lenums/TestEnumExternalSget;->ext:Lenums/ExtEnum;
+
+    return-void
+.end method
+
+.method public static valueOf(Ljava/lang/String;)Lenums/TestEnumExternalSget;
+    .registers 2
+
+    const-class v0, Lenums/TestEnumExternalSget;
+
+    invoke-static {v0, p0}, Ljava/lang/Enum;->valueOf(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;
+
+    move-result-object p0
+
+    check-cast p0, Lenums/TestEnumExternalSget;
+
+    return-object p0
+.end method
+
+.method public static values()[Lenums/TestEnumExternalSget;
+    .registers 1
+
+    sget-object v0, Lenums/TestEnumExternalSget;->$VALUES:[Lenums/TestEnumExternalSget;
+
+    invoke-virtual {v0}, [Lenums/TestEnumExternalSget;->clone()Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, [Lenums/TestEnumExternalSget;
+
+    return-object v0
+.end method


### PR DESCRIPTION
### Problem

Fixes #2618. When a Dalvik enum's constant constructors take an argument whose SSA value is a static-field read (`SGET`) of an **external** constant — typically a constant of another enum, reused across several constants so R8 keeps it in a register instead of inlining it — `EnumVisitor` fails to restore the enum:

```
jadx.core.utils.exceptions.JadxRuntimeException: Init of enum field '...' uses external variables
	at jadx.core.dex.visitors.EnumVisitor.createEnumFieldByConstructor(EnumVisitor.java:485)
```

The class is then emitted as a plain `class` with the `enum` modifier and super class stripped.

### Fix

`inlineExternalRegs` already inlines a constructor argument that references another constant of the **same** enum. This extends it: when the argument's SSA value is instead assigned by an external `SGET`, inline a copy of that `SGET` into the enum-field initializer. Existing behaviour is unchanged — the new branch is only reached where the old code returned `null` (and threw).

### Test

Adds `TestEnumExternalSget` (multi-file `SmaliTest`, reduced from the reporter's sample): an enum whose constants pass reused `ExtEnum.*` values to the constructor. Before the fix the class is emitted as `class` with the enum-restore-failure warning; after, it is restored as `enum TestEnumExternalSget` with `A(ExtEnum.FIRST)`, `B(ExtEnum.FIRST)`, `C(ExtEnum.SECOND)`.

Verified locally: the full `jadx.tests.integration.enums.*` package is green (33 tests), the whole `:jadx-core:test` suite shows no new failures versus master, and `:jadx-core:spotlessCheck` passes.