### PR TITLE
Fix collapsed single-child directory chains display problems

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
+++ b/jadx-gui/src/main/java/jadx/gui/treemodel/JResource.java
@@ -2,11 +2,12 @@ package jadx.gui.treemodel;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -171,7 +172,7 @@ public class JResource extends JLoadableNode {
 	private static void mergeChildren(List<JResource> children) {
 		for (int i = 0; i < children.size(); i++) {
 			JResource sub = children.get(i);
-			JResource replaced = mergeChain(sub, new ArrayList<>());
+			JResource replaced = mergeChain(sub);
 			if (replaced != sub) {
 				children.set(i, replaced);
 			}
@@ -179,24 +180,26 @@ public class JResource extends JLoadableNode {
 		}
 	}
 
-	private static JResource mergeChain(JResource node, List<JResource> merged) {
-		if (node.type == JResType.DIR) {
-			List<JResource> subs = node.subNodes;
-			if (subs.size() == 1 && subs.get(0).type == JResType.DIR) {
-				merged.add(node);
-				return mergeChain(subs.get(0), merged);
-			}
+	private static JResource mergeChain(JResource node) {
+		if (node.type != JResType.DIR) {
+			return node;
+		}
+		List<JResource> merged = new LinkedList<>();
+		JResource deepestDir = node;
+		List<JResource> subs = deepestDir.subNodes;
+		while (subs.size() == 1 && subs.get(0).type == JResType.DIR) {
+			deepestDir = subs.get(0);
+			merged.add(deepestDir);
+			subs = deepestDir.subNodes;
 		}
 		if (!merged.isEmpty()) {
-			merged.add(node);
-			StringBuilder sb = new StringBuilder();
-			for (int i = 0; i < merged.size(); i++) {
-				if (i > 0) {
-					sb.append('/');
-				}
-				sb.append(merged.get(i).shortName);
-			}
-			node.shortName = sb.toString();
+			// merge the found single-child dir chain into the current node
+			merged.add(0, node);
+			String shortName = merged.stream().map(n -> n.shortName).collect(Collectors.joining("/"));
+			String name = merged.stream().map(n -> n.name).collect(Collectors.joining("/"));
+			JResource mergedNode = new JResource(node.resFile, name, shortName, JResType.DIR);
+			mergedNode.subNodes = deepestDir.subNodes;
+			return mergedNode;
 		}
 		return node;
 	}


### PR DESCRIPTION
The code for collapsing nodes which was introduced in PR #2866 had some problems causing various display glitches (see #2924).

This PR fixes those problems. It simplifies the collapsing code, removing one recursion.
  
In addition it also fixes the problem that the the collapsed path was only updated in the `shortName` of that node, but not in it's `name`. 

In my tests all collapsed entries worked as expected, I extended the sample from #2924 by two-level collapsing, and even collapsed dir chain containing again a collapsed dir chain.

<img width="455" height="492" alt="image" src="https://github.com/user-attachments/assets/b724781c-8a03-49f4-a3ce-dc41c84f7814" />
