### PR TITLE
fix(gui): load next binary block at block boundary

### DIFF
--- a/jadx-gui/src/main/java/jadx/gui/ui/hexviewer/LazyLoadingBinaryData.java
+++ b/jadx-gui/src/main/java/jadx/gui/ui/hexviewer/LazyLoadingBinaryData.java
@@ -97,8 +97,14 @@ public class LazyLoadingBinaryData implements BinaryData {
 
 	@Override
 	public byte getByte(long position) {
-		if (!ensurePositionLoaded(position)) {
-			throw new RuntimeException("Unreachable position: " + position);
+		if (position < 0) {
+			throw new IndexOutOfBoundsException("Position out of bounds: " + position);
+		}
+		if (!ensurePositionLoaded(position + 1)) {
+			throw new IndexOutOfBoundsException("Unreachable position: " + position);
+		}
+		if (position >= size) {
+			throw new IndexOutOfBoundsException("Position out of bounds: " + position);
 		}
 		int blockNum = (int) (position / blockSize);
 		int blockOffset = (int) (position % blockSize);

--- a/jadx-gui/src/test/java/jadx/gui/ui/hexviewer/LazyLoadingBinaryDataTest.java
+++ b/jadx-gui/src/test/java/jadx/gui/ui/hexviewer/LazyLoadingBinaryDataTest.java
@@ -1,0 +1,55 @@
+package jadx.gui.ui.hexviewer;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LazyLoadingBinaryDataTest {
+
+	private static final int BLOCK_SIZE = 1024 * 512;
+
+	@Test
+	void getByteLoadsByteAtBlockBoundary() {
+		byte[] source = new byte[BLOCK_SIZE + 2];
+		source[BLOCK_SIZE - 1] = 1;
+		source[BLOCK_SIZE] = 2;
+		source[BLOCK_SIZE + 1] = 3;
+		LazyLoadingBinaryData data = new LazyLoadingBinaryData(new ByteArrayInputStream(source), source.length);
+
+		assertThat(data.getByte(BLOCK_SIZE - 1)).isEqualTo((byte) 1);
+		assertThat(data.getByte(BLOCK_SIZE)).isEqualTo((byte) 2);
+		assertThat(data.getByte(BLOCK_SIZE + 1)).isEqualTo((byte) 3);
+	}
+
+	@Test
+	void getByteLoadsByteAtBlockBoundaryForStreamWithUnknownSize() {
+		byte[] source = new byte[BLOCK_SIZE + 2];
+		source[BLOCK_SIZE] = 2;
+		LazyLoadingBinaryData data = new LazyLoadingBinaryData(
+				new FilterInputStream(new ByteArrayInputStream(source)) {
+					@Override
+					public int available() throws IOException {
+						return -1;
+					}
+				},
+				0);
+
+		assertThat(data.getByte(BLOCK_SIZE)).isEqualTo((byte) 2);
+	}
+
+	@Test
+	void getByteRejectsPositionsOutsideData() {
+		byte[] source = new byte[BLOCK_SIZE + 1];
+		Arrays.fill(source, (byte) 7);
+		LazyLoadingBinaryData data = new LazyLoadingBinaryData(new ByteArrayInputStream(source), source.length);
+
+		assertThatThrownBy(() -> data.getByte(-1)).isInstanceOf(IndexOutOfBoundsException.class);
+		assertThatThrownBy(() -> data.getByte(source.length)).isInstanceOf(IndexOutOfBoundsException.class);
+	}
+}


### PR DESCRIPTION
:exclamation: Please review the contribution guidelines:
https://github.com/skylot/jadx/blob/master/CONTRIBUTING.md#pull-request-process

### Description

Fix an IndexOutOfBoundsException in LazyLoadingBinaryData when getByte() is called exactly at a 512 KiB block boundary.

The previous implementation only ensured that the stream had been read up to the requested position. For a position equal to readPos, the next block was not loaded even though getByte() subsequently accessed that block.


Fixes https://github.com/skylot/jadx/issues/2947

