### PR TITLE
fix(gui): use save mode for package directory export

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/filedialog/FileDialogWrapper.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/filedialog/FileDialogWrapper.java
@@ -124,7 +124,7 @@ public class FileDialogWrapper {
 				break;
 
 			case EXPORT_NODE_FOLDER:
-				isOpen = true;
+				isOpen = false;
 				title = NLS.str("file.save_all_msg");
 				currentDir = mainWindow.getSettings().getLastSaveFilePath();
 				selectionMode = JFileChooser.DIRECTORIES_ONLY;

--- a/jadx-gui/src/main/java/jadx/gui/ui/popupmenu/JPackagePopupMenu.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/popupmenu/JPackagePopupMenu.java
@@ -110,7 +110,7 @@ public class JPackagePopupMenu extends JPopupMenu {
 		Path subSavePath = savePath.resolve(pkg.getName());
 		try {
 			if (!Files.isDirectory(subSavePath)) {
-				Files.createDirectory(subSavePath);
+				Files.createDirectories(subSavePath);
 			}
 		} catch (IOException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
### Description

fix package directory export by using save mode for `EXPORT_NODE_FOLDER`.
use `Files.createDirectories` to support nested package directories.
