### PR TITLE
fix(gui): sanitize user comments

### DIFF
--- a/jadx-core/src/main/java/jadx/api/data/impl/JadxCodeComment.java
+++ b/jadx-core/src/main/java/jadx/api/data/impl/JadxCodeComment.java
@@ -31,7 +31,7 @@ public class JadxCodeComment implements ICodeComment {
 	public JadxCodeComment(IJavaNodeRef nodeRef, @Nullable IJavaCodeRef codeRef, String comment, CommentStyle style) {
 		this.nodeRef = nodeRef;
 		this.codeRef = codeRef;
-		this.comment = comment;
+		this.comment = comment.replace("*/", "* /"); // sanitize comment
 		this.style = style;
 	}
 
@@ -64,7 +64,7 @@ public class JadxCodeComment implements ICodeComment {
 	}
 
 	public void setComment(String comment) {
-		this.comment = comment;
+		this.comment = comment.replace("*/", "* /"); // sanitize comment
 	}
 
 	@Override


### PR DESCRIPTION
The comment dialog allows inputs like `*/`. When the comment style is not INPUT, this will produce invalid code. If we sanitize user comments (replace invalid string `*/` with `* /`), we can enforce valid comments in jadx output. 

A guarantee for valid comments in decompiled code would help me to simplify java parsing in [jadx-apkspy-plugin](https://github.com/nitram84/jadx-apkspy-plugin).

(It's currently even possible to inject valid java code in jadx generated code using comments. This is not a security issue, but I don't want to support this feature this way:

Sample class: 

```java
public class InjectMethodsWithComments {
  public void doSomething1() {
  }
}
```

Add this comment to doSomething1() and select comment style BLOCK:

```
*/public void doSomething() {/*
*/ System.out.println("Try to inject a method for jadx-apkspy-plugin, since adding new methods is not implemented yet."); /*  
*/}/*
/*
```

will produce valid code:

```java
public class InjectMethodsWithComments {
    /*
     * */public void doSomething() {/*
     * */ System.out.println("Try to inject a method for jadx-apkspy-plugin, since adding new methods is not implemented yet."); /*  
     * */}/*
     * /*
     */
     public void doSomething1() {
     }
}
```