### PR TITLE
fix(gui): Allow adb serial numbers with 8 and 9 characters - fixes #2927

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/device/protocol/ADB.java
+++ b/jadx-gui/src/main/java/jadx/gui/device/protocol/ADB.java
@@ -276,7 +276,7 @@ public class ADB {
 		return rst;
 	}
 
-	private static final Pattern SERIAL_PATTERN = Pattern.compile("^[\\w-]{10,20}$");
+	private static final Pattern SERIAL_PATTERN = Pattern.compile("^[\\w-]{8,20}$");
 
 	private static void checkSerial(String serial) {
 		if (!SERIAL_PATTERN.matcher(serial).matches()) {


### PR DESCRIPTION
Seems like there is no specification how an adb serial number should look. 

Therefore I don't see a problem, changing the accepted minimum length from 10 to 8 as proposed by @rehwinkel in #2927.